### PR TITLE
Allow the extraction of structures as tuples

### DIFF
--- a/compiler/Config.ml
+++ b/compiler/Config.ml
@@ -338,7 +338,7 @@ let type_check_pure_code = ref false
     as far as possible while leaving "holes" in the generated code? *)
 let fail_hard = ref true
 
-(** if true, add the type name as a prefix
+(** If true, add the type name as a prefix
     to the variant names.
     Ex.:
     In Rust:
@@ -364,3 +364,19 @@ let fail_hard = ref true
       ]}
  *)
 let variant_concatenate_type_name = ref true
+
+(** If true, extract the structures with unnamed fields as tuples.
+
+    ex.:
+    {[
+      // Rust
+      struct Foo(u32)
+
+      // OCaml
+      type Foo = (u32)
+    ]}
+ *)
+let use_tuple_structs = ref true
+
+let backend_has_tuple_projectors () =
+  match !backend with Lean -> true | Coq | FStar | HOL4 -> false

--- a/compiler/Interpreter.ml
+++ b/compiler/Interpreter.ml
@@ -206,7 +206,7 @@ let initialize_symbolic_context_for_fun (ctx : decls_ctx) (fdef : fun_decl) :
   in
   (* Create fresh symbolic values for the inputs *)
   let input_svs =
-    List.map (fun ty -> mk_fresh_symbolic_value SynthInput ty) inst_sg.inputs
+    List.map (fun ty -> mk_fresh_symbolic_value ty) inst_sg.inputs
   in
   (* Initialize the abstractions as empty (i.e., with no avalues) abstractions *)
   let call_id = fresh_fun_call_id () in

--- a/compiler/InterpreterBorrows.ml
+++ b/compiler/InterpreterBorrows.ml
@@ -444,13 +444,6 @@ let give_back_symbolic_value (_config : config) (proj_regions : RegionId.Set.t)
     (ctx : eval_ctx) : eval_ctx =
   (* Sanity checks *)
   assert (sv.sv_id <> nsv.sv_id && ty_is_rty proj_ty);
-  (match nsv.sv_kind with
-  | SynthInputGivenBack | SynthRetGivenBack | FunCallGivenBack | LoopGivenBack
-    ->
-      ()
-  | FunCallRet | SynthInput | Global | KindConstGeneric | LoopOutput | LoopJoin
-  | Aggregate | ConstGeneric | TraitConst ->
-      raise (Failure "Unreachable"));
   (* Store the given-back value as a meta-value for synthesis purposes *)
   let mv = nsv in
   (* Substitution function, to replace the borrow projectors over symbolic values *)
@@ -459,31 +452,20 @@ let give_back_symbolic_value (_config : config) (proj_regions : RegionId.Set.t)
     let _ = raise Utils.Unimplemented in
     (* Compute the projection over the given back value *)
     let child_proj =
