### PR TITLE
Update rustc to nightly-2023-06-02

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         "rust-overlay": "rust-overlay_2"
       },
       "locked": {
-        "lastModified": 1691564264,
-        "narHash": "sha256-l0vAmWIlF2mLl5dXaK+mvwEy+0cH7IjpepMIEPn/Ba4=",
+        "lastModified": 1691568898,
+        "narHash": "sha256-BqKlmpX+tV2VYDZXhIhPbO1v9fbNy1/pzd8AooOXvxE=",
         "owner": "aeneasverif",
         "repo": "charon",
-        "rev": "d7694fc250a3f96b8ad1ed4d687d3e341edc68cd",
+        "rev": "5a81a41bafe18101d368e9ab4af440d7fefeee25",
         "type": "github"
       },
       "original": {
@@ -35,11 +35,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1684981077,
-        "narHash": "sha256-68X9cFm0RTZm8u0rXPbeBzOVUH5OoUGAfeHHVoxGd9o=",
+        "lastModified": 1691423162,
+        "narHash": "sha256-cReUZCo83YEEmFcHX8CcOVTZYUrcWgHQO34zxQzy7WI=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "35110cccf28823320f4fd697fcafcb5038683982",
+        "rev": "b5d9d42ea3fa8fea1805d9af1416fe207d0dd1dc",
         "type": "github"
       },
       "original": {
@@ -69,11 +69,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1685518550,
-        "narHash": "sha256-o2d0KcvaXzTrPRIo0kOLV0/QXHhDQ5DTi+OxcjO8xqY=",
+        "lastModified": 1689068808,
+        "narHash": "sha256-6ixXo3wt24N/melDWjq70UuHQLxGV8jZvooRanIHXw0=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "a1720a10a6cfe8234c0e93907ffe81be440f4cef",
+        "rev": "919d646de7be200f3bf08cb76ae1f09402b6f9b4",
         "type": "github"
       },
       "original": {
@@ -427,11 +427,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1685564631,
-        "narHash": "sha256-8ywr3AkblY4++3lIVxmrWZFzac7+f32ZEhH/A8pNscI=",
+        "lastModified": 1691472822,
+        "narHash": "sha256-XVfYZ2oB3lNPVq6sHCY9WkdQ8lHoIDzzbpg8bB6oBxA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4f53efe34b3a8877ac923b9350c874e3dcd5dc0a",
+        "rev": "41c7605718399dcfa53dd7083793b6ae3bc969ff",
         "type": "github"
       },
       "original": {
@@ -597,11 +597,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1683080331,
-        "narHash": "sha256-nGDvJ1DAxZIwdn6ww8IFwzoHb2rqBP4wv/65Wt5vflk=",
+        "lastModified": 1691029059,
+        "narHash": "sha256-QwVeE9YTgH3LmL7yw2V/hgswL6yorIvYSp4YGI8lZYM=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "d59c3fa0cba8336e115b376c2d9e91053aa59e56",
+        "rev": "99df4908445be37ddb2d332580365fce512a7dcf",
         "type": "github"
       },
       "original": {
@@ -622,11 +622,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1685587239,
-        "narHash": "sha256-zpOir1AWpWyQscP5dMpqMrCgBzjzH7Wv0FNUsQ0dcS0=",
+        "lastModified": 1691547503,
+        "narHash": "sha256-l0AIKJucygbDFc2vuAkxmFMjNNJImDd7jYahA88/E+o=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "acb7e896a73b0cf2c6ffe40b2051eb7f88fc2a10",
+        "rev": "3380f16b39457b49c8186d5e20e7a68ccf4fc96e",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         "rust-overlay": "rust-overlay_2"
       },
       "locked": {
-        "lastModified": 1691392627,
-        "narHash": "sha256-9h6jiaI6633oknl+wI/5h5LVXZ0iYLH3QPZQOpjEaxA=",
+        "lastModified": 1691564264,
+        "narHash": "sha256-l0vAmWIlF2mLl5dXaK+mvwEy+0cH7IjpepMIEPn/Ba4=",
         "owner": "aeneasverif",
         "repo": "charon",
-        "rev": "9c0011255830bb560a0aa4d0a279d32f2742585f",
+        "rev": "d7694fc250a3f96b8ad1ed4d687d3e341edc68cd",
         "type": "github"
       },
       "original": {
@@ -287,11 +287,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1691332350,
-        "narHash": "sha256-UVlpyyAobfa15i4ZKT1oP6iHjNkceNN47BpnQqu6wWU=",
+        "lastModified": 1691545327,
+        "narHash": "sha256-9oAUBNRvZxK8dBuxzH5GGhET5lyolecOHmbwywgyk4s=",
         "owner": "leanprover",
         "repo": "lean4",
-        "rev": "1f3ef28a1dfe903c0a62663fee4301e6da015942",
+        "rev": "e7a1512da8d6f9339766f3a269de56e546757fde",
         "type": "github"
       },
       "original": {
@@ -340,11 +340,11 @@
         "nixpkgs": "nixpkgs_7"
       },
       "locked": {
-        "lastModified": 1691332350,
-        "narHash": "sha256-UVlpyyAobfa15i4ZKT1oP6iHjNkceNN47BpnQqu6wWU=",
+        "lastModified": 1691545327,
+        "narHash": "sha256-9oAUBNRvZxK8dBuxzH5GGhET5lyolecOHmbwywgyk4s=",
         "owner": "leanprover",
         "repo": "lean4",
-        "rev": "1f3ef28a1dfe903c0a62663fee4301e6da015942",
+        "rev": "e7a1512da8d6f9339766f3a269de56e546757fde",
         "type": "github"
       },
       "original": {

--- a/tests/coq/betree/BetreeMain_Funs.v
+++ b/tests/coq/betree/BetreeMain_Funs.v
@@ -75,7 +75,7 @@ Definition betree_node_id_counter_fresh_id_back
   Return {| Betree_node_id_counter_next_node_id := i |}
 .
 
-(** [core::num::u64::{10}::MAX] *)
+(** [core::num::u64::{9}::MAX] *)
 Definition core_num_u64_max_body : result u64 :=
   Return 18446744073709551615%u64
 .

--- a/tests/coq/hashmap/Hashmap_Funs.v
+++ b/tests/coq/hashmap/Hashmap_Funs.v
@@ -190,7 +190,7 @@ Definition hash_map_insert_no_resize_fwd_back
       |})
 .
 