-      match nsv.sv_kind with
-      | SynthRetGivenBack ->
-          (* The given back value comes from the return value of the function
-             we are currently synthesizing (as it is given back, it means
-             we ended one of the regions appearing in the signature: we are
-             currently synthesizing one of the backward functions).
+      (* TODO: there is something wrong here.
+         Consider this:
+         {[
+           abs0 {'a} { AProjLoans (s0 : &'a mut T) [] }
+           abs1 {'b} { AProjBorrows (s0 : &'a mut T <: &'b mut T) }
+         ]}
 
-             As we don't allow borrow overwrites on returned value, we can
-             (and MUST) forget the borrows *)
-          AIgnoredProjBorrows
-      | FunCallGivenBack ->
-          (* TODO: there is something wrong here.
-             Consider this:
-             {[
-               abs0 {'a} { AProjLoans (s0 : &'a mut T) [] }
-               abs1 {'b} { AProjBorrows (s0 : &'a mut T <: &'b mut T) }
-             ]}
-
-             Upon ending abs1, we give back some fresh symbolic value [s1],
-             that we reinsert where the loan for [s0] is. However, the mutable
-             borrow in the type [&'a mut T] was ended: we give back a value of
-             type [T]! We thus *mustn't* introduce a projector here.
-          *)
-          AProjBorrows (nsv, sv.sv_ty)
-      | _ -> raise (Failure "Unreachable")
+         Upon ending abs1, we give back some fresh symbolic value [s1],
+         that we reinsert where the loan for [s0] is. However, the mutable
+         borrow in the type [&'a mut T] was ended: we give back a value of
+         type [T]! We thus *mustn't* introduce a projector here.
+      *)
+      (* AProjBorrows (nsv, sv.sv_ty) *)
+      raise (Failure "TODO")
     in
     AProjLoans (sv, (mv, child_proj) :: local_given_back)
   in
@@ -739,17 +721,7 @@ let reborrow_shared (original_bid : BorrowId.id) (new_bid : BorrowId.id)
  *)
 let convert_avalue_to_given_back_value (abs_kind : abs_kind) (av : typed_avalue)
     : symbolic_value =
-  let sv_kind =
-    match abs_kind with
-    | FunCall _ -> FunCallGivenBack
-    | SynthRet _ -> SynthRetGivenBack
-    | SynthInput _ -> SynthInputGivenBack
-    | Loop _ -> LoopGivenBack
-    | Identity ->
-        (* Identity abstractions give back nothing *)
-        raise (Failure "Unreachable")
-  in
-  mk_fresh_symbolic_value sv_kind av.ty
+  mk_fresh_symbolic_value av.ty
 
 (** Auxiliary function: see {!end_borrow_aux}.
 
@@ -1239,7 +1211,7 @@ and end_abstraction_borrows (config : config) (chain : borrow_or_abs_ids)
           ("end_abstraction_borrows: found aproj borrows: "
           ^ aproj_to_string ctx (AProjBorrows (sv, proj_ty))));
       (* Generate a fresh symbolic value *)
-      let nsv = mk_fresh_symbolic_value FunCallGivenBack proj_ty in
+      let nsv = mk_fresh_symbolic_value proj_ty in
       (* Replace the proj_borrows - there should be exactly one *)
       let ended_borrow = AEndedProjBorrows nsv in
       let ctx = update_aproj_borrows abs.abs_id sv ended_borrow ctx in

--- a/compiler/InterpreterExpressions.ml
+++ b/compiler/InterpreterExpressions.ml
@@ -283,7 +283,7 @@ let eval_operand_no_reorganize (config : config) (op : operand)
                 List.find (fun (name, _) -> name = const_name) trait_decl.consts
               in
               (* Introduce a fresh symbolic value *)
-              let v = mk_fresh_symbolic_typed_value TraitConst ty in
+              let v = mk_fresh_symbolic_typed_value ty in
               (* Continue the evaluation *)
               let e = cf v ctx in
               (* We have to wrap the generated expression *)
@@ -315,7 +315,7 @@ let eval_operand_no_reorganize (config : config) (op : operand)
                 copy_value allow_adt_copy config ctx cv
             | SymbolicMode ->
                 (* We use the looked up value only for its type *)
-                let v = mk_fresh_symbolic_typed_value KindConstGeneric cv.ty in
+                let v = mk_fresh_symbolic_typed_value cv.ty in
                 (ctx, v)
           in
           (* Continue *)
@@ -464,9 +464,7 @@ let eval_unary_op_symbolic (config : config) (unop : unop) (op : operand)
       | Cast (CastInteger (_, tgt_ty)), _ -> TLiteral (TInteger tgt_ty)
       | _ -> raise (Failure "Invalid input for unop")
     in
-    let res_sv =
-      { sv_kind = FunCallRet; sv_id = res_sv_id; sv_ty = res_sv_ty }
-    in
+    let res_sv = { sv_id = res_sv_id; sv_ty = res_sv_ty } in
     (* Call the continuation *)
     let expr = cf (Ok (mk_typed_value_from_symbolic_value res_sv)) ctx in
     (* Synthesize the symbolic AST *)
@@ -603,9 +601,7 @@ let eval_binary_op_symbolic (config : config) (binop : binop) (op1 : operand)
             | Ne | Eq -> raise (Failure "Unreachable"))
         | _ -> raise (Failure "Invalid inputs for binop")
     in
-    let res_sv =
-      { sv_kind = FunCallRet; sv_id = res_sv_id; sv_ty = res_sv_ty }
-    in
+    let res_sv = { sv_id = res_sv_id; sv_ty = res_sv_ty } in
     (* Call the continuattion *)
     let v = mk_typed_value_from_symbolic_value res_sv in
     let expr = cf (Ok v) ctx in
@@ -769,7 +765,7 @@ let eval_rvalue_aggregate (config : config) (aggregate_kind : aggregate_kind)
            array we introduce here might be duplicated in the generated
            code: by introducing a symbolic value we introduce a let-binding
            in the generated code. *)