-(** [core::num::u32::{9}::MAX] *)
+(** [core::num::u32::{8}::MAX] *)
 Definition core_num_u32_max_body : result u32 := Return 4294967295%u32.
 Definition core_num_u32_max_c : u32 := core_num_u32_max_body%global.
 

--- a/tests/coq/hashmap_on_disk/HashmapMain_Funs.v
+++ b/tests/coq/hashmap_on_disk/HashmapMain_Funs.v
@@ -208,7 +208,7 @@ Definition hashmap_hash_map_insert_no_resize_fwd_back
       |})
 .
 
-(** [core::num::u32::{9}::MAX] *)
+(** [core::num::u32::{8}::MAX] *)
 Definition core_num_u32_max_body : result u32 := Return 4294967295%u32.
 Definition core_num_u32_max_c : u32 := core_num_u32_max_body%global.
 

--- a/tests/coq/misc/Constants.v
+++ b/tests/coq/misc/Constants.v
@@ -12,7 +12,7 @@ Module Constants.
 Definition x0_body : result u32 := Return 0%u32.
 Definition x0_c : u32 := x0_body%global.
 
-(** [core::num::u32::{9}::MAX] *)
+(** [core::num::u32::{8}::MAX] *)
 Definition core_num_u32_max_body : result u32 := Return 4294967295%u32.
 Definition core_num_u32_max_c : u32 := core_num_u32_max_body%global.
 

--- a/tests/fstar/betree/BetreeMain.Funs.fst
+++ b/tests/fstar/betree/BetreeMain.Funs.fst
@@ -60,7 +60,7 @@ let betree_node_id_counter_fresh_id_back
   let* i = u64_add self.betree_node_id_counter_next_node_id 1 in
   Return { betree_node_id_counter_next_node_id = i }
 
-(** [core::num::u64::{10}::MAX] *)
+(** [core::num::u64::{9}::MAX] *)
 let core_num_u64_max_body : result u64 = Return 18446744073709551615
 let core_num_u64_max_c : u64 = eval_global core_num_u64_max_body
 

--- a/tests/fstar/betree_back_stateful/BetreeMain.Funs.fst
+++ b/tests/fstar/betree_back_stateful/BetreeMain.Funs.fst
@@ -60,7 +60,7 @@ let betree_node_id_counter_fresh_id_back
   let* i = u64_add self.betree_node_id_counter_next_node_id 1 in
   Return { betree_node_id_counter_next_node_id = i }
 
-(** [core::num::u64::{10}::MAX] *)
+(** [core::num::u64::{9}::MAX] *)
 let core_num_u64_max_body : result u64 = Return 18446744073709551615
 let core_num_u64_max_c : u64 = eval_global core_num_u64_max_body
 

--- a/tests/fstar/hashmap/Hashmap.Funs.fst
+++ b/tests/fstar/hashmap/Hashmap.Funs.fst
@@ -139,7 +139,7 @@ let hash_map_insert_no_resize_fwd_back
     let* v = vec_index_mut_back (list_t t) self.hash_map_slots hash_mod l0 in
     Return { self with hash_map_slots = v }
 
-(** [core::num::u32::{9}::MAX] *)
+(** [core::num::u32::{8}::MAX] *)
 let core_num_u32_max_body : result u32 = Return 4294967295
 let core_num_u32_max_c : u32 = eval_global core_num_u32_max_body
 

--- a/tests/fstar/hashmap_on_disk/HashmapMain.Funs.fst
+++ b/tests/fstar/hashmap_on_disk/HashmapMain.Funs.fst
@@ -157,7 +157,7 @@ let hashmap_hash_map_insert_no_resize_fwd_back
         hash_mod l0 in
     Return { self with hashmap_hash_map_slots = v }
 
-(** [core::num::u32::{9}::MAX] *)
+(** [core::num::u32::{8}::MAX] *)
 let core_num_u32_max_body : result u32 = Return 4294967295
 let core_num_u32_max_c : u32 = eval_global core_num_u32_max_body
 

--- a/tests/fstar/misc/Constants.fst
+++ b/tests/fstar/misc/Constants.fst
@@ -9,7 +9,7 @@ open Primitives
 let x0_body : result u32 = Return 0
 let x0_c : u32 = eval_global x0_body
 
-(** [core::num::u32::{9}::MAX] *)
+(** [core::num::u32::{8}::MAX] *)
 let core_num_u32_max_body : result u32 = Return 4294967295
 let core_num_u32_max_c : u32 = eval_global core_num_u32_max_body
 

--- a/tests/hol4/betree/betreeMain_FunsScript.sml
+++ b/tests/hol4/betree/betreeMain_FunsScript.sml
@@ -88,7 +88,7 @@ val betree_node_id_counter_fresh_id_back_def = Define ‘
     od
 ’
 
-(** [core::num::u64::{10}::MAX] *)
+(** [core::num::u64::{9}::MAX] *)
 Definition core_num_u64_max_body_def:
   core_num_u64_max_body : u64 result = Return (int_to_u64 18446744073709551615)
 End

--- a/tests/hol4/hashmap/hashmap_FunsScript.sml
+++ b/tests/hol4/hashmap/hashmap_FunsScript.sml
@@ -170,7 +170,7 @@ val hash_map_insert_no_resize_fwd_back_def = Define ‘
     od
 ’
 
-(** [core::num::u32::{9}::MAX] *)
+(** [core::num::u32::{8}::MAX] *)
 Definition core_num_u32_max_body_def:
   core_num_u32_max_body : u32 result = Return (int_to_u32 4294967295)
 End