-        let saggregated = mk_fresh_symbolic_typed_value Aggregate ty in
+        let saggregated = mk_fresh_symbolic_typed_value ty in
         (* Call the continuation *)
         match cf saggregated ctx with
         | None -> None

--- a/compiler/InterpreterLoopsMatchCtxs.ml
+++ b/compiler/InterpreterLoopsMatchCtxs.ml
@@ -389,7 +389,7 @@ module MakeJoinMatcher (S : MatchJoinState) : PrimMatcher = struct
 
   let match_distinct_literals (ty : ety) (_ : literal) (_ : literal) :
       typed_value =
-    mk_fresh_symbolic_typed_value_from_no_regions_ty LoopJoin ty
+    mk_fresh_symbolic_typed_value_from_no_regions_ty ty
 
   let match_distinct_adts (ty : ety) (adt0 : adt_value) (adt1 : adt_value) :
       typed_value =
@@ -418,7 +418,7 @@ module MakeJoinMatcher (S : MatchJoinState) : PrimMatcher = struct
     check_loans false adt1.field_values;
 
     (* No borrows, no loans: we can introduce a symbolic value *)
-    mk_fresh_symbolic_typed_value_from_no_regions_ty LoopJoin ty
+    mk_fresh_symbolic_typed_value_from_no_regions_ty ty
 
   let match_shared_borrows _ (ty : ety) (bid0 : borrow_id) (bid1 : borrow_id) :
       borrow_id =
@@ -435,9 +435,7 @@ module MakeJoinMatcher (S : MatchJoinState) : PrimMatcher = struct
 
       (* Generate a fresh symbolic value for the shared value *)
       let _, bv_ty, kind = ty_as_ref ty in
-      let sv =
-        mk_fresh_symbolic_typed_value_from_no_regions_ty LoopJoin bv_ty
-      in
+      let sv = mk_fresh_symbolic_typed_value_from_no_regions_ty bv_ty in
 
       let borrow_ty = mk_ref_ty (RFVar rid) bv_ty kind in
 
@@ -582,9 +580,7 @@ module MakeJoinMatcher (S : MatchJoinState) : PrimMatcher = struct
 
       (* Generate a fresh symbolic value for the borrowed value *)
       let _, bv_ty, kind = ty_as_ref ty in
-      let sv =
-        mk_fresh_symbolic_typed_value_from_no_regions_ty LoopJoin bv_ty
-      in
+      let sv = mk_fresh_symbolic_typed_value_from_no_regions_ty bv_ty in
 
       let borrow_ty = mk_ref_ty (RFVar rid) bv_ty kind in
 
@@ -664,7 +660,7 @@ module MakeJoinMatcher (S : MatchJoinState) : PrimMatcher = struct
          borrows *)
       assert (not (ty_has_borrows S.ctx.type_context.type_infos sv0.sv_ty));
       (* We simply introduce a fresh symbolic value *)
-      mk_fresh_symbolic_value LoopJoin sv0.sv_ty)
+      mk_fresh_symbolic_value sv0.sv_ty)
 
   let match_symbolic_with_other (left : bool) (sv : symbolic_value)
       (v : typed_value) : typed_value =
@@ -685,7 +681,7 @@ module MakeJoinMatcher (S : MatchJoinState) : PrimMatcher = struct
         if value_is_left then raise (ValueMatchFailure (LoanInLeft id))
         else raise (ValueMatchFailure (LoanInRight id)));
     (* Return a fresh symbolic value *)