--- a/tests/hol4/hashmap_on_disk/hashmapMain_FunsScript.sml
+++ b/tests/hol4/hashmap_on_disk/hashmapMain_FunsScript.sml
@@ -193,7 +193,7 @@ val hashmap_hash_map_insert_no_resize_fwd_back_def = Define ‘
     od
 ’
 
-(** [core::num::u32::{9}::MAX] *)
+(** [core::num::u32::{8}::MAX] *)
 Definition core_num_u32_max_body_def:
   core_num_u32_max_body : u32 result = Return (int_to_u32 4294967295)
 End

--- a/tests/hol4/misc-constants/constantsScript.sml
+++ b/tests/hol4/misc-constants/constantsScript.sml
@@ -13,7 +13,7 @@ Definition x0_c_def:
   x0_c : u32 = get_return_value x0_body
 End
 
-(** [core::num::u32::{9}::MAX] *)
+(** [core::num::u32::{8}::MAX] *)
 Definition core_num_u32_max_body_def:
   core_num_u32_max_body : u32 result = Return (int_to_u32 4294967295)
 End

--- a/tests/lean/BetreeMain/Funs.lean
+++ b/tests/lean/BetreeMain/Funs.lean
@@ -64,7 +64,7 @@ def betree.NodeIdCounter.fresh_id_back
     let i ← self.next_node_id + (U64.ofInt 1)
     Result.ret { next_node_id := i }
 
-/- [core::num::u64::{10}::MAX] -/
+/- [core::num::u64::{9}::MAX] -/
 def core_num_u64_max_body : Result U64 :=
   Result.ret (U64.ofInt 18446744073709551615)
 def core_num_u64_max_c : U64 := eval_global core_num_u64_max_body (by simp)

--- a/tests/lean/Constants.lean
+++ b/tests/lean/Constants.lean
@@ -9,7 +9,7 @@ namespace constants
 def x0_body : Result U32 := Result.ret (U32.ofInt 0)
 def x0_c : U32 := eval_global x0_body (by simp)
 
-/- [core::num::u32::{9}::MAX] -/
+/- [core::num::u32::{8}::MAX] -/
 def core_num_u32_max_body : Result U32 := Result.ret (U32.ofInt 4294967295)
 def core_num_u32_max_c : U32 := eval_global core_num_u32_max_body (by simp)
 

--- a/tests/lean/Hashmap/Funs.lean
+++ b/tests/lean/Hashmap/Funs.lean
@@ -132,7 +132,7 @@ def HashMap.insert_no_resize
         let v ← Vec.index_mut_back (List T) self.slots hash_mod l0
         Result.ret { self with slots := v }
 
-/- [core::num::u32::{9}::MAX] -/
+/- [core::num::u32::{8}::MAX] -/
 def core_num_u32_max_body : Result U32 := Result.ret (U32.ofInt 4294967295)
 def core_num_u32_max_c : U32 := eval_global core_num_u32_max_body (by simp)
 

--- a/tests/lean/HashmapMain/Funs.lean
+++ b/tests/lean/HashmapMain/Funs.lean
@@ -147,7 +147,7 @@ def hashmap.HashMap.insert_no_resize
         let v ← Vec.index_mut_back (hashmap.List T) self.slots hash_mod l0
         Result.ret { self with slots := v }
 
-/- [core::num::u32::{9}::MAX] -/
+/- [core::num::u32::{8}::MAX] -/
 def core_num_u32_max_body : Result U32 := Result.ret (U32.ofInt 4294967295)
 def core_num_u32_max_c : U32 := eval_global core_num_u32_max_body (by simp)
 


### PR DESCRIPTION
Some comments in the generated file changed, because when designating the source definitions we refer to the `impl` block indices in the names. For instance: `(** [core::num::u64::{10}::MAX] *)` became `(** [core::num::u64::{9}::MAX] *)`. We might want to change that to get rid of this unnecessary noise.