-    mk_fresh_symbolic_typed_value LoopJoin sv.sv_ty
+    mk_fresh_symbolic_typed_value sv.sv_ty
 
   let match_bottom_with_other (left : bool) (v : typed_value) : typed_value =
     (* If there are outer loans in the non-bottom value, raise an exception.
@@ -834,7 +830,7 @@ struct
 
   let match_distinct_literals (ty : ety) (_ : literal) (_ : literal) :
       typed_value =
-    mk_fresh_symbolic_typed_value_from_no_regions_ty LoopJoin ty
+    mk_fresh_symbolic_typed_value_from_no_regions_ty ty
 
   let match_distinct_adts (_ty : ety) (_adt0 : adt_value) (_adt1 : adt_value) :
       typed_value =
@@ -904,11 +900,7 @@ struct
         GetSetSid.match_e "match_symbolic_values: ids: " S.sid_map id0 id1
       in
       let sv_ty = match_rtys sv0.sv_ty sv1.sv_ty in
-      let sv_kind =
-        if sv0.sv_kind = sv1.sv_kind then sv0.sv_kind
-        else raise (Distinct "match_symbolic_values: sv_kind")
-      in
-      let sv = { sv_id; sv_ty; sv_kind } in
+      let sv = { sv_id; sv_ty } in
       sv
     else (
       (* Check: fixed values are fixed *)

--- a/compiler/InterpreterStatements.ml
+++ b/compiler/InterpreterStatements.ml
@@ -1008,7 +1008,7 @@ and eval_global (config : config) (dest : place) (gid : GlobalDeclId.id) :
       (* Generate a fresh symbolic value. In the translation, this fresh symbolic value will be
        * defined as equal to the value of the global (see {!S.synthesize_global_eval}). *)
       assert (ty_no_regions global.ty);
-      let sval = mk_fresh_symbolic_value Global global.ty in
+      let sval = mk_fresh_symbolic_value global.ty in
       let cc =
         assign_to_place config (mk_typed_value_from_symbolic_value sval) dest
       in
@@ -1312,7 +1312,7 @@ and eval_function_call_symbolic_from_inst_sig (config : config)
 
   (* Generate a fresh symbolic value for the return value *)
   let ret_sv_ty = inst_sg.output in
-  let ret_spc = mk_fresh_symbolic_value FunCallRet ret_sv_ty in
+  let ret_spc = mk_fresh_symbolic_value ret_sv_ty in
   let ret_value = mk_typed_value_from_symbolic_value ret_spc in
   let ret_av regions =
     mk_aproj_loans_value_from_symbolic_value regions ret_spc

--- a/compiler/PureUtils.ml
+++ b/compiler/PureUtils.ml
@@ -687,3 +687,14 @@ let trait_impl_is_empty (trait_impl : trait_impl) : bool =
   in
   parent_trait_refs = [] && consts = [] && types = [] && required_methods = []
   && provided_methods = []
+
+(** Return true if a type declaration should be extracted as a tuple, because
+    it is a non-recursive structure with unnamed fields. *)
+let type_decl_from_type_id_is_tuple_struct (ctx : TypesAnalysis.type_infos)
+    (id : type_id) : bool =
+  match id with
+  | TTuple -> true
+  | TAdtId id ->
+      let info = TypeDeclId.Map.find id ctx in
+      info.is_tuple_struct
+  | TAssumed _ -> false

--- a/compiler/TypesUtils.ml
+++ b/compiler/TypesUtils.ml
@@ -111,3 +111,21 @@ let trait_type_constraint_no_regions (x : trait_type_constraint) : bool =
     raise_if_region_ty_visitor#visit_ty () ty;
     true
   with Found -> false
+
+(** Return true if a type declaration should be extracted as a tuple, because
+    it is a non-recursive structure with unnamed fields. *)
+let type_decl_from_decl_id_is_tuple_struct (ctx : TypesAnalysis.type_infos)
+    (id : TypeDeclId.id) : bool =
+  let info = TypeDeclId.Map.find id ctx in
+  info.is_tuple_struct
+
+(** Return true if a type declaration should be extracted as a tuple, because
+    it is a non-recursive structure with unnamed fields. *)
+let type_decl_from_type_id_is_tuple_struct (ctx : TypesAnalysis.type_infos)
+    (id : type_id) : bool =
+  match id with
+  | TTuple -> true
+  | TAdtId id ->
+      let info = TypeDeclId.Map.find id ctx in
+      info.is_tuple_struct
+  | TAssumed _ -> false

--- a/compiler/Values.ml
+++ b/compiler/Values.ml
@@ -15,47 +15,6 @@ module LoopId = IdGen ()
 type symbolic_value_id = SymbolicValueId.id [@@deriving show, ord]
 type symbolic_value_id_set = SymbolicValueId.Set.t [@@deriving show, ord]
 type loop_id = LoopId.id [@@deriving show, ord]
-
-(** The kind of a symbolic value, which precises how the value was generated.
-
-    TODO: remove? This is not useful anymore.
-  *)
-type sv_kind =
-  | FunCallRet  (** The value is the return value of a function call *)
-  | FunCallGivenBack
-      (** The value is a borrowed value given back by an abstraction
-          (happens when giving a borrow to a function: when the abstraction
-          introduced to model the function call ends we reintroduce a symbolic
-          value in the context for the value modified by the abstraction through
-          the borrow).
-       *)
-  | SynthInput
-      (** The value is an input value of the function whose body we are
-          currently synthesizing.
-       *)
-  | SynthRetGivenBack
-      (** The value is a borrowed value that the function whose body we are
-          synthesizing returned, and which was given back because we ended
-          one of the lifetimes of this function (we do this to synthesize
-          the backward functions).
-       *)
-  | SynthInputGivenBack
-      (** The value was given back upon ending one of the input abstractions *)
-  | Global  (** The value is a global *)
-  | KindConstGeneric  (** The value is a const generic *)
-  | LoopOutput  (** The output of a loop (seen as a forward computation) *)
-  | LoopGivenBack
-      (** A value given back by a loop (when ending abstractions while going backwards) *)
-  | LoopJoin
-      (** The result of a loop join (when computing loop fixed points) *)
-  | Aggregate
-      (** A symbolic value we introduce in place of an aggregate value *)
-  | ConstGeneric
-      (** A symbolic value we introduce when using a const generic as a value *)
-  | TraitConst
-      (** A symbolic value we introduce when evaluating a trait associated constant *)
-[@@deriving show, ord]
-
 type borrow_id = BorrowId.id [@@deriving show, ord]
 type borrow_id_set = BorrowId.Set.t [@@deriving show, ord]
 type loan_id = BorrowId.id [@@deriving show, ord]
@@ -65,7 +24,6 @@ type loan_id_set = BorrowId.Set.t [@@deriving show, ord]
 class ['self] iter_typed_value_base =
   object (self : 'self)
     inherit [_] iter_ty
-    method visit_sv_kind : 'env -> sv_kind -> unit = fun _ _ -> ()
 
     method visit_symbolic_value_id : 'env -> symbolic_value_id -> unit =
       fun _ _ -> ()
@@ -85,7 +43,6 @@ class ['self] iter_typed_value_base =
 class ['self] map_typed_value_base =
   object (self : 'self)
     inherit [_] map_ty
-    method visit_sv_kind : 'env -> sv_kind -> sv_kind = fun _ x -> x
 
     method visit_symbolic_value_id
         : 'env -> symbolic_value_id -> symbolic_value_id =
@@ -104,7 +61,6 @@ class ['self] map_typed_value_base =
 
 (** A symbolic value *)
 type symbolic_value = {
-  sv_kind : sv_kind;
   sv_id : symbolic_value_id;
   sv_ty : ty;  (** This should be a type with regions *)
 }

--- a/tests/coq/misc/NoNestedBorrows.v
+++ b/tests/coq/misc/NoNestedBorrows.v
@@ -42,7 +42,7 @@ Inductive Enum_t := | Enum_Variant1 : Enum_t | Enum_Variant2 : Enum_t.
 
 (** [no_nested_borrows::EmptyStruct]
     Source: 'src/no_nested_borrows.rs', lines 39:0-39:22 *)
-Record EmptyStruct_t := mkEmptyStruct_t {  }.
+Definition EmptyStruct_t : Type := unit.
 
 (** [no_nested_borrows::Sum]
     Source: 'src/no_nested_borrows.rs', lines 41:0-41:20 *)
@@ -643,5 +643,37 @@ Definition test_shared_borrow_enum1 (l : List_t u32) : result u32 :=
     Source: 'src/no_nested_borrows.rs', lines 519:0-519:40 *)
 Definition test_shared_borrow_enum2 : result u32 :=
   Return 0%u32.
+
+(** [no_nested_borrows::Tuple]
+    Source: 'src/no_nested_borrows.rs', lines 530:0-530:24 *)
+Definition Tuple_t (T1 T2 : Type) : Type := T1 * T2.
+
+(** [no_nested_borrows::use_tuple_struct]: merged forward/backward function
+    (there is a single backward function, and the forward function returns ())
+    Source: 'src/no_nested_borrows.rs', lines 532:0-532:48 *)
+Definition use_tuple_struct (x : Tuple_t u32 u32) : result (Tuple_t u32 u32) :=
+  let (_, i) := x in Return (1%u32, i)
+.
+
+(** [no_nested_borrows::create_tuple_struct]: forward function
+    Source: 'src/no_nested_borrows.rs', lines 536:0-536:61 *)
+Definition create_tuple_struct
+  (x : u32) (y : u64) : result (Tuple_t u32 u64) :=
+  Return (x, y)
+.
+
+(** [no_nested_borrows::IdType]
+    Source: 'src/no_nested_borrows.rs', lines 541:0-541:20 *)
+Definition IdType_t (T : Type) : Type := T.
+
+(** [no_nested_borrows::use_id_type]: forward function
+    Source: 'src/no_nested_borrows.rs', lines 543:0-543:40 *)
+Definition use_id_type (T : Type) (x : IdType_t T) : result T :=
+  Return x.
+
+(** [no_nested_borrows::create_id_type]: forward function
+    Source: 'src/no_nested_borrows.rs', lines 547:0-547:43 *)
+Definition create_id_type (T : Type) (x : T) : result (IdType_t T) :=
+  Return x.
 
 End NoNestedBorrows.

--- a/tests/coq/traits/Traits.v
+++ b/tests/coq/traits/Traits.v
@@ -223,18 +223,11 @@ Definition h4
 
 (** [traits::TestType]
     Source: 'src/traits.rs', lines 122:0-122:22 *)
-Record TestType_t (T : Type) := mkTestType_t { testType_0 : T; }.
-
-Arguments mkTestType_t { _ }.
-Arguments testType_0 { _ }.
+Definition TestType_t (T : Type) : Type := T.
 
 (** [traits::{traits::TestType<T>#6}::test::TestType1]
     Source: 'src/traits.rs', lines 127:8-127:24 *)
-Record TestType_test_TestType1_t :=
-mkTestType_test_TestType1_t {
-  testType_test_TestType1_0 : u64;
-}
-.
+Definition TestType_test_TestType1_t : Type := u64.
 
 (** Trait declaration: [traits::{traits::TestType<T>#6}::test::TestTrait]
     Source: 'src/traits.rs', lines 128:8-128:23 *)
@@ -249,7 +242,7 @@ Arguments TestType_test_TestTrait_t_test { _ }.
     Source: 'src/traits.rs', lines 139:12-139:34 *)
 Definition testType_test_TestType1_test
   (self : TestType_test_TestType1_t) : result bool :=
-  Return (self.(testType_test_TestType1_0) s> 1%u64)
+  Return (self s> 1%u64)
 .
 
 (** Trait implementation: [traits::{traits::TestType<T>#6}::test::{traits::{traits::TestType<T>#6}::test::TestType1}]
@@ -266,14 +259,12 @@ Definition testType_test
   result bool
   :=
   x0 <- toU64TInst.(ToU64_t_to_u64) x;
-  if x0 s> 0%u64
-  then testType_test_TestType1_test {| testType_test_TestType1_0 := 0%u64 |}
-  else Return false
+  if x0 s> 0%u64 then testType_test_TestType1_test 0%u64 else Return false
 .
 
 (** [traits::BoolWrapper]
     Source: 'src/traits.rs', lines 150:0-150:22 *)
-Record BoolWrapper_t := mkBoolWrapper_t { boolWrapper_0 : bool; }.
+Definition BoolWrapper_t : Type := bool.
 
 (** [traits::{traits::BoolWrapper#7}::to_type]: forward function
     Source: 'src/traits.rs', lines 156:4-156:25 *)
@@ -281,7 +272,7 @@ Definition boolWrapper_to_type
   (T : Type) (toTypeBoolTInst : ToType_t bool T) (self : BoolWrapper_t) :
   result T
   :=
-  toTypeBoolTInst.(ToType_t_to_type) self.(boolWrapper_0)
+  toTypeBoolTInst.(ToType_t_to_type) self
 .
 
 (** Trait implementation: [traits::{traits::BoolWrapper#7}]

--- a/tests/fstar/misc/NoNestedBorrows.fst
+++ b/tests/fstar/misc/NoNestedBorrows.fst
@@ -560,3 +560,32 @@ let test_shared_borrow_enum1 (l : list_t u32) : result u32 =
 let test_shared_borrow_enum2 : result u32 =
   Return 0
 
+(** [no_nested_borrows::Tuple]
+    Source: 'src/no_nested_borrows.rs', lines 530:0-530:24 *)
+type tuple_t (t1 t2 : Type0) = t1 * t2
+
+(** [no_nested_borrows::use_tuple_struct]: merged forward/backward function
+    (there is a single backward function, and the forward function returns ())
+    Source: 'src/no_nested_borrows.rs', lines 532:0-532:48 *)
+let use_tuple_struct (x : tuple_t u32 u32) : result (tuple_t u32 u32) =
+  let (_, i) = x in Return (1, i)
+
+(** [no_nested_borrows::create_tuple_struct]: forward function
+    Source: 'src/no_nested_borrows.rs', lines 536:0-536:61 *)
+let create_tuple_struct (x : u32) (y : u64) : result (tuple_t u32 u64) =
+  Return (x, y)
+
+(** [no_nested_borrows::IdType]
+    Source: 'src/no_nested_borrows.rs', lines 541:0-541:20 *)
+type idType_t (t : Type0) = t
+
+(** [no_nested_borrows::use_id_type]: forward function
+    Source: 'src/no_nested_borrows.rs', lines 543:0-543:40 *)
+let use_id_type (t : Type0) (x : idType_t t) : result t =
+  Return x
+
+(** [no_nested_borrows::create_id_type]: forward function
+    Source: 'src/no_nested_borrows.rs', lines 547:0-547:43 *)
+let create_id_type (t : Type0) (x : t) : result (idType_t t) =
+  Return x
+

--- a/tests/fstar/traits/Traits.fst
+++ b/tests/fstar/traits/Traits.fst
@@ -177,11 +177,11 @@ let h4
 
 (** [traits::TestType]
     Source: 'src/traits.rs', lines 122:0-122:22 *)
-type testType_t (t : Type0) = { _0 : t; }
+type testType_t (t : Type0) = t
 
 (** [traits::{traits::TestType<T>#6}::test::TestType1]
     Source: 'src/traits.rs', lines 127:8-127:24 *)
-type testType_test_TestType1_t = { _0 : u64; }
+type testType_test_TestType1_t = u64
 
 (** Trait declaration: [traits::{traits::TestType<T>#6}::test::TestTrait]
     Source: 'src/traits.rs', lines 128:8-128:23 *)
@@ -193,7 +193,7 @@ noeq type testType_test_TestTrait_t (self : Type0) = {
     Source: 'src/traits.rs', lines 139:12-139:34 *)
 let testType_test_TestType1_test
   (self : testType_test_TestType1_t) : result bool =
-  Return (self._0 > 1)
+  Return (self > 1)
 
 (** Trait implementation: [traits::{traits::TestType<T>#6}::test::{traits::{traits::TestType<T>#6}::test::TestType1}]
     Source: 'src/traits.rs', lines 138:8-138:36 *)
@@ -209,11 +209,11 @@ let testType_test
   result bool
   =
   let* x0 = toU64TInst.to_u64 x in
-  if x0 > 0 then testType_test_TestType1_test { _0 = 0 } else Return false
+  if x0 > 0 then testType_test_TestType1_test 0 else Return false
 
 (** [traits::BoolWrapper]
     Source: 'src/traits.rs', lines 150:0-150:22 *)
-type boolWrapper_t = { _0 : bool; }
+type boolWrapper_t = bool
 
 (** [traits::{traits::BoolWrapper#7}::to_type]: forward function
     Source: 'src/traits.rs', lines 156:4-156:25 *)
@@ -221,7 +221,7 @@ let boolWrapper_to_type
   (t : Type0) (toTypeBoolTInst : toType_t bool t) (self : boolWrapper_t) :
   result t
   =
-  toTypeBoolTInst.to_type self._0
+  toTypeBoolTInst.to_type self
 
 (** Trait implementation: [traits::{traits::BoolWrapper#7}]
     Source: 'src/traits.rs', lines 152:0-152:33 *)

--- a/tests/lean/NoNestedBorrows.lean
+++ b/tests/lean/NoNestedBorrows.lean
@@ -35,7 +35,7 @@ inductive Enum :=
 
 /- [no_nested_borrows::EmptyStruct]
    Source: 'src/no_nested_borrows.rs', lines 39:0-39:22 -/
-structure EmptyStruct where
+@[reducible] def EmptyStruct := Unit
 
 /- [no_nested_borrows::Sum]
    Source: 'src/no_nested_borrows.rs', lines 41:0-41:20 -/
@@ -642,5 +642,34 @@ def test_shared_borrow_enum1 (l : List U32) : Result U32 :=
    Source: 'src/no_nested_borrows.rs', lines 519:0-519:40 -/
 def test_shared_borrow_enum2 : Result U32 :=
   Result.ret 0#u32
+
+/- [no_nested_borrows::Tuple]
+   Source: 'src/no_nested_borrows.rs', lines 530:0-530:24 -/
+def Tuple (T1 T2 : Type) := T1 × T2
+
+/- [no_nested_borrows::use_tuple_struct]: merged forward/backward function
+   (there is a single backward function, and the forward function returns ())
+   Source: 'src/no_nested_borrows.rs', lines 532:0-532:48 -/
+def use_tuple_struct (x : Tuple U32 U32) : Result (Tuple U32 U32) :=
+  Result.ret (1#u32, x.1)
+
+/- [no_nested_borrows::create_tuple_struct]: forward function
+   Source: 'src/no_nested_borrows.rs', lines 536:0-536:61 -/
+def create_tuple_struct (x : U32) (y : U64) : Result (Tuple U32 U64) :=
+  Result.ret (x, y)
+
+/- [no_nested_borrows::IdType]
+   Source: 'src/no_nested_borrows.rs', lines 541:0-541:20 -/
+@[reducible] def IdType (T : Type) := T
+
+/- [no_nested_borrows::use_id_type]: forward function
+   Source: 'src/no_nested_borrows.rs', lines 543:0-543:40 -/
+def use_id_type (T : Type) (x : IdType T) : Result T :=
+  Result.ret x
+
+/- [no_nested_borrows::create_id_type]: forward function
+   Source: 'src/no_nested_borrows.rs', lines 547:0-547:43 -/
+def create_id_type (T : Type) (x : T) : Result (IdType T) :=
+  Result.ret x
 
 end no_nested_borrows

--- a/tests/lean/Traits.lean
+++ b/tests/lean/Traits.lean
@@ -190,13 +190,11 @@ def h4
 
 /- [traits::TestType]
    Source: 'src/traits.rs', lines 122:0-122:22 -/
-structure TestType (T : Type) where
-  _0 : T
+@[reducible] def TestType (T : Type) := T
 
 /- [traits::{traits::TestType<T>#6}::test::TestType1]
    Source: 'src/traits.rs', lines 127:8-127:24 -/
-structure TestType.test.TestType1 where
-  _0 : U64
+@[reducible] def TestType.test.TestType1 := U64
 
 /- Trait declaration: [traits::{traits::TestType<T>#6}::test::TestTrait]
    Source: 'src/traits.rs', lines 128:8-128:23 -/
@@ -207,7 +205,7 @@ structure TestType.test.TestTrait (Self : Type) where
    Source: 'src/traits.rs', lines 139:12-139:34 -/
 def TestType.test.TestType1.test
   (self : TestType.test.TestType1) : Result Bool :=
-  Result.ret (self._0 > 1#u64)
+  Result.ret (self > 1#u64)
 
 /- Trait implementation: [traits::{traits::TestType<T>#6}::test::{traits::{traits::TestType<T>#6}::test::TestType1}]
    Source: 'src/traits.rs', lines 138:8-138:36 -/
@@ -225,13 +223,12 @@ def TestType.test
   do
     let x0 ← ToU64TInst.to_u64 x
     if x0 > 0#u64
-    then TestType.test.TestType1.test { _0 := 0#u64 }
+    then TestType.test.TestType1.test 0#u64
     else Result.ret false
 
 /- [traits::BoolWrapper]
    Source: 'src/traits.rs', lines 150:0-150:22 -/
-structure BoolWrapper where
-  _0 : Bool
+@[reducible] def BoolWrapper := Bool
 
 /- [traits::{traits::BoolWrapper#7}::to_type]: forward function
    Source: 'src/traits.rs', lines 156:4-156:25 -/
@@ -239,7 +236,7 @@ def BoolWrapper.to_type
   (T : Type) (ToTypeBoolTInst : ToType Bool T) (self : BoolWrapper) :
   Result T
   :=
-  ToTypeBoolTInst.to_type self._0
+  ToTypeBoolTInst.to_type self
 
 /- Trait implementation: [traits::{traits::BoolWrapper#7}]
    Source: 'src/traits.rs', lines 152:0-152:33 -/


### PR DESCRIPTION
This PR update the extractions of the types so that some types are extracted to tuples.
For instance:
```rust
type Tuple<T1, T2>(T1, T2)
```
is now extracted in Lean to:
```lean
def Tuple (T1 T2 : Type) := T1 × T2
```