### PR TITLE
Fix an issue with loops

### DIFF
--- a/compiler/InterpreterLoops.ml
+++ b/compiler/InterpreterLoops.ml
@@ -93,10 +93,20 @@ let eval_loop_symbolic (config : config) (meta : meta)
   let fp_bl_corresp =
     compute_fixed_point_id_correspondance fixed_ids ctx fp_ctx
   in
-  let end_expr =
+  log#ldebug
+    (lazy
+      ("eval_loop_symbolic: about to match the fixed-point context with the \
+        original context:\n\
+        - src ctx (fixed-point ctx)" ^ eval_ctx_to_string fp_ctx
+     ^ "\n\n-tgt ctx (original context):\n" ^ eval_ctx_to_string ctx));
+  let end_expr : SymbolicAst.expression option =
     match_ctx_with_target config loop_id true fp_bl_corresp fp_input_svalues
       fixed_ids fp_ctx cf ctx
   in
+  log#ldebug
+    (lazy
+      "eval_loop_symbolic: matched the fixed-point context with the original \
+       context");
 
   (* Synthesize the loop body by evaluating it, with the continuation for
      after the loop starting at the *fixed point*, but with a special
@@ -115,6 +125,12 @@ let eval_loop_symbolic (config : config) (meta : meta)
     | Continue i ->
         (* We don't support nested loops for now *)
         assert (i = 0);
+        log#ldebug
+          (lazy
+            ("eval_loop_symbolic: about to match the fixed-point context with \
+              the context at a continue:\n\
+              - src ctx (fixed-point ctx)" ^ eval_ctx_to_string fp_ctx
+           ^ "\n\n-tgt ctx (ctx at continue):\n" ^ eval_ctx_to_string ctx));
         let cc =
           match_ctx_with_target config loop_id false fp_bl_corresp
             fp_input_svalues fixed_ids fp_ctx

--- a/compiler/InterpreterLoopsMatchCtxs.ml
+++ b/compiler/InterpreterLoopsMatchCtxs.ml
@@ -824,10 +824,10 @@ module MakeMoveMatcher (S : MatchMoveState) : PrimMatcher = struct
     bid1
 
   let match_mut_borrows (_ : eval_ctx) (_ : eval_ctx) (_ : ety) (_ : borrow_id)
-      (_ : typed_value) (bid1 : borrow_id) (_ : typed_value) (bv : typed_value)
+      (_ : typed_value) (bid1 : borrow_id) (bv1 : typed_value) (_ : typed_value)
       : borrow_id * typed_value =
     (* There can't be bottoms in borrowed values *)
-    (bid1, bv)
+    (bid1, bv1)
 
   let match_shared_loans (_ : eval_ctx) (_ : eval_ctx) (_ : ety)
       (_ : loan_id_set) (ids1 : loan_id_set) (sv : typed_value) :

--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1703290921,
-        "narHash": "sha256-Jbf7JETi3XHLV19pDz8AT/Gyu8PpEfZhxO7T4W94uws=",
+        "lastModified": 1706179002,
+        "narHash": "sha256-sVAG73/MMnGOFdjUvEyEt3BD2gC6H1VhIQBX3VB7H6A=",
         "owner": "aeneasverif",
         "repo": "charon",
-        "rev": "f91d9d16520f0615047ccdf98b654cf47a10b0ce",
+        "rev": "9a4ac0c8c88c6778da31177f69b0f93bac66a88b",
         "type": "github"
       },
       "original": {
@@ -82,11 +82,11 @@
         "systems": "systems_3"
       },
       "locked": {
-        "lastModified": 1701680307,
-        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
+        "lastModified": 1705309234,
+        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
+        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
         "type": "github"
       },
       "original": {
@@ -131,11 +131,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1703180293,
-        "narHash": "sha256-zQPEPf1Q3Z4Wt86Bef9czyKfff8r8vr2LEsfR5qxoaU=",
+        "lastModified": 1706129113,
+        "narHash": "sha256-7YW9RkxDfVQFej2Lw4equuAFb5lEWwsNxW/G+fft768=",
         "owner": "fstarlang",
         "repo": "fstar",
-        "rev": "0806a005a879f256ff5af6736fbea4d45ea6f6ca",
+        "rev": "1be61a27b7413c4e35c1f9affcc6979e8c9a43d6",
         "type": "github"
       },
       "original": {
@@ -164,11 +164,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1703047078,
-        "narHash": "sha256-LbEoFtOMFB1LVAV4O4WvOvKNjT5QTQo44mkwbzTaA2A=",
+        "lastModified": 1705864452,
+        "narHash": "sha256-vjW9bxQ8gm5c0b316NOfjqXaWDLGDCGCnXd6HcvIV+k=",
         "owner": "hacl-star",
         "repo": "hacl-star",
-        "rev": "1e571f77e1752449d48fe7361787cc7d01f93a49",
+        "rev": "73e719274a8372122994919ae2722a3b1be2bb32",
         "type": "github"
       },
       "original": {
@@ -194,11 +194,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1703207646,
-        "narHash": "sha256-ZM7WeH5Inwottbxefjn0Acw3z6Q/iarkqldbTWt/2lQ=",
+        "lastModified": 1706145524,
+        "narHash": "sha256-gVS1+zqmQa2ghxbPgHG98QmpTqvTB9JM7G9pbe2rLbM=",
         "owner": "hacl-star",
         "repo": "hacl-nix",
-        "rev": "31e836f69da3cddbc1d3324de40b4901a69de320",
+        "rev": "757aa30e65f111714797d8ba37b38cc0f03aa6b2",
         "type": "github"
       },
       "original": {
@@ -223,11 +223,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1702906344,
-        "narHash": "sha256-bfg18GolyW8/LcmUKh/bwryMjSQCR6GaGVuKmJIdBwQ=",
+        "lastModified": 1705542599,
+        "narHash": "sha256-wNtuRRvMzRzBE2xKreNSM9uJecDHFUXyug1+O9t+eyQ=",
         "owner": "fstarlang",
         "repo": "karamel",
-        "rev": "67b19d9a05f6578aec0b640fcb6e432ff18daa71",
+        "rev": "fdf6a10aa22f9b1b3effffeeb270229447b5bb9b",
         "type": "github"
       },
       "original": {
@@ -265,11 +265,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1703256773,
-        "narHash": "sha256-HuiHOhvfNVaJAOgpSMpUp24YcYxuRWMt7X77bT+sNAg=",
+        "lastModified": 1706176580,
+        "narHash": "sha256-GPvacgrLp/LGt1YU8P40dNnJBCMs376kB7SZAo6MV88=",
         "owner": "leanprover",
         "repo": "lean4",
-        "rev": "7c38649527c85116345df831254985afa2680dd0",
+        "rev": "1f4359cc80d9942d6ee651017cc17dcd62da6595",
         "type": "github"
       },
       "original": {
@@ -318,11 +318,11 @@
         "nixpkgs": "nixpkgs_7"
       },
       "locked": {
-        "lastModified": 1703256773,
-        "narHash": "sha256-HuiHOhvfNVaJAOgpSMpUp24YcYxuRWMt7X77bT+sNAg=",
+        "lastModified": 1706176580,
+        "narHash": "sha256-GPvacgrLp/LGt1YU8P40dNnJBCMs376kB7SZAo6MV88=",
         "owner": "leanprover",
         "repo": "lean4",
-        "rev": "7c38649527c85116345df831254985afa2680dd0",
+        "rev": "1f4359cc80d9942d6ee651017cc17dcd62da6595",
         "type": "github"
       },
       "original": {

--- a/tests/coq/misc/Loops.v
+++ b/tests/coq/misc/Loops.v
@@ -70,8 +70,31 @@ Definition sum_with_shared_borrows (n : nat) (max : u32) : result u32 :=
   sum_with_shared_borrows_loop n max 0%u32 0%u32
 .
 
+(** [loops::sum_array]: loop 0:
+    Source: 'src/loops.rs', lines 50:0-58:1 *)
+Fixpoint sum_array_loop
+  (N : usize) (n : nat) (a : array u32 N) (i : usize) (s : u32) : result u32 :=
+  match n with
+  | O => Fail_ OutOfFuel
+  | S n1 =>
+    if i s< N
+    then (
+      i1 <- array_index_usize u32 N a i;
+      s1 <- u32_add s i1;
+      i2 <- usize_add i 1%usize;
+      sum_array_loop N n1 a i2 s1)
+    else Return s
+  end
+.
+
+(** [loops::sum_array]:
+    Source: 'src/loops.rs', lines 50:0-50:52 *)
+Definition sum_array (N : usize) (n : nat) (a : array u32 N) : result u32 :=
+  sum_array_loop N n a 0%usize 0%u32
+.
+
 (** [loops::clear]: loop 0:
-    Source: 'src/loops.rs', lines 52:0-58:1 *)
+    Source: 'src/loops.rs', lines 62:0-68:1 *)
 Fixpoint clear_loop
   (n : nat) (v : alloc_vec_Vec u32) (i : usize) : result (alloc_vec_Vec u32) :=
   match n with
@@ -92,14 +115,14 @@ Fixpoint clear_loop
 .
 
 (** [loops::clear]:
-    Source: 'src/loops.rs', lines 52:0-52:30 *)
+    Source: 'src/loops.rs', lines 62:0-62:30 *)
 Definition clear
   (n : nat) (v : alloc_vec_Vec u32) : result (alloc_vec_Vec u32) :=
   clear_loop n v 0%usize
 .
 
 (** [loops::List]
-    Source: 'src/loops.rs', lines 60:0-60:16 *)
+    Source: 'src/loops.rs', lines 70:0-70:16 *)
 Inductive List_t (T : Type) :=
 | List_Cons : T -> List_t T -> List_t T
 | List_Nil : List_t T
@@ -109,7 +132,7 @@ Arguments List_Cons { _ }.
 Arguments List_Nil { _ }.
 
 (** [loops::list_mem]: loop 0:
-    Source: 'src/loops.rs', lines 66:0-75:1 *)
+    Source: 'src/loops.rs', lines 76:0-85:1 *)
 Fixpoint list_mem_loop (n : nat) (x : u32) (ls : List_t u32) : result bool :=
   match n with
   | O => Fail_ OutOfFuel
@@ -122,13 +145,13 @@ Fixpoint list_mem_loop (n : nat) (x : u32) (ls : List_t u32) : result bool :=
 .
 
 (** [loops::list_mem]:
-    Source: 'src/loops.rs', lines 66:0-66:52 *)
+    Source: 'src/loops.rs', lines 76:0-76:52 *)
 Definition list_mem (n : nat) (x : u32) (ls : List_t u32) : result bool :=
   list_mem_loop n x ls
 .
 
 (** [loops::list_nth_mut_loop]: loop 0:
-    Source: 'src/loops.rs', lines 78:0-88:1 *)
+    Source: 'src/loops.rs', lines 88:0-98:1 *)
 Fixpoint list_nth_mut_loop_loop
   (T : Type) (n : nat) (ls : List_t T) (i : u32) :
   result (T * (T -> result (List_t T)))
@@ -155,7 +178,7 @@ Fixpoint list_nth_mut_loop_loop
 .
 
 (** [loops::list_nth_mut_loop]:
-    Source: 'src/loops.rs', lines 78:0-78:71 *)
+    Source: 'src/loops.rs', lines 88:0-88:71 *)
 Definition list_nth_mut_loop
   (T : Type) (n : nat) (ls : List_t T) (i : u32) :
   result (T * (T -> result (List_t T)))
@@ -164,7 +187,7 @@ Definition list_nth_mut_loop
 .
 
 (** [loops::list_nth_shared_loop]: loop 0:
-    Source: 'src/loops.rs', lines 91:0-101:1 *)
+    Source: 'src/loops.rs', lines 101:0-111:1 *)
 Fixpoint list_nth_shared_loop_loop
   (T : Type) (n : nat) (ls : List_t T) (i : u32) : result T :=
   match n with
@@ -181,14 +204,14 @@ Fixpoint list_nth_shared_loop_loop
 .
 
 (** [loops::list_nth_shared_loop]:
-    Source: 'src/loops.rs', lines 91:0-91:66 *)
+    Source: 'src/loops.rs', lines 101:0-101:66 *)
 Definition list_nth_shared_loop
   (T : Type) (n : nat) (ls : List_t T) (i : u32) : result T :=
   list_nth_shared_loop_loop T n ls i
 .
 
 (** [loops::get_elem_mut]: loop 0:
-    Source: 'src/loops.rs', lines 103:0-117:1 *)
+    Source: 'src/loops.rs', lines 113:0-127:1 *)
 Fixpoint get_elem_mut_loop
   (n : nat) (x : usize) (ls : List_t usize) :
   result (usize * (usize -> result (List_t usize)))
@@ -214,7 +237,7 @@ Fixpoint get_elem_mut_loop
 .
 
 (** [loops::get_elem_mut]:
-    Source: 'src/loops.rs', lines 103:0-103:73 *)
+    Source: 'src/loops.rs', lines 113:0-113:73 *)
 Definition get_elem_mut
   (n : nat) (slots : alloc_vec_Vec (List_t usize)) (x : usize) :
   result (usize * (usize -> result (alloc_vec_Vec (List_t usize))))
@@ -230,7 +253,7 @@ Definition get_elem_mut
 .
 
 (** [loops::get_elem_shared]: loop 0:
-    Source: 'src/loops.rs', lines 119:0-133:1 *)
+    Source: 'src/loops.rs', lines 129:0-143:1 *)
 Fixpoint get_elem_shared_loop
   (n : nat) (x : usize) (ls : List_t usize) : result usize :=
   match n with
@@ -245,7 +268,7 @@ Fixpoint get_elem_shared_loop
 .
 
 (** [loops::get_elem_shared]:
-    Source: 'src/loops.rs', lines 119:0-119:68 *)
+    Source: 'src/loops.rs', lines 129:0-129:68 *)
 Definition get_elem_shared
   (n : nat) (slots : alloc_vec_Vec (List_t usize)) (x : usize) :
   result usize
@@ -257,7 +280,7 @@ Definition get_elem_shared
 .
 
 (** [loops::id_mut]:
-    Source: 'src/loops.rs', lines 135:0-135:50 *)
+    Source: 'src/loops.rs', lines 145:0-145:50 *)
 Definition id_mut
   (T : Type) (ls : List_t T) :
   result ((List_t T) * (List_t T -> result (List_t T)))
@@ -266,13 +289,13 @@ Definition id_mut
 .
 
 (** [loops::id_shared]:
-    Source: 'src/loops.rs', lines 139:0-139:45 *)
+    Source: 'src/loops.rs', lines 149:0-149:45 *)
 Definition id_shared (T : Type) (ls : List_t T) : result (List_t T) :=
   Return ls
 .
 
 (** [loops::list_nth_mut_loop_with_id]: loop 0:
-    Source: 'src/loops.rs', lines 144:0-155:1 *)
+    Source: 'src/loops.rs', lines 154:0-165:1 *)
 Fixpoint list_nth_mut_loop_with_id_loop
   (T : Type) (n : nat) (i : u32) (ls : List_t T) :
   result (T * (T -> result (List_t T)))
@@ -299,7 +322,7 @@ Fixpoint list_nth_mut_loop_with_id_loop
 .
 
 (** [loops::list_nth_mut_loop_with_id]:
-    Source: 'src/loops.rs', lines 144:0-144:75 *)
+    Source: 'src/loops.rs', lines 154:0-154:75 *)
 Definition list_nth_mut_loop_with_id
   (T : Type) (n : nat) (ls : List_t T) (i : u32) :
   result (T * (T -> result (List_t T)))
@@ -313,7 +336,7 @@ Definition list_nth_mut_loop_with_id
 .
 
 (** [loops::list_nth_shared_loop_with_id]: loop 0:
-    Source: 'src/loops.rs', lines 158:0-169:1 *)
+    Source: 'src/loops.rs', lines 168:0-179:1 *)
 Fixpoint list_nth_shared_loop_with_id_loop
   (T : Type) (n : nat) (i : u32) (ls : List_t T) : result T :=
   match n with
@@ -331,14 +354,14 @@ Fixpoint list_nth_shared_loop_with_id_loop
 .
 
 (** [loops::list_nth_shared_loop_with_id]:
-    Source: 'src/loops.rs', lines 158:0-158:70 *)
+    Source: 'src/loops.rs', lines 168:0-168:70 *)
 Definition list_nth_shared_loop_with_id
   (T : Type) (n : nat) (ls : List_t T) (i : u32) : result T :=
   ls1 <- id_shared T ls; list_nth_shared_loop_with_id_loop T n i ls1
 .
 
 (** [loops::list_nth_mut_loop_pair]: loop 0:
-    Source: 'src/loops.rs', lines 174:0-195:1 *)
+    Source: 'src/loops.rs', lines 184:0-205:1 *)
 Fixpoint list_nth_mut_loop_pair_loop
   (T : Type) (n : nat) (ls0 : List_t T) (ls1 : List_t T) (i : u32) :
   result ((T * T) * (T -> result (List_t T)) * (T -> result (List_t T)))
@@ -372,7 +395,7 @@ Fixpoint list_nth_mut_loop_pair_loop
 .
 
 (** [loops::list_nth_mut_loop_pair]:
-    Source: 'src/loops.rs', lines 174:0-178:27 *)
+    Source: 'src/loops.rs', lines 184:0-188:27 *)
 Definition list_nth_mut_loop_pair
   (T : Type) (n : nat) (ls0 : List_t T) (ls1 : List_t T) (i : u32) :
   result ((T * T) * (T -> result (List_t T)) * (T -> result (List_t T)))
@@ -383,7 +406,7 @@ Definition list_nth_mut_loop_pair
 .
 
 (** [loops::list_nth_shared_loop_pair]: loop 0:
-    Source: 'src/loops.rs', lines 198:0-219:1 *)
+    Source: 'src/loops.rs', lines 208:0-229:1 *)
 Fixpoint list_nth_shared_loop_pair_loop
   (T : Type) (n : nat) (ls0 : List_t T) (ls1 : List_t T) (i : u32) :
   result (T * T)
@@ -407,7 +430,7 @@ Fixpoint list_nth_shared_loop_pair_loop
 .
 
 (** [loops::list_nth_shared_loop_pair]:
-    Source: 'src/loops.rs', lines 198:0-202:19 *)
+    Source: 'src/loops.rs', lines 208:0-212:19 *)
 Definition list_nth_shared_loop_pair
   (T : Type) (n : nat) (ls0 : List_t T) (ls1 : List_t T) (i : u32) :
   result (T * T)
@@ -416,7 +439,7 @@ Definition list_nth_shared_loop_pair
 .
 
 (** [loops::list_nth_mut_loop_pair_merge]: loop 0:
-    Source: 'src/loops.rs', lines 223:0-238:1 *)
+    Source: 'src/loops.rs', lines 233:0-248:1 *)
 Fixpoint list_nth_mut_loop_pair_merge_loop
   (T : Type) (n : nat) (ls0 : List_t T) (ls1 : List_t T) (i : u32) :
   result ((T * T) * ((T * T) -> result ((List_t T) * (List_t T))))
@@ -453,7 +476,7 @@ Fixpoint list_nth_mut_loop_pair_merge_loop
 .
 
 (** [loops::list_nth_mut_loop_pair_merge]:
-    Source: 'src/loops.rs', lines 223:0-227:27 *)
+    Source: 'src/loops.rs', lines 233:0-237:27 *)
 Definition list_nth_mut_loop_pair_merge
   (T : Type) (n : nat) (ls0 : List_t T) (ls1 : List_t T) (i : u32) :
   result ((T * T) * ((T * T) -> result ((List_t T) * (List_t T))))
@@ -464,7 +487,7 @@ Definition list_nth_mut_loop_pair_merge
 .
 
 (** [loops::list_nth_shared_loop_pair_merge]: loop 0:
-    Source: 'src/loops.rs', lines 241:0-256:1 *)
+    Source: 'src/loops.rs', lines 251:0-266:1 *)
 Fixpoint list_nth_shared_loop_pair_merge_loop
   (T : Type) (n : nat) (ls0 : List_t T) (ls1 : List_t T) (i : u32) :
   result (T * T)
@@ -489,7 +512,7 @@ Fixpoint list_nth_shared_loop_pair_merge_loop
 .
 
 (** [loops::list_nth_shared_loop_pair_merge]:
-    Source: 'src/loops.rs', lines 241:0-245:19 *)
+    Source: 'src/loops.rs', lines 251:0-255:19 *)
 Definition list_nth_shared_loop_pair_merge
   (T : Type) (n : nat) (ls0 : List_t T) (ls1 : List_t T) (i : u32) :
   result (T * T)
@@ -498,7 +521,7 @@ Definition list_nth_shared_loop_pair_merge
 .
 
 (** [loops::list_nth_mut_shared_loop_pair]: loop 0:
-    Source: 'src/loops.rs', lines 259:0-274:1 *)
+    Source: 'src/loops.rs', lines 269:0-284:1 *)
 Fixpoint list_nth_mut_shared_loop_pair_loop
   (T : Type) (n : nat) (ls0 : List_t T) (ls1 : List_t T) (i : u32) :
   result ((T * T) * (T -> result (List_t T)))
@@ -529,7 +552,7 @@ Fixpoint list_nth_mut_shared_loop_pair_loop
 .
 
 (** [loops::list_nth_mut_shared_loop_pair]:
-    Source: 'src/loops.rs', lines 259:0-263:23 *)
+    Source: 'src/loops.rs', lines 269:0-273:23 *)
 Definition list_nth_mut_shared_loop_pair
   (T : Type) (n : nat) (ls0 : List_t T) (ls1 : List_t T) (i : u32) :
   result ((T * T) * (T -> result (List_t T)))
@@ -540,7 +563,7 @@ Definition list_nth_mut_shared_loop_pair
 .
 
 (** [loops::list_nth_mut_shared_loop_pair_merge]: loop 0:
-    Source: 'src/loops.rs', lines 278:0-293:1 *)
+    Source: 'src/loops.rs', lines 288:0-303:1 *)
 Fixpoint list_nth_mut_shared_loop_pair_merge_loop
   (T : Type) (n : nat) (ls0 : List_t T) (ls1 : List_t T) (i : u32) :
   result ((T * T) * (T -> result (List_t T)))
@@ -571,7 +594,7 @@ Fixpoint list_nth_mut_shared_loop_pair_merge_loop
 .
 
 (** [loops::list_nth_mut_shared_loop_pair_merge]:
-    Source: 'src/loops.rs', lines 278:0-282:23 *)
+    Source: 'src/loops.rs', lines 288:0-292:23 *)
 Definition list_nth_mut_shared_loop_pair_merge
   (T : Type) (n : nat) (ls0 : List_t T) (ls1 : List_t T) (i : u32) :
   result ((T * T) * (T -> result (List_t T)))
@@ -582,7 +605,7 @@ Definition list_nth_mut_shared_loop_pair_merge
 .
 
 (** [loops::list_nth_shared_mut_loop_pair]: loop 0:
-    Source: 'src/loops.rs', lines 297:0-312:1 *)
+    Source: 'src/loops.rs', lines 307:0-322:1 *)
 Fixpoint list_nth_shared_mut_loop_pair_loop
   (T : Type) (n : nat) (ls0 : List_t T) (ls1 : List_t T) (i : u32) :
   result ((T * T) * (T -> result (List_t T)))
@@ -613,7 +636,7 @@ Fixpoint list_nth_shared_mut_loop_pair_loop
 .
 
 (** [loops::list_nth_shared_mut_loop_pair]:
-    Source: 'src/loops.rs', lines 297:0-301:23 *)
+    Source: 'src/loops.rs', lines 307:0-311:23 *)
 Definition list_nth_shared_mut_loop_pair
   (T : Type) (n : nat) (ls0 : List_t T) (ls1 : List_t T) (i : u32) :
   result ((T * T) * (T -> result (List_t T)))
@@ -624,7 +647,7 @@ Definition list_nth_shared_mut_loop_pair
 .
 
 (** [loops::list_nth_shared_mut_loop_pair_merge]: loop 0:
-    Source: 'src/loops.rs', lines 316:0-331:1 *)
+    Source: 'src/loops.rs', lines 326:0-341:1 *)
 Fixpoint list_nth_shared_mut_loop_pair_merge_loop
   (T : Type) (n : nat) (ls0 : List_t T) (ls1 : List_t T) (i : u32) :
   result ((T * T) * (T -> result (List_t T)))
@@ -655,7 +678,7 @@ Fixpoint list_nth_shared_mut_loop_pair_merge_loop
 .
 
 (** [loops::list_nth_shared_mut_loop_pair_merge]:
-    Source: 'src/loops.rs', lines 316:0-320:23 *)
+    Source: 'src/loops.rs', lines 326:0-330:23 *)
 Definition list_nth_shared_mut_loop_pair_merge
   (T : Type) (n : nat) (ls0 : List_t T) (ls1 : List_t T) (i : u32) :
   result ((T * T) * (T -> result (List_t T)))

--- a/tests/coq/traits/Traits.v
+++ b/tests/coq/traits/Traits.v
@@ -402,17 +402,8 @@ Arguments mkChildTrait_t { _ }.
 Arguments ChildTrait_tChildTrait_t_ParentTrait0SelfInst { _ }.
 Arguments ChildTrait_tChildTrait_t_ParentTrait1SelfInst { _ }.
 
-(** [traits::test_parent_trait0]:
-    Source: 'src/traits.rs', lines 208:0-208:57 *)
-Definition test_parent_trait0
-  (T : Type) (parentTrait0TInst : ParentTrait0_t T) (x : T) :
-  result parentTrait0TInst.(ParentTrait0_tParentTrait0_t_W)
-  :=
-  parentTrait0TInst.(ParentTrait0_t_get_w) x
-.
-
 (** [traits::test_child_trait1]:
-    Source: 'src/traits.rs', lines 213:0-213:56 *)
+    Source: 'src/traits.rs', lines 209:0-209:56 *)
 Definition test_child_trait1
   (T : Type) (childTraitTInst : ChildTrait_t T) (x : T) : result string :=
   childTraitTInst.(ChildTrait_tChildTrait_t_ParentTrait0SelfInst).(ParentTrait0_t_get_name)
@@ -420,7 +411,7 @@ Definition test_child_trait1
 .
 
 (** [traits::test_child_trait2]:
-    Source: 'src/traits.rs', lines 217:0-217:54 *)
+    Source: 'src/traits.rs', lines 213:0-213:54 *)
 Definition test_child_trait2
   (T : Type) (childTraitTInst : ChildTrait_t T) (x : T) :
   result
@@ -431,7 +422,7 @@ Definition test_child_trait2
 .
 
 (** [traits::order1]:
-    Source: 'src/traits.rs', lines 223:0-223:59 *)
+    Source: 'src/traits.rs', lines 219:0-219:59 *)
 Definition order1
   (T U : Type) (parentTrait0TInst : ParentTrait0_t T) (parentTrait0UInst :
   ParentTrait0_t U) :
@@ -441,7 +432,7 @@ Definition order1
 .
 
 (** Trait declaration: [traits::ChildTrait1]
-    Source: 'src/traits.rs', lines 226:0-226:35 *)
+    Source: 'src/traits.rs', lines 222:0-222:35 *)
 Record ChildTrait1_t (Self : Type) := mkChildTrait1_t {
   ChildTrait1_tChildTrait1_t_ParentTrait1SelfInst : ParentTrait1_t Self;
 }.
@@ -450,19 +441,19 @@ Arguments mkChildTrait1_t { _ }.
 Arguments ChildTrait1_tChildTrait1_t_ParentTrait1SelfInst { _ }.
 
 (** Trait implementation: [traits::{usize#9}]
-    Source: 'src/traits.rs', lines 228:0-228:27 *)
+    Source: 'src/traits.rs', lines 224:0-224:27 *)
 Definition traits_ParentTrait1UsizeInst : ParentTrait1_t usize
   := mkParentTrait1_t.
 
 (** Trait implementation: [traits::{usize#10}]
-    Source: 'src/traits.rs', lines 229:0-229:26 *)
+    Source: 'src/traits.rs', lines 225:0-225:26 *)
 Definition traits_ChildTrait1UsizeInst : ChildTrait1_t usize := {|
   ChildTrait1_tChildTrait1_t_ParentTrait1SelfInst :=
     traits_ParentTrait1UsizeInst;
 |}.
 
 (** Trait declaration: [traits::Iterator]
-    Source: 'src/traits.rs', lines 233:0-233:18 *)
+    Source: 'src/traits.rs', lines 229:0-229:18 *)
 Record Iterator_t (Self : Type) := mkIterator_t {
   Iterator_tIterator_t_Item : Type;
 }.
@@ -471,7 +462,7 @@ Arguments mkIterator_t { _ }.
 Arguments Iterator_tIterator_t_Item { _ }.
 
 (** Trait declaration: [traits::IntoIterator]
-    Source: 'src/traits.rs', lines 237:0-237:22 *)
+    Source: 'src/traits.rs', lines 233:0-233:22 *)
 Record IntoIterator_t (Self : Type) := mkIntoIterator_t {
   IntoIterator_tIntoIterator_t_Item : Type;
   IntoIterator_tIntoIterator_t_IntoIter : Type;
@@ -488,13 +479,13 @@ Arguments IntoIterator_tIntoIterator_t_IntoIter_clause_0 { _ }.
 Arguments IntoIterator_t_into_iter { _ }.
 
 (** Trait declaration: [traits::FromResidual]
-    Source: 'src/traits.rs', lines 254:0-254:21 *)
+    Source: 'src/traits.rs', lines 250:0-250:21 *)
 Record FromResidual_t (Self T : Type) := mkFromResidual_t{}.
 
 Arguments mkFromResidual_t { _ _ }.
 
 (** Trait declaration: [traits::Try]
-    Source: 'src/traits.rs', lines 250:0-250:48 *)
+    Source: 'src/traits.rs', lines 246:0-246:48 *)
 Record Try_t (Self : Type) := mkTry_t {
   Try_tTry_t_Residual : Type;
   Try_tTry_t_FromResidualSelftraitsTrySelfResidualInst : FromResidual_t Self
@@ -506,7 +497,7 @@ Arguments Try_tTry_t_Residual { _ }.
 Arguments Try_tTry_t_FromResidualSelftraitsTrySelfResidualInst { _ }.
 
 (** Trait declaration: [traits::WithTarget]
-    Source: 'src/traits.rs', lines 256:0-256:20 *)
+    Source: 'src/traits.rs', lines 252:0-252:20 *)
 Record WithTarget_t (Self : Type) := mkWithTarget_t {
   WithTarget_tWithTarget_t_Target : Type;
 }.
@@ -515,7 +506,7 @@ Arguments mkWithTarget_t { _ }.
 Arguments WithTarget_tWithTarget_t_Target { _ }.
 
 (** Trait declaration: [traits::ParentTrait2]
-    Source: 'src/traits.rs', lines 260:0-260:22 *)
+    Source: 'src/traits.rs', lines 256:0-256:22 *)
 Record ParentTrait2_t (Self : Type) := mkParentTrait2_t {
   ParentTrait2_tParentTrait2_t_U : Type;
   ParentTrait2_tParentTrait2_t_U_clause_0 : WithTarget_t
@@ -527,7 +518,7 @@ Arguments ParentTrait2_tParentTrait2_t_U { _ }.
 Arguments ParentTrait2_tParentTrait2_t_U_clause_0 { _ }.
 
 (** Trait declaration: [traits::ChildTrait2]
-    Source: 'src/traits.rs', lines 264:0-264:35 *)
+    Source: 'src/traits.rs', lines 260:0-260:35 *)
 Record ChildTrait2_t (Self : Type) := mkChildTrait2_t {
   ChildTrait2_tChildTrait2_t_ParentTrait2SelfInst : ParentTrait2_t Self;
   ChildTrait2_t_convert :
@@ -541,25 +532,25 @@ Arguments ChildTrait2_tChildTrait2_t_ParentTrait2SelfInst { _ }.
 Arguments ChildTrait2_t_convert { _ }.
 
 (** Trait implementation: [traits::{u32#11}]
-    Source: 'src/traits.rs', lines 268:0-268:23 *)
+    Source: 'src/traits.rs', lines 264:0-264:23 *)
 Definition traits_WithTargetU32Inst : WithTarget_t u32 := {|
   WithTarget_tWithTarget_t_Target := u32;
 |}.
 
 (** Trait implementation: [traits::{u32#12}]
-    Source: 'src/traits.rs', lines 272:0-272:25 *)
+    Source: 'src/traits.rs', lines 268:0-268:25 *)
 Definition traits_ParentTrait2U32Inst : ParentTrait2_t u32 := {|
   ParentTrait2_tParentTrait2_t_U := u32;
   ParentTrait2_tParentTrait2_t_U_clause_0 := traits_WithTargetU32Inst;
 |}.
 
 (** [traits::{u32#13}::convert]:
-    Source: 'src/traits.rs', lines 277:4-277:29 *)
+    Source: 'src/traits.rs', lines 273:4-273:29 *)
 Definition u32_convert (x : u32) : result u32 :=
   Return x.
 
 (** Trait implementation: [traits::{u32#13}]
-    Source: 'src/traits.rs', lines 276:0-276:24 *)
+    Source: 'src/traits.rs', lines 272:0-272:24 *)
 Definition traits_ChildTrait2U32Inst : ChildTrait2_t u32 := {|
   ChildTrait2_tChildTrait2_t_ParentTrait2SelfInst :=
     traits_ParentTrait2U32Inst;
@@ -567,7 +558,7 @@ Definition traits_ChildTrait2U32Inst : ChildTrait2_t u32 := {|
 |}.
 
 (** Trait declaration: [traits::CFnOnce]
-    Source: 'src/traits.rs', lines 290:0-290:23 *)
+    Source: 'src/traits.rs', lines 286:0-286:23 *)
 Record CFnOnce_t (Self Args : Type) := mkCFnOnce_t {
   CFnOnce_tCFnOnce_t_Output : Type;
   CFnOnce_t_call_once : Self -> Args -> result CFnOnce_tCFnOnce_t_Output;
@@ -578,7 +569,7 @@ Arguments CFnOnce_tCFnOnce_t_Output { _ _ }.
 Arguments CFnOnce_t_call_once { _ _ }.
 
 (** Trait declaration: [traits::CFnMut]
-    Source: 'src/traits.rs', lines 296:0-296:37 *)
+    Source: 'src/traits.rs', lines 292:0-292:37 *)
 Record CFnMut_t (Self Args : Type) := mkCFnMut_t {
   CFnMut_tCFnMut_t_CFnOnceSelfArgsInst : CFnOnce_t Self Args;
   CFnMut_t_call_mut : Self -> Args -> result
@@ -591,7 +582,7 @@ Arguments CFnMut_tCFnMut_t_CFnOnceSelfArgsInst { _ _ }.
 Arguments CFnMut_t_call_mut { _ _ }.
 
 (** Trait declaration: [traits::CFn]
-    Source: 'src/traits.rs', lines 300:0-300:33 *)
+    Source: 'src/traits.rs', lines 296:0-296:33 *)
 Record CFn_t (Self Args : Type) := mkCFn_t {
   CFn_tCFn_t_CFnMutSelfArgsInst : CFnMut_t Self Args;
   CFn_t_call : Self -> Args -> result
@@ -603,7 +594,7 @@ Arguments CFn_tCFn_t_CFnMutSelfArgsInst { _ _ }.
 Arguments CFn_t_call { _ _ }.
 
 (** Trait declaration: [traits::GetTrait]
-    Source: 'src/traits.rs', lines 304:0-304:18 *)
+    Source: 'src/traits.rs', lines 300:0-300:18 *)
 Record GetTrait_t (Self : Type) := mkGetTrait_t {
   GetTrait_tGetTrait_t_W : Type;
   GetTrait_t_get_w : Self -> result GetTrait_tGetTrait_t_W;
@@ -614,7 +605,7 @@ Arguments GetTrait_tGetTrait_t_W { _ }.
 Arguments GetTrait_t_get_w { _ }.
 
 (** [traits::test_get_trait]:
-    Source: 'src/traits.rs', lines 309:0-309:49 *)
+    Source: 'src/traits.rs', lines 305:0-305:49 *)
 Definition test_get_trait
   (T : Type) (getTraitTInst : GetTrait_t T) (x : T) :
   result getTraitTInst.(GetTrait_tGetTrait_t_W)

--- a/tests/fstar-split/misc/Loops.Clauses.Template.fst
+++ b/tests/fstar-split/misc/Loops.Clauses.Template.fst
@@ -24,106 +24,113 @@ let sum_with_shared_borrows_loop_decreases (max : u32) (i : u32) (s : u32) :
   nat =
   admit ()
 
+(** [loops::sum_array]: decreases clause
+    Source: 'src/loops.rs', lines 50:0-58:1 *)
+unfold
+let sum_array_loop_decreases (n : usize) (a : array u32 n) (i : usize)
+  (s : u32) : nat =
+  admit ()
+
 (** [loops::clear]: decreases clause
-    Source: 'src/loops.rs', lines 52:0-58:1 *)
+    Source: 'src/loops.rs', lines 62:0-68:1 *)
 unfold
 let clear_loop_decreases (v : alloc_vec_Vec u32) (i : usize) : nat = admit ()
 
 (** [loops::list_mem]: decreases clause
-    Source: 'src/loops.rs', lines 66:0-75:1 *)
+    Source: 'src/loops.rs', lines 76:0-85:1 *)
 unfold let list_mem_loop_decreases (x : u32) (ls : list_t u32) : nat = admit ()
 
 (** [loops::list_nth_mut_loop]: decreases clause
-    Source: 'src/loops.rs', lines 78:0-88:1 *)
+    Source: 'src/loops.rs', lines 88:0-98:1 *)
 unfold
 let list_nth_mut_loop_loop_decreases (t : Type0) (ls : list_t t) (i : u32) :
   nat =
   admit ()
 
 (** [loops::list_nth_shared_loop]: decreases clause
-    Source: 'src/loops.rs', lines 91:0-101:1 *)
+    Source: 'src/loops.rs', lines 101:0-111:1 *)
 unfold
 let list_nth_shared_loop_loop_decreases (t : Type0) (ls : list_t t) (i : u32) :
   nat =
   admit ()
 
 (** [loops::get_elem_mut]: decreases clause
-    Source: 'src/loops.rs', lines 103:0-117:1 *)
+    Source: 'src/loops.rs', lines 113:0-127:1 *)
 unfold
 let get_elem_mut_loop_decreases (x : usize) (ls : list_t usize) : nat =
   admit ()
 
 (** [loops::get_elem_shared]: decreases clause
-    Source: 'src/loops.rs', lines 119:0-133:1 *)
+    Source: 'src/loops.rs', lines 129:0-143:1 *)
 unfold
 let get_elem_shared_loop_decreases (x : usize) (ls : list_t usize) : nat =
   admit ()
 
 (** [loops::list_nth_mut_loop_with_id]: decreases clause
-    Source: 'src/loops.rs', lines 144:0-155:1 *)
+    Source: 'src/loops.rs', lines 154:0-165:1 *)
 unfold
 let list_nth_mut_loop_with_id_loop_decreases (t : Type0) (i : u32)
   (ls : list_t t) : nat =
   admit ()
 
 (** [loops::list_nth_shared_loop_with_id]: decreases clause
-    Source: 'src/loops.rs', lines 158:0-169:1 *)
+    Source: 'src/loops.rs', lines 168:0-179:1 *)
 unfold
 let list_nth_shared_loop_with_id_loop_decreases (t : Type0) (i : u32)
   (ls : list_t t) : nat =
   admit ()
 
 (** [loops::list_nth_mut_loop_pair]: decreases clause
-    Source: 'src/loops.rs', lines 174:0-195:1 *)
+    Source: 'src/loops.rs', lines 184:0-205:1 *)
 unfold
 let list_nth_mut_loop_pair_loop_decreases (t : Type0) (ls0 : list_t t)
   (ls1 : list_t t) (i : u32) : nat =
   admit ()
 
 (** [loops::list_nth_shared_loop_pair]: decreases clause
-    Source: 'src/loops.rs', lines 198:0-219:1 *)
+    Source: 'src/loops.rs', lines 208:0-229:1 *)
 unfold
 let list_nth_shared_loop_pair_loop_decreases (t : Type0) (ls0 : list_t t)
   (ls1 : list_t t) (i : u32) : nat =
   admit ()
 
 (** [loops::list_nth_mut_loop_pair_merge]: decreases clause
-    Source: 'src/loops.rs', lines 223:0-238:1 *)
+    Source: 'src/loops.rs', lines 233:0-248:1 *)
 unfold
 let list_nth_mut_loop_pair_merge_loop_decreases (t : Type0) (ls0 : list_t t)
   (ls1 : list_t t) (i : u32) : nat =
   admit ()
 
 (** [loops::list_nth_shared_loop_pair_merge]: decreases clause
-    Source: 'src/loops.rs', lines 241:0-256:1 *)
+    Source: 'src/loops.rs', lines 251:0-266:1 *)
 unfold
 let list_nth_shared_loop_pair_merge_loop_decreases (t : Type0) (ls0 : list_t t)
   (ls1 : list_t t) (i : u32) : nat =
   admit ()
 
 (** [loops::list_nth_mut_shared_loop_pair]: decreases clause
-    Source: 'src/loops.rs', lines 259:0-274:1 *)
+    Source: 'src/loops.rs', lines 269:0-284:1 *)
 unfold
 let list_nth_mut_shared_loop_pair_loop_decreases (t : Type0) (ls0 : list_t t)
   (ls1 : list_t t) (i : u32) : nat =
   admit ()
 
 (** [loops::list_nth_mut_shared_loop_pair_merge]: decreases clause
-    Source: 'src/loops.rs', lines 278:0-293:1 *)
+    Source: 'src/loops.rs', lines 288:0-303:1 *)
 unfold
 let list_nth_mut_shared_loop_pair_merge_loop_decreases (t : Type0)
   (ls0 : list_t t) (ls1 : list_t t) (i : u32) : nat =
   admit ()
 
 (** [loops::list_nth_shared_mut_loop_pair]: decreases clause
-    Source: 'src/loops.rs', lines 297:0-312:1 *)
+    Source: 'src/loops.rs', lines 307:0-322:1 *)
 unfold
 let list_nth_shared_mut_loop_pair_loop_decreases (t : Type0) (ls0 : list_t t)
   (ls1 : list_t t) (i : u32) : nat =
   admit ()
 
 (** [loops::list_nth_shared_mut_loop_pair_merge]: decreases clause
-    Source: 'src/loops.rs', lines 316:0-331:1 *)
+    Source: 'src/loops.rs', lines 326:0-341:1 *)
 unfold
 let list_nth_shared_mut_loop_pair_merge_loop_decreases (t : Type0)
   (ls0 : list_t t) (ls1 : list_t t) (i : u32) : nat =

--- a/tests/fstar-split/misc/Loops.Clauses.fst
+++ b/tests/fstar-split/misc/Loops.Clauses.fst
@@ -19,6 +19,11 @@ unfold
 let sum_with_shared_borrows_loop_decreases (max : u32) (i : u32) (s : u32) : nat =
   if max >= i then max - i else 0
 
+(** [loops::sum_array]: decreases clause *)
+unfold
+let sum_array_loop_decreases (n : usize) (_ : array u32 n) (i : usize) (_ : u32) : nat =
+  if n >= i then n - i else 0
+
 (** [loops::clear]: decreases clause *)
 unfold let clear_loop_decreases (v : alloc_vec_Vec u32) (i : usize) : nat =
   if i <= List.Tot.length v then List.Tot.length v - i else 0

--- a/tests/fstar-split/misc/Loops.Funs.fst
+++ b/tests/fstar-split/misc/Loops.Funs.fst
@@ -58,9 +58,28 @@ let rec sum_with_shared_borrows_loop
 let sum_with_shared_borrows (max : u32) : result u32 =
   sum_with_shared_borrows_loop max 0 0
 
+(** [loops::sum_array]: loop 0: forward function
+    Source: 'src/loops.rs', lines 50:0-58:1 *)
+let rec sum_array_loop
+  (n : usize) (a : array u32 n) (i : usize) (s : u32) :
+  Tot (result u32) (decreases (sum_array_loop_decreases n a i s))
+  =
+  if i < n
+  then
+    let* i1 = array_index_usize u32 n a i in
+    let* s1 = u32_add s i1 in
+    let* i2 = usize_add i 1 in
+    sum_array_loop n a i2 s1
+  else Return s
+
+(** [loops::sum_array]: forward function
+    Source: 'src/loops.rs', lines 50:0-50:52 *)
+let sum_array (n : usize) (a : array u32 n) : result u32 =
+  sum_array_loop n a 0 0
+
 (** [loops::clear]: loop 0: merged forward/backward function
     (there is a single backward function, and the forward function returns ())
-    Source: 'src/loops.rs', lines 52:0-58:1 *)
+    Source: 'src/loops.rs', lines 62:0-68:1 *)
 let rec clear_loop
   (v : alloc_vec_Vec u32) (i : usize) :
   Tot (result (alloc_vec_Vec u32)) (decreases (clear_loop_decreases v i))
@@ -77,12 +96,12 @@ let rec clear_loop
 
 (** [loops::clear]: merged forward/backward function
     (there is a single backward function, and the forward function returns ())
-    Source: 'src/loops.rs', lines 52:0-52:30 *)
+    Source: 'src/loops.rs', lines 62:0-62:30 *)
 let clear (v : alloc_vec_Vec u32) : result (alloc_vec_Vec u32) =
   clear_loop v 0
 
 (** [loops::list_mem]: loop 0: forward function
-    Source: 'src/loops.rs', lines 66:0-75:1 *)
+    Source: 'src/loops.rs', lines 76:0-85:1 *)
 let rec list_mem_loop
   (x : u32) (ls : list_t u32) :
   Tot (result bool) (decreases (list_mem_loop_decreases x ls))
@@ -93,12 +112,12 @@ let rec list_mem_loop
   end
 
 (** [loops::list_mem]: forward function
-    Source: 'src/loops.rs', lines 66:0-66:52 *)
+    Source: 'src/loops.rs', lines 76:0-76:52 *)
 let list_mem (x : u32) (ls : list_t u32) : result bool =
   list_mem_loop x ls
 
 (** [loops::list_nth_mut_loop]: loop 0: forward function
-    Source: 'src/loops.rs', lines 78:0-88:1 *)
+    Source: 'src/loops.rs', lines 88:0-98:1 *)
 let rec list_nth_mut_loop_loop
   (t : Type0) (ls : list_t t) (i : u32) :
   Tot (result t) (decreases (list_nth_mut_loop_loop_decreases t ls i))
@@ -112,12 +131,12 @@ let rec list_nth_mut_loop_loop
   end
 
 (** [loops::list_nth_mut_loop]: forward function
-    Source: 'src/loops.rs', lines 78:0-78:71 *)
+    Source: 'src/loops.rs', lines 88:0-88:71 *)
 let list_nth_mut_loop (t : Type0) (ls : list_t t) (i : u32) : result t =
   list_nth_mut_loop_loop t ls i
 
 (** [loops::list_nth_mut_loop]: loop 0: backward function 0
-    Source: 'src/loops.rs', lines 78:0-88:1 *)
+    Source: 'src/loops.rs', lines 88:0-98:1 *)
 let rec list_nth_mut_loop_loop_back
   (t : Type0) (ls : list_t t) (i : u32) (ret : t) :
   Tot (result (list_t t)) (decreases (list_nth_mut_loop_loop_decreases t ls i))
@@ -134,13 +153,13 @@ let rec list_nth_mut_loop_loop_back
   end
 
 (** [loops::list_nth_mut_loop]: backward function 0
-    Source: 'src/loops.rs', lines 78:0-78:71 *)
+    Source: 'src/loops.rs', lines 88:0-88:71 *)
 let list_nth_mut_loop_back
   (t : Type0) (ls : list_t t) (i : u32) (ret : t) : result (list_t t) =
   list_nth_mut_loop_loop_back t ls i ret
 
 (** [loops::list_nth_shared_loop]: loop 0: forward function
-    Source: 'src/loops.rs', lines 91:0-101:1 *)
+    Source: 'src/loops.rs', lines 101:0-111:1 *)
 let rec list_nth_shared_loop_loop
   (t : Type0) (ls : list_t t) (i : u32) :
   Tot (result t) (decreases (list_nth_shared_loop_loop_decreases t ls i))
@@ -154,12 +173,12 @@ let rec list_nth_shared_loop_loop
   end
 
 (** [loops::list_nth_shared_loop]: forward function
-    Source: 'src/loops.rs', lines 91:0-91:66 *)
+    Source: 'src/loops.rs', lines 101:0-101:66 *)
 let list_nth_shared_loop (t : Type0) (ls : list_t t) (i : u32) : result t =
   list_nth_shared_loop_loop t ls i
 
 (** [loops::get_elem_mut]: loop 0: forward function
-    Source: 'src/loops.rs', lines 103:0-117:1 *)
+    Source: 'src/loops.rs', lines 113:0-127:1 *)
 let rec get_elem_mut_loop
   (x : usize) (ls : list_t usize) :
   Tot (result usize) (decreases (get_elem_mut_loop_decreases x ls))
@@ -170,7 +189,7 @@ let rec get_elem_mut_loop
   end
 
 (** [loops::get_elem_mut]: forward function
-    Source: 'src/loops.rs', lines 103:0-103:73 *)
+    Source: 'src/loops.rs', lines 113:0-113:73 *)
 let get_elem_mut
   (slots : alloc_vec_Vec (list_t usize)) (x : usize) : result usize =
   let* l =
@@ -179,7 +198,7 @@ let get_elem_mut
   get_elem_mut_loop x l
 
 (** [loops::get_elem_mut]: loop 0: backward function 0
-    Source: 'src/loops.rs', lines 103:0-117:1 *)
+    Source: 'src/loops.rs', lines 113:0-127:1 *)
 let rec get_elem_mut_loop_back
   (x : usize) (ls : list_t usize) (ret : usize) :
   Tot (result (list_t usize)) (decreases (get_elem_mut_loop_decreases x ls))
@@ -193,7 +212,7 @@ let rec get_elem_mut_loop_back
   end
 
 (** [loops::get_elem_mut]: backward function 0
-    Source: 'src/loops.rs', lines 103:0-103:73 *)
+    Source: 'src/loops.rs', lines 113:0-113:73 *)
 let get_elem_mut_back
   (slots : alloc_vec_Vec (list_t usize)) (x : usize) (ret : usize) :
   result (alloc_vec_Vec (list_t usize))
@@ -206,7 +225,7 @@ let get_elem_mut_back
     (core_slice_index_SliceIndexUsizeSliceTInst (list_t usize)) slots 0 l1
 
 (** [loops::get_elem_shared]: loop 0: forward function
-    Source: 'src/loops.rs', lines 119:0-133:1 *)
+    Source: 'src/loops.rs', lines 129:0-143:1 *)
 let rec get_elem_shared_loop
   (x : usize) (ls : list_t usize) :
   Tot (result usize) (decreases (get_elem_shared_loop_decreases x ls))
@@ -217,7 +236,7 @@ let rec get_elem_shared_loop
   end
 
 (** [loops::get_elem_shared]: forward function
-    Source: 'src/loops.rs', lines 119:0-119:68 *)
+    Source: 'src/loops.rs', lines 129:0-129:68 *)
 let get_elem_shared
   (slots : alloc_vec_Vec (list_t usize)) (x : usize) : result usize =
   let* l =
@@ -226,23 +245,23 @@ let get_elem_shared
   get_elem_shared_loop x l
 
 (** [loops::id_mut]: forward function
-    Source: 'src/loops.rs', lines 135:0-135:50 *)
+    Source: 'src/loops.rs', lines 145:0-145:50 *)
 let id_mut (t : Type0) (ls : list_t t) : result (list_t t) =
   Return ls
 
 (** [loops::id_mut]: backward function 0
-    Source: 'src/loops.rs', lines 135:0-135:50 *)
+    Source: 'src/loops.rs', lines 145:0-145:50 *)
 let id_mut_back
   (t : Type0) (ls : list_t t) (ret : list_t t) : result (list_t t) =
   Return ret
 
 (** [loops::id_shared]: forward function
-    Source: 'src/loops.rs', lines 139:0-139:45 *)
+    Source: 'src/loops.rs', lines 149:0-149:45 *)
 let id_shared (t : Type0) (ls : list_t t) : result (list_t t) =
   Return ls
 
 (** [loops::list_nth_mut_loop_with_id]: loop 0: forward function
-    Source: 'src/loops.rs', lines 144:0-155:1 *)
+    Source: 'src/loops.rs', lines 154:0-165:1 *)
 let rec list_nth_mut_loop_with_id_loop
   (t : Type0) (i : u32) (ls : list_t t) :
   Tot (result t) (decreases (list_nth_mut_loop_with_id_loop_decreases t i ls))
@@ -256,13 +275,13 @@ let rec list_nth_mut_loop_with_id_loop
   end
 
 (** [loops::list_nth_mut_loop_with_id]: forward function
-    Source: 'src/loops.rs', lines 144:0-144:75 *)
+    Source: 'src/loops.rs', lines 154:0-154:75 *)
 let list_nth_mut_loop_with_id
   (t : Type0) (ls : list_t t) (i : u32) : result t =
   let* ls1 = id_mut t ls in list_nth_mut_loop_with_id_loop t i ls1
 
 (** [loops::list_nth_mut_loop_with_id]: loop 0: backward function 0
-    Source: 'src/loops.rs', lines 144:0-155:1 *)
+    Source: 'src/loops.rs', lines 154:0-165:1 *)
 let rec list_nth_mut_loop_with_id_loop_back
   (t : Type0) (i : u32) (ls : list_t t) (ret : t) :
   Tot (result (list_t t))
@@ -280,7 +299,7 @@ let rec list_nth_mut_loop_with_id_loop_back
   end
 
 (** [loops::list_nth_mut_loop_with_id]: backward function 0
-    Source: 'src/loops.rs', lines 144:0-144:75 *)
+    Source: 'src/loops.rs', lines 154:0-154:75 *)
 let list_nth_mut_loop_with_id_back
   (t : Type0) (ls : list_t t) (i : u32) (ret : t) : result (list_t t) =
   let* ls1 = id_mut t ls in
@@ -288,7 +307,7 @@ let list_nth_mut_loop_with_id_back
   id_mut_back t ls l
 
 (** [loops::list_nth_shared_loop_with_id]: loop 0: forward function
-    Source: 'src/loops.rs', lines 158:0-169:1 *)
+    Source: 'src/loops.rs', lines 168:0-179:1 *)
 let rec list_nth_shared_loop_with_id_loop
   (t : Type0) (i : u32) (ls : list_t t) :
   Tot (result t)
@@ -303,13 +322,13 @@ let rec list_nth_shared_loop_with_id_loop
   end
 
 (** [loops::list_nth_shared_loop_with_id]: forward function
-    Source: 'src/loops.rs', lines 158:0-158:70 *)
+    Source: 'src/loops.rs', lines 168:0-168:70 *)
 let list_nth_shared_loop_with_id
   (t : Type0) (ls : list_t t) (i : u32) : result t =
   let* ls1 = id_shared t ls in list_nth_shared_loop_with_id_loop t i ls1
 
 (** [loops::list_nth_mut_loop_pair]: loop 0: forward function
-    Source: 'src/loops.rs', lines 174:0-195:1 *)
+    Source: 'src/loops.rs', lines 184:0-205:1 *)
 let rec list_nth_mut_loop_pair_loop
   (t : Type0) (ls0 : list_t t) (ls1 : list_t t) (i : u32) :
   Tot (result (t & t))
@@ -328,13 +347,13 @@ let rec list_nth_mut_loop_pair_loop
   end
 
 (** [loops::list_nth_mut_loop_pair]: forward function
-    Source: 'src/loops.rs', lines 174:0-178:27 *)
+    Source: 'src/loops.rs', lines 184:0-188:27 *)
 let list_nth_mut_loop_pair
   (t : Type0) (ls0 : list_t t) (ls1 : list_t t) (i : u32) : result (t & t) =
   list_nth_mut_loop_pair_loop t ls0 ls1 i
 
 (** [loops::list_nth_mut_loop_pair]: loop 0: backward function 0
-    Source: 'src/loops.rs', lines 174:0-195:1 *)
+    Source: 'src/loops.rs', lines 184:0-205:1 *)
 let rec list_nth_mut_loop_pair_loop_back'a
   (t : Type0) (ls0 : list_t t) (ls1 : list_t t) (i : u32) (ret : t) :
   Tot (result (list_t t))
@@ -356,7 +375,7 @@ let rec list_nth_mut_loop_pair_loop_back'a
   end
 
 (** [loops::list_nth_mut_loop_pair]: backward function 0
-    Source: 'src/loops.rs', lines 174:0-178:27 *)
+    Source: 'src/loops.rs', lines 184:0-188:27 *)
 let list_nth_mut_loop_pair_back'a
   (t : Type0) (ls0 : list_t t) (ls1 : list_t t) (i : u32) (ret : t) :
   result (list_t t)
@@ -364,7 +383,7 @@ let list_nth_mut_loop_pair_back'a
   list_nth_mut_loop_pair_loop_back'a t ls0 ls1 i ret
 
 (** [loops::list_nth_mut_loop_pair]: loop 0: backward function 1
-    Source: 'src/loops.rs', lines 174:0-195:1 *)
+    Source: 'src/loops.rs', lines 184:0-205:1 *)
 let rec list_nth_mut_loop_pair_loop_back'b
   (t : Type0) (ls0 : list_t t) (ls1 : list_t t) (i : u32) (ret : t) :
   Tot (result (list_t t))
@@ -386,7 +405,7 @@ let rec list_nth_mut_loop_pair_loop_back'b
   end
 
 (** [loops::list_nth_mut_loop_pair]: backward function 1
-    Source: 'src/loops.rs', lines 174:0-178:27 *)
+    Source: 'src/loops.rs', lines 184:0-188:27 *)
 let list_nth_mut_loop_pair_back'b
   (t : Type0) (ls0 : list_t t) (ls1 : list_t t) (i : u32) (ret : t) :
   result (list_t t)
@@ -394,7 +413,7 @@ let list_nth_mut_loop_pair_back'b
   list_nth_mut_loop_pair_loop_back'b t ls0 ls1 i ret
 
 (** [loops::list_nth_shared_loop_pair]: loop 0: forward function
-    Source: 'src/loops.rs', lines 198:0-219:1 *)
+    Source: 'src/loops.rs', lines 208:0-229:1 *)
 let rec list_nth_shared_loop_pair_loop
   (t : Type0) (ls0 : list_t t) (ls1 : list_t t) (i : u32) :
   Tot (result (t & t))
@@ -413,13 +432,13 @@ let rec list_nth_shared_loop_pair_loop
   end
 
 (** [loops::list_nth_shared_loop_pair]: forward function
-    Source: 'src/loops.rs', lines 198:0-202:19 *)
+    Source: 'src/loops.rs', lines 208:0-212:19 *)
 let list_nth_shared_loop_pair
   (t : Type0) (ls0 : list_t t) (ls1 : list_t t) (i : u32) : result (t & t) =
   list_nth_shared_loop_pair_loop t ls0 ls1 i
 
 (** [loops::list_nth_mut_loop_pair_merge]: loop 0: forward function
-    Source: 'src/loops.rs', lines 223:0-238:1 *)
+    Source: 'src/loops.rs', lines 233:0-248:1 *)
 let rec list_nth_mut_loop_pair_merge_loop
   (t : Type0) (ls0 : list_t t) (ls1 : list_t t) (i : u32) :
   Tot (result (t & t))
@@ -439,13 +458,13 @@ let rec list_nth_mut_loop_pair_merge_loop
   end
 
 (** [loops::list_nth_mut_loop_pair_merge]: forward function
-    Source: 'src/loops.rs', lines 223:0-227:27 *)
+    Source: 'src/loops.rs', lines 233:0-237:27 *)
 let list_nth_mut_loop_pair_merge
   (t : Type0) (ls0 : list_t t) (ls1 : list_t t) (i : u32) : result (t & t) =
   list_nth_mut_loop_pair_merge_loop t ls0 ls1 i
 
 (** [loops::list_nth_mut_loop_pair_merge]: loop 0: backward function 0
-    Source: 'src/loops.rs', lines 223:0-238:1 *)
+    Source: 'src/loops.rs', lines 233:0-248:1 *)
 let rec list_nth_mut_loop_pair_merge_loop_back
   (t : Type0) (ls0 : list_t t) (ls1 : list_t t) (i : u32) (ret : (t & t)) :
   Tot (result ((list_t t) & (list_t t)))
@@ -468,7 +487,7 @@ let rec list_nth_mut_loop_pair_merge_loop_back
   end
 
 (** [loops::list_nth_mut_loop_pair_merge]: backward function 0
-    Source: 'src/loops.rs', lines 223:0-227:27 *)
+    Source: 'src/loops.rs', lines 233:0-237:27 *)
 let list_nth_mut_loop_pair_merge_back
   (t : Type0) (ls0 : list_t t) (ls1 : list_t t) (i : u32) (ret : (t & t)) :
   result ((list_t t) & (list_t t))
@@ -476,7 +495,7 @@ let list_nth_mut_loop_pair_merge_back
   list_nth_mut_loop_pair_merge_loop_back t ls0 ls1 i ret
 
 (** [loops::list_nth_shared_loop_pair_merge]: loop 0: forward function
-    Source: 'src/loops.rs', lines 241:0-256:1 *)
+    Source: 'src/loops.rs', lines 251:0-266:1 *)
 let rec list_nth_shared_loop_pair_merge_loop
   (t : Type0) (ls0 : list_t t) (ls1 : list_t t) (i : u32) :
   Tot (result (t & t))
@@ -497,13 +516,13 @@ let rec list_nth_shared_loop_pair_merge_loop
   end
 
 (** [loops::list_nth_shared_loop_pair_merge]: forward function
-    Source: 'src/loops.rs', lines 241:0-245:19 *)
+    Source: 'src/loops.rs', lines 251:0-255:19 *)
 let list_nth_shared_loop_pair_merge
   (t : Type0) (ls0 : list_t t) (ls1 : list_t t) (i : u32) : result (t & t) =
   list_nth_shared_loop_pair_merge_loop t ls0 ls1 i
 
 (** [loops::list_nth_mut_shared_loop_pair]: loop 0: forward function
-    Source: 'src/loops.rs', lines 259:0-274:1 *)
+    Source: 'src/loops.rs', lines 269:0-284:1 *)
 let rec list_nth_mut_shared_loop_pair_loop
   (t : Type0) (ls0 : list_t t) (ls1 : list_t t) (i : u32) :
   Tot (result (t & t))
@@ -524,13 +543,13 @@ let rec list_nth_mut_shared_loop_pair_loop
   end
 
 (** [loops::list_nth_mut_shared_loop_pair]: forward function
-    Source: 'src/loops.rs', lines 259:0-263:23 *)
+    Source: 'src/loops.rs', lines 269:0-273:23 *)
 let list_nth_mut_shared_loop_pair
   (t : Type0) (ls0 : list_t t) (ls1 : list_t t) (i : u32) : result (t & t) =
   list_nth_mut_shared_loop_pair_loop t ls0 ls1 i
 
 (** [loops::list_nth_mut_shared_loop_pair]: loop 0: backward function 0
-    Source: 'src/loops.rs', lines 259:0-274:1 *)
+    Source: 'src/loops.rs', lines 269:0-284:1 *)
 let rec list_nth_mut_shared_loop_pair_loop_back
   (t : Type0) (ls0 : list_t t) (ls1 : list_t t) (i : u32) (ret : t) :
   Tot (result (list_t t))
@@ -552,7 +571,7 @@ let rec list_nth_mut_shared_loop_pair_loop_back
   end
 
 (** [loops::list_nth_mut_shared_loop_pair]: backward function 0
-    Source: 'src/loops.rs', lines 259:0-263:23 *)
+    Source: 'src/loops.rs', lines 269:0-273:23 *)
 let list_nth_mut_shared_loop_pair_back
   (t : Type0) (ls0 : list_t t) (ls1 : list_t t) (i : u32) (ret : t) :
   result (list_t t)
@@ -560,7 +579,7 @@ let list_nth_mut_shared_loop_pair_back
   list_nth_mut_shared_loop_pair_loop_back t ls0 ls1 i ret
 
 (** [loops::list_nth_mut_shared_loop_pair_merge]: loop 0: forward function
-    Source: 'src/loops.rs', lines 278:0-293:1 *)
+    Source: 'src/loops.rs', lines 288:0-303:1 *)
 let rec list_nth_mut_shared_loop_pair_merge_loop
   (t : Type0) (ls0 : list_t t) (ls1 : list_t t) (i : u32) :
   Tot (result (t & t))
@@ -581,13 +600,13 @@ let rec list_nth_mut_shared_loop_pair_merge_loop
   end
 
 (** [loops::list_nth_mut_shared_loop_pair_merge]: forward function
-    Source: 'src/loops.rs', lines 278:0-282:23 *)
+    Source: 'src/loops.rs', lines 288:0-292:23 *)
 let list_nth_mut_shared_loop_pair_merge
   (t : Type0) (ls0 : list_t t) (ls1 : list_t t) (i : u32) : result (t & t) =
   list_nth_mut_shared_loop_pair_merge_loop t ls0 ls1 i
 
 (** [loops::list_nth_mut_shared_loop_pair_merge]: loop 0: backward function 0
-    Source: 'src/loops.rs', lines 278:0-293:1 *)
+    Source: 'src/loops.rs', lines 288:0-303:1 *)
 let rec list_nth_mut_shared_loop_pair_merge_loop_back
   (t : Type0) (ls0 : list_t t) (ls1 : list_t t) (i : u32) (ret : t) :
   Tot (result (list_t t))
@@ -610,7 +629,7 @@ let rec list_nth_mut_shared_loop_pair_merge_loop_back
   end
 
 (** [loops::list_nth_mut_shared_loop_pair_merge]: backward function 0
-    Source: 'src/loops.rs', lines 278:0-282:23 *)
+    Source: 'src/loops.rs', lines 288:0-292:23 *)
 let list_nth_mut_shared_loop_pair_merge_back
   (t : Type0) (ls0 : list_t t) (ls1 : list_t t) (i : u32) (ret : t) :
   result (list_t t)
@@ -618,7 +637,7 @@ let list_nth_mut_shared_loop_pair_merge_back
   list_nth_mut_shared_loop_pair_merge_loop_back t ls0 ls1 i ret
 
 (** [loops::list_nth_shared_mut_loop_pair]: loop 0: forward function
-    Source: 'src/loops.rs', lines 297:0-312:1 *)
+    Source: 'src/loops.rs', lines 307:0-322:1 *)
 let rec list_nth_shared_mut_loop_pair_loop
   (t : Type0) (ls0 : list_t t) (ls1 : list_t t) (i : u32) :
   Tot (result (t & t))
@@ -639,13 +658,13 @@ let rec list_nth_shared_mut_loop_pair_loop
   end
 
 (** [loops::list_nth_shared_mut_loop_pair]: forward function
-    Source: 'src/loops.rs', lines 297:0-301:23 *)
+    Source: 'src/loops.rs', lines 307:0-311:23 *)
 let list_nth_shared_mut_loop_pair
   (t : Type0) (ls0 : list_t t) (ls1 : list_t t) (i : u32) : result (t & t) =
   list_nth_shared_mut_loop_pair_loop t ls0 ls1 i
 
 (** [loops::list_nth_shared_mut_loop_pair]: loop 0: backward function 1
-    Source: 'src/loops.rs', lines 297:0-312:1 *)
+    Source: 'src/loops.rs', lines 307:0-322:1 *)
 let rec list_nth_shared_mut_loop_pair_loop_back
   (t : Type0) (ls0 : list_t t) (ls1 : list_t t) (i : u32) (ret : t) :
   Tot (result (list_t t))
@@ -667,7 +686,7 @@ let rec list_nth_shared_mut_loop_pair_loop_back
   end
 
 (** [loops::list_nth_shared_mut_loop_pair]: backward function 1
-    Source: 'src/loops.rs', lines 297:0-301:23 *)
+    Source: 'src/loops.rs', lines 307:0-311:23 *)
 let list_nth_shared_mut_loop_pair_back
   (t : Type0) (ls0 : list_t t) (ls1 : list_t t) (i : u32) (ret : t) :
   result (list_t t)
@@ -675,7 +694,7 @@ let list_nth_shared_mut_loop_pair_back
   list_nth_shared_mut_loop_pair_loop_back t ls0 ls1 i ret
 
 (** [loops::list_nth_shared_mut_loop_pair_merge]: loop 0: forward function
-    Source: 'src/loops.rs', lines 316:0-331:1 *)
+    Source: 'src/loops.rs', lines 326:0-341:1 *)
 let rec list_nth_shared_mut_loop_pair_merge_loop
   (t : Type0) (ls0 : list_t t) (ls1 : list_t t) (i : u32) :
   Tot (result (t & t))
@@ -696,13 +715,13 @@ let rec list_nth_shared_mut_loop_pair_merge_loop
   end
 
 (** [loops::list_nth_shared_mut_loop_pair_merge]: forward function
-    Source: 'src/loops.rs', lines 316:0-320:23 *)
+    Source: 'src/loops.rs', lines 326:0-330:23 *)
 let list_nth_shared_mut_loop_pair_merge
   (t : Type0) (ls0 : list_t t) (ls1 : list_t t) (i : u32) : result (t & t) =
   list_nth_shared_mut_loop_pair_merge_loop t ls0 ls1 i
 
 (** [loops::list_nth_shared_mut_loop_pair_merge]: loop 0: backward function 0
-    Source: 'src/loops.rs', lines 316:0-331:1 *)
+    Source: 'src/loops.rs', lines 326:0-341:1 *)
 let rec list_nth_shared_mut_loop_pair_merge_loop_back
   (t : Type0) (ls0 : list_t t) (ls1 : list_t t) (i : u32) (ret : t) :
   Tot (result (list_t t))
@@ -725,7 +744,7 @@ let rec list_nth_shared_mut_loop_pair_merge_loop_back
   end
 
 (** [loops::list_nth_shared_mut_loop_pair_merge]: backward function 0
-    Source: 'src/loops.rs', lines 316:0-320:23 *)
+    Source: 'src/loops.rs', lines 326:0-330:23 *)
 let list_nth_shared_mut_loop_pair_merge_back
   (t : Type0) (ls0 : list_t t) (ls1 : list_t t) (i : u32) (ret : t) :
   result (list_t t)

--- a/tests/fstar-split/misc/Loops.Types.fst
+++ b/tests/fstar-split/misc/Loops.Types.fst
@@ -6,7 +6,7 @@ open Primitives
 #set-options "--z3rlimit 50 --fuel 1 --ifuel 1"
 
 (** [loops::List]
-    Source: 'src/loops.rs', lines 60:0-60:16 *)
+    Source: 'src/loops.rs', lines 70:0-70:16 *)
 type list_t (t : Type0) =
 | List_Cons : t -> list_t t -> list_t t
 | List_Nil : list_t t

--- a/tests/fstar-split/traits/Traits.fst
+++ b/tests/fstar-split/traits/Traits.fst
@@ -326,22 +326,14 @@ noeq type childTrait_t (self : Type0) = {
   parentTrait1SelfInst : parentTrait1_t self;
 }
 
-(** [traits::test_parent_trait0]: forward function
-    Source: 'src/traits.rs', lines 208:0-208:57 *)
-let test_parent_trait0
-  (t : Type0) (parentTrait0TInst : parentTrait0_t t) (x : t) :
-  result parentTrait0TInst.tW
-  =
-  parentTrait0TInst.get_w x
-
 (** [traits::test_child_trait1]: forward function
-    Source: 'src/traits.rs', lines 213:0-213:56 *)
+    Source: 'src/traits.rs', lines 209:0-209:56 *)
 let test_child_trait1
   (t : Type0) (childTraitTInst : childTrait_t t) (x : t) : result string =
   childTraitTInst.parentTrait0SelfInst.get_name x
 
 (** [traits::test_child_trait2]: forward function
-    Source: 'src/traits.rs', lines 217:0-217:54 *)
+    Source: 'src/traits.rs', lines 213:0-213:54 *)
 let test_child_trait2
   (t : Type0) (childTraitTInst : childTrait_t t) (x : t) :
   result childTraitTInst.parentTrait0SelfInst.tW
@@ -349,7 +341,7 @@ let test_child_trait2
   childTraitTInst.parentTrait0SelfInst.get_w x
 
 (** [traits::order1]: forward function
-    Source: 'src/traits.rs', lines 223:0-223:59 *)
+    Source: 'src/traits.rs', lines 219:0-219:59 *)
 let order1
   (t u : Type0) (parentTrait0TInst : parentTrait0_t t) (parentTrait0UInst :
   parentTrait0_t u) :
@@ -358,27 +350,27 @@ let order1
   Return ()
 
 (** Trait declaration: [traits::ChildTrait1]
-    Source: 'src/traits.rs', lines 226:0-226:35 *)
+    Source: 'src/traits.rs', lines 222:0-222:35 *)
 noeq type childTrait1_t (self : Type0) = {
   parentTrait1SelfInst : parentTrait1_t self;
 }
 
 (** Trait implementation: [traits::{usize#9}]
-    Source: 'src/traits.rs', lines 228:0-228:27 *)
+    Source: 'src/traits.rs', lines 224:0-224:27 *)
 let traits_ParentTrait1UsizeInst : parentTrait1_t usize = ()
 
 (** Trait implementation: [traits::{usize#10}]
-    Source: 'src/traits.rs', lines 229:0-229:26 *)
+    Source: 'src/traits.rs', lines 225:0-225:26 *)
 let traits_ChildTrait1UsizeInst : childTrait1_t usize = {
   parentTrait1SelfInst = traits_ParentTrait1UsizeInst;
 }
 
 (** Trait declaration: [traits::Iterator]
-    Source: 'src/traits.rs', lines 233:0-233:18 *)
+    Source: 'src/traits.rs', lines 229:0-229:18 *)
 noeq type iterator_t (self : Type0) = { tItem : Type0; }
 
 (** Trait declaration: [traits::IntoIterator]
-    Source: 'src/traits.rs', lines 237:0-237:22 *)
+    Source: 'src/traits.rs', lines 233:0-233:22 *)
 noeq type intoIterator_t (self : Type0) = {
   tItem : Type0;
   tIntoIter : Type0;
@@ -387,29 +379,29 @@ noeq type intoIterator_t (self : Type0) = {
 }
 
 (** Trait declaration: [traits::FromResidual]
-    Source: 'src/traits.rs', lines 254:0-254:21 *)
+    Source: 'src/traits.rs', lines 250:0-250:21 *)
 type fromResidual_t (self t : Type0) = unit
 
 (** Trait declaration: [traits::Try]
-    Source: 'src/traits.rs', lines 250:0-250:48 *)
+    Source: 'src/traits.rs', lines 246:0-246:48 *)
 noeq type try_t (self : Type0) = {
   tResidual : Type0;
   fromResidualSelftraitsTrySelfResidualInst : fromResidual_t self tResidual;
 }
 
 (** Trait declaration: [traits::WithTarget]
-    Source: 'src/traits.rs', lines 256:0-256:20 *)
+    Source: 'src/traits.rs', lines 252:0-252:20 *)
 noeq type withTarget_t (self : Type0) = { tTarget : Type0; }
 
 (** Trait declaration: [traits::ParentTrait2]
-    Source: 'src/traits.rs', lines 260:0-260:22 *)
+    Source: 'src/traits.rs', lines 256:0-256:22 *)
 noeq type parentTrait2_t (self : Type0) = {
   tU : Type0;
   tU_clause_0 : withTarget_t tU;
 }
 
 (** Trait declaration: [traits::ChildTrait2]
-    Source: 'src/traits.rs', lines 264:0-264:35 *)
+    Source: 'src/traits.rs', lines 260:0-260:35 *)
 noeq type childTrait2_t (self : Type0) = {
   parentTrait2SelfInst : parentTrait2_t self;
   convert : parentTrait2SelfInst.tU -> result
@@ -417,37 +409,37 @@ noeq type childTrait2_t (self : Type0) = {
 }
 
 (** Trait implementation: [traits::{u32#11}]
-    Source: 'src/traits.rs', lines 268:0-268:23 *)
+    Source: 'src/traits.rs', lines 264:0-264:23 *)
 let traits_WithTargetU32Inst : withTarget_t u32 = { tTarget = u32; }
 
 (** Trait implementation: [traits::{u32#12}]
-    Source: 'src/traits.rs', lines 272:0-272:25 *)
+    Source: 'src/traits.rs', lines 268:0-268:25 *)
 let traits_ParentTrait2U32Inst : parentTrait2_t u32 = {
   tU = u32;
   tU_clause_0 = traits_WithTargetU32Inst;
 }
 
 (** [traits::{u32#13}::convert]: forward function
-    Source: 'src/traits.rs', lines 277:4-277:29 *)
+    Source: 'src/traits.rs', lines 273:4-273:29 *)
 let u32_convert (x : u32) : result u32 =
   Return x
 
 (** Trait implementation: [traits::{u32#13}]
-    Source: 'src/traits.rs', lines 276:0-276:24 *)
+    Source: 'src/traits.rs', lines 272:0-272:24 *)
 let traits_ChildTrait2U32Inst : childTrait2_t u32 = {
   parentTrait2SelfInst = traits_ParentTrait2U32Inst;
   convert = u32_convert;
 }
 
 (** Trait declaration: [traits::CFnOnce]
-    Source: 'src/traits.rs', lines 290:0-290:23 *)
+    Source: 'src/traits.rs', lines 286:0-286:23 *)
 noeq type cFnOnce_t (self args : Type0) = {
   tOutput : Type0;
   call_once : self -> args -> result tOutput;
 }
 
 (** Trait declaration: [traits::CFnMut]
-    Source: 'src/traits.rs', lines 296:0-296:37 *)
+    Source: 'src/traits.rs', lines 292:0-292:37 *)
 noeq type cFnMut_t (self args : Type0) = {
   cFnOnceSelfArgsInst : cFnOnce_t self args;
   call_mut : self -> args -> result cFnOnceSelfArgsInst.tOutput;
@@ -455,19 +447,19 @@ noeq type cFnMut_t (self args : Type0) = {
 }
 
 (** Trait declaration: [traits::CFn]
-    Source: 'src/traits.rs', lines 300:0-300:33 *)
+    Source: 'src/traits.rs', lines 296:0-296:33 *)
 noeq type cFn_t (self args : Type0) = {
   cFnMutSelfArgsInst : cFnMut_t self args;
   call : self -> args -> result cFnMutSelfArgsInst.cFnOnceSelfArgsInst.tOutput;
 }
 
 (** Trait declaration: [traits::GetTrait]
-    Source: 'src/traits.rs', lines 304:0-304:18 *)
+    Source: 'src/traits.rs', lines 300:0-300:18 *)
 noeq type getTrait_t (self : Type0) = { tW : Type0; get_w : self -> result tW;
 }
 
 (** [traits::test_get_trait]: forward function
-    Source: 'src/traits.rs', lines 309:0-309:49 *)
+    Source: 'src/traits.rs', lines 305:0-305:49 *)
 let test_get_trait
   (t : Type0) (getTraitTInst : getTrait_t t) (x : t) :
   result getTraitTInst.tW

--- a/tests/fstar/misc/Loops.Clauses.Template.fst
+++ b/tests/fstar/misc/Loops.Clauses.Template.fst
@@ -24,106 +24,113 @@ let sum_with_shared_borrows_loop_decreases (max : u32) (i : u32) (s : u32) :
   nat =
   admit ()
 
+(** [loops::sum_array]: decreases clause
+    Source: 'src/loops.rs', lines 50:0-58:1 *)
+unfold
+let sum_array_loop_decreases (n : usize) (a : array u32 n) (i : usize)
+  (s : u32) : nat =
+  admit ()
+
 (** [loops::clear]: decreases clause
-    Source: 'src/loops.rs', lines 52:0-58:1 *)
+    Source: 'src/loops.rs', lines 62:0-68:1 *)
 unfold
 let clear_loop_decreases (v : alloc_vec_Vec u32) (i : usize) : nat = admit ()
 
 (** [loops::list_mem]: decreases clause
-    Source: 'src/loops.rs', lines 66:0-75:1 *)
+    Source: 'src/loops.rs', lines 76:0-85:1 *)
 unfold let list_mem_loop_decreases (x : u32) (ls : list_t u32) : nat = admit ()
 
 (** [loops::list_nth_mut_loop]: decreases clause
-    Source: 'src/loops.rs', lines 78:0-88:1 *)
+    Source: 'src/loops.rs', lines 88:0-98:1 *)
 unfold
 let list_nth_mut_loop_loop_decreases (t : Type0) (ls : list_t t) (i : u32) :
   nat =
   admit ()
 
 (** [loops::list_nth_shared_loop]: decreases clause
-    Source: 'src/loops.rs', lines 91:0-101:1 *)
+    Source: 'src/loops.rs', lines 101:0-111:1 *)
 unfold
 let list_nth_shared_loop_loop_decreases (t : Type0) (ls : list_t t) (i : u32) :
   nat =
   admit ()
 
 (** [loops::get_elem_mut]: decreases clause
-    Source: 'src/loops.rs', lines 103:0-117:1 *)
+    Source: 'src/loops.rs', lines 113:0-127:1 *)
 unfold
 let get_elem_mut_loop_decreases (x : usize) (ls : list_t usize) : nat =
   admit ()
 
 (** [loops::get_elem_shared]: decreases clause
-    Source: 'src/loops.rs', lines 119:0-133:1 *)
+    Source: 'src/loops.rs', lines 129:0-143:1 *)
 unfold
 let get_elem_shared_loop_decreases (x : usize) (ls : list_t usize) : nat =
   admit ()
 
 (** [loops::list_nth_mut_loop_with_id]: decreases clause
-    Source: 'src/loops.rs', lines 144:0-155:1 *)
+    Source: 'src/loops.rs', lines 154:0-165:1 *)
 unfold
 let list_nth_mut_loop_with_id_loop_decreases (t : Type0) (i : u32)
   (ls : list_t t) : nat =
   admit ()
 
 (** [loops::list_nth_shared_loop_with_id]: decreases clause
-    Source: 'src/loops.rs', lines 158:0-169:1 *)
+    Source: 'src/loops.rs', lines 168:0-179:1 *)
 unfold
 let list_nth_shared_loop_with_id_loop_decreases (t : Type0) (i : u32)
   (ls : list_t t) : nat =
   admit ()
 
 (** [loops::list_nth_mut_loop_pair]: decreases clause
-    Source: 'src/loops.rs', lines 174:0-195:1 *)
+    Source: 'src/loops.rs', lines 184:0-205:1 *)
 unfold
 let list_nth_mut_loop_pair_loop_decreases (t : Type0) (ls0 : list_t t)
   (ls1 : list_t t) (i : u32) : nat =
   admit ()
 
 (** [loops::list_nth_shared_loop_pair]: decreases clause
-    Source: 'src/loops.rs', lines 198:0-219:1 *)
+    Source: 'src/loops.rs', lines 208:0-229:1 *)
 unfold
 let list_nth_shared_loop_pair_loop_decreases (t : Type0) (ls0 : list_t t)
   (ls1 : list_t t) (i : u32) : nat =
   admit ()
 
 (** [loops::list_nth_mut_loop_pair_merge]: decreases clause
-    Source: 'src/loops.rs', lines 223:0-238:1 *)
+    Source: 'src/loops.rs', lines 233:0-248:1 *)
 unfold
 let list_nth_mut_loop_pair_merge_loop_decreases (t : Type0) (ls0 : list_t t)
   (ls1 : list_t t) (i : u32) : nat =
   admit ()
 
 (** [loops::list_nth_shared_loop_pair_merge]: decreases clause
-    Source: 'src/loops.rs', lines 241:0-256:1 *)
+    Source: 'src/loops.rs', lines 251:0-266:1 *)
 unfold
 let list_nth_shared_loop_pair_merge_loop_decreases (t : Type0) (ls0 : list_t t)
   (ls1 : list_t t) (i : u32) : nat =
   admit ()
 
 (** [loops::list_nth_mut_shared_loop_pair]: decreases clause
-    Source: 'src/loops.rs', lines 259:0-274:1 *)
+    Source: 'src/loops.rs', lines 269:0-284:1 *)
 unfold
 let list_nth_mut_shared_loop_pair_loop_decreases (t : Type0) (ls0 : list_t t)
   (ls1 : list_t t) (i : u32) : nat =
   admit ()
 
 (** [loops::list_nth_mut_shared_loop_pair_merge]: decreases clause
-    Source: 'src/loops.rs', lines 278:0-293:1 *)
+    Source: 'src/loops.rs', lines 288:0-303:1 *)
 unfold
 let list_nth_mut_shared_loop_pair_merge_loop_decreases (t : Type0)
   (ls0 : list_t t) (ls1 : list_t t) (i : u32) : nat =
   admit ()
 
 (** [loops::list_nth_shared_mut_loop_pair]: decreases clause
-    Source: 'src/loops.rs', lines 297:0-312:1 *)
+    Source: 'src/loops.rs', lines 307:0-322:1 *)
 unfold
 let list_nth_shared_mut_loop_pair_loop_decreases (t : Type0) (ls0 : list_t t)
   (ls1 : list_t t) (i : u32) : nat =
   admit ()
 
 (** [loops::list_nth_shared_mut_loop_pair_merge]: decreases clause
-    Source: 'src/loops.rs', lines 316:0-331:1 *)
+    Source: 'src/loops.rs', lines 326:0-341:1 *)
 unfold
 let list_nth_shared_mut_loop_pair_merge_loop_decreases (t : Type0)
   (ls0 : list_t t) (ls1 : list_t t) (i : u32) : nat =

--- a/tests/fstar/misc/Loops.Clauses.fst
+++ b/tests/fstar/misc/Loops.Clauses.fst
@@ -19,6 +19,11 @@ unfold
 let sum_with_shared_borrows_loop_decreases (max : u32) (i : u32) (s : u32) : nat =
   if max >= i then max - i else 0
 
+(** [loops::sum_array]: decreases clause *)
+unfold
+let sum_array_loop_decreases (n : usize) (_ : array u32 n) (i : usize) (_ : u32) : nat =
+  if n >= i then n - i else 0
+
 (** [loops::clear]: decreases clause *)
 unfold let clear_loop_decreases (v : alloc_vec_Vec u32) (i : usize) : nat =
   if i <= List.Tot.length v then List.Tot.length v - i else 0

--- a/tests/fstar/misc/Loops.Funs.fst
+++ b/tests/fstar/misc/Loops.Funs.fst
@@ -58,8 +58,27 @@ let rec sum_with_shared_borrows_loop
 let sum_with_shared_borrows (max : u32) : result u32 =
   sum_with_shared_borrows_loop max 0 0
 
+(** [loops::sum_array]: loop 0:
+    Source: 'src/loops.rs', lines 50:0-58:1 *)
+let rec sum_array_loop
+  (n : usize) (a : array u32 n) (i : usize) (s : u32) :
+  Tot (result u32) (decreases (sum_array_loop_decreases n a i s))
+  =
+  if i < n
+  then
+    let* i1 = array_index_usize u32 n a i in
+    let* s1 = u32_add s i1 in
+    let* i2 = usize_add i 1 in
+    sum_array_loop n a i2 s1
+  else Return s
+
+(** [loops::sum_array]:
+    Source: 'src/loops.rs', lines 50:0-50:52 *)
+let sum_array (n : usize) (a : array u32 n) : result u32 =
+  sum_array_loop n a 0 0
+
 (** [loops::clear]: loop 0:
-    Source: 'src/loops.rs', lines 52:0-58:1 *)
+    Source: 'src/loops.rs', lines 62:0-68:1 *)
 let rec clear_loop
   (v : alloc_vec_Vec u32) (i : usize) :
   Tot (result (alloc_vec_Vec u32)) (decreases (clear_loop_decreases v i))
@@ -76,12 +95,12 @@ let rec clear_loop
   else Return v
 
 (** [loops::clear]:
-    Source: 'src/loops.rs', lines 52:0-52:30 *)
+    Source: 'src/loops.rs', lines 62:0-62:30 *)
 let clear (v : alloc_vec_Vec u32) : result (alloc_vec_Vec u32) =
   clear_loop v 0
 
 (** [loops::list_mem]: loop 0:
-    Source: 'src/loops.rs', lines 66:0-75:1 *)
+    Source: 'src/loops.rs', lines 76:0-85:1 *)
 let rec list_mem_loop
   (x : u32) (ls : list_t u32) :
   Tot (result bool) (decreases (list_mem_loop_decreases x ls))
@@ -92,12 +111,12 @@ let rec list_mem_loop
   end
 
 (** [loops::list_mem]:
-    Source: 'src/loops.rs', lines 66:0-66:52 *)
+    Source: 'src/loops.rs', lines 76:0-76:52 *)
 let list_mem (x : u32) (ls : list_t u32) : result bool =
   list_mem_loop x ls
 
 (** [loops::list_nth_mut_loop]: loop 0:
-    Source: 'src/loops.rs', lines 78:0-88:1 *)
+    Source: 'src/loops.rs', lines 88:0-98:1 *)
 let rec list_nth_mut_loop_loop
   (t : Type0) (ls : list_t t) (i : u32) :
   Tot (result (t & (t -> result (list_t t))))
@@ -116,7 +135,7 @@ let rec list_nth_mut_loop_loop
   end
 
 (** [loops::list_nth_mut_loop]:
-    Source: 'src/loops.rs', lines 78:0-78:71 *)
+    Source: 'src/loops.rs', lines 88:0-88:71 *)
 let list_nth_mut_loop
   (t : Type0) (ls : list_t t) (i : u32) :
   result (t & (t -> result (list_t t)))
@@ -124,7 +143,7 @@ let list_nth_mut_loop
   let* (x, back) = list_nth_mut_loop_loop t ls i in Return (x, back)
 
 (** [loops::list_nth_shared_loop]: loop 0:
-    Source: 'src/loops.rs', lines 91:0-101:1 *)
+    Source: 'src/loops.rs', lines 101:0-111:1 *)
 let rec list_nth_shared_loop_loop
   (t : Type0) (ls : list_t t) (i : u32) :
   Tot (result t) (decreases (list_nth_shared_loop_loop_decreases t ls i))
@@ -138,12 +157,12 @@ let rec list_nth_shared_loop_loop
   end
 
 (** [loops::list_nth_shared_loop]:
-    Source: 'src/loops.rs', lines 91:0-91:66 *)
+    Source: 'src/loops.rs', lines 101:0-101:66 *)
 let list_nth_shared_loop (t : Type0) (ls : list_t t) (i : u32) : result t =
   list_nth_shared_loop_loop t ls i
 
 (** [loops::get_elem_mut]: loop 0:
-    Source: 'src/loops.rs', lines 103:0-117:1 *)
+    Source: 'src/loops.rs', lines 113:0-127:1 *)
 let rec get_elem_mut_loop
   (x : usize) (ls : list_t usize) :
   Tot (result (usize & (usize -> result (list_t usize))))
@@ -161,7 +180,7 @@ let rec get_elem_mut_loop
   end
 
 (** [loops::get_elem_mut]:
-    Source: 'src/loops.rs', lines 103:0-103:73 *)
+    Source: 'src/loops.rs', lines 113:0-113:73 *)
 let get_elem_mut
   (slots : alloc_vec_Vec (list_t usize)) (x : usize) :
   result (usize & (usize -> result (alloc_vec_Vec (list_t usize))))
@@ -174,7 +193,7 @@ let get_elem_mut
   Return (i, back1)
 
 (** [loops::get_elem_shared]: loop 0:
-    Source: 'src/loops.rs', lines 119:0-133:1 *)
+    Source: 'src/loops.rs', lines 129:0-143:1 *)
 let rec get_elem_shared_loop
   (x : usize) (ls : list_t usize) :
   Tot (result usize) (decreases (get_elem_shared_loop_decreases x ls))
@@ -185,7 +204,7 @@ let rec get_elem_shared_loop
   end
 
 (** [loops::get_elem_shared]:
-    Source: 'src/loops.rs', lines 119:0-119:68 *)
+    Source: 'src/loops.rs', lines 129:0-129:68 *)
 let get_elem_shared
   (slots : alloc_vec_Vec (list_t usize)) (x : usize) : result usize =
   let* l =
@@ -194,7 +213,7 @@ let get_elem_shared
   get_elem_shared_loop x l
 
 (** [loops::id_mut]:
-    Source: 'src/loops.rs', lines 135:0-135:50 *)
+    Source: 'src/loops.rs', lines 145:0-145:50 *)
 let id_mut
   (t : Type0) (ls : list_t t) :
   result ((list_t t) & (list_t t -> result (list_t t)))
@@ -202,12 +221,12 @@ let id_mut
   Return (ls, Return)
 
 (** [loops::id_shared]:
-    Source: 'src/loops.rs', lines 139:0-139:45 *)
+    Source: 'src/loops.rs', lines 149:0-149:45 *)
 let id_shared (t : Type0) (ls : list_t t) : result (list_t t) =
   Return ls
 
 (** [loops::list_nth_mut_loop_with_id]: loop 0:
-    Source: 'src/loops.rs', lines 144:0-155:1 *)
+    Source: 'src/loops.rs', lines 154:0-165:1 *)
 let rec list_nth_mut_loop_with_id_loop
   (t : Type0) (i : u32) (ls : list_t t) :
   Tot (result (t & (t -> result (list_t t))))
@@ -226,7 +245,7 @@ let rec list_nth_mut_loop_with_id_loop
   end
 
 (** [loops::list_nth_mut_loop_with_id]:
-    Source: 'src/loops.rs', lines 144:0-144:75 *)
+    Source: 'src/loops.rs', lines 154:0-154:75 *)
 let list_nth_mut_loop_with_id
   (t : Type0) (ls : list_t t) (i : u32) :
   result (t & (t -> result (list_t t)))
@@ -237,7 +256,7 @@ let list_nth_mut_loop_with_id
   Return (x, back1)
 
 (** [loops::list_nth_shared_loop_with_id]: loop 0:
-    Source: 'src/loops.rs', lines 158:0-169:1 *)
+    Source: 'src/loops.rs', lines 168:0-179:1 *)
 let rec list_nth_shared_loop_with_id_loop
   (t : Type0) (i : u32) (ls : list_t t) :
   Tot (result t)
@@ -252,13 +271,13 @@ let rec list_nth_shared_loop_with_id_loop
   end
 
 (** [loops::list_nth_shared_loop_with_id]:
-    Source: 'src/loops.rs', lines 158:0-158:70 *)
+    Source: 'src/loops.rs', lines 168:0-168:70 *)
 let list_nth_shared_loop_with_id
   (t : Type0) (ls : list_t t) (i : u32) : result t =
   let* ls1 = id_shared t ls in list_nth_shared_loop_with_id_loop t i ls1
 
 (** [loops::list_nth_mut_loop_pair]: loop 0:
-    Source: 'src/loops.rs', lines 174:0-195:1 *)
+    Source: 'src/loops.rs', lines 184:0-205:1 *)
 let rec list_nth_mut_loop_pair_loop
   (t : Type0) (ls0 : list_t t) (ls1 : list_t t) (i : u32) :
   Tot (result ((t & t) & (t -> result (list_t t)) & (t -> result (list_t t))))
@@ -288,7 +307,7 @@ let rec list_nth_mut_loop_pair_loop
   end
 
 (** [loops::list_nth_mut_loop_pair]:
-    Source: 'src/loops.rs', lines 174:0-178:27 *)
+    Source: 'src/loops.rs', lines 184:0-188:27 *)
 let list_nth_mut_loop_pair
   (t : Type0) (ls0 : list_t t) (ls1 : list_t t) (i : u32) :
   result ((t & t) & (t -> result (list_t t)) & (t -> result (list_t t)))
@@ -297,7 +316,7 @@ let list_nth_mut_loop_pair
   Return (p, back_'a, back_'b)
 
 (** [loops::list_nth_shared_loop_pair]: loop 0:
-    Source: 'src/loops.rs', lines 198:0-219:1 *)
+    Source: 'src/loops.rs', lines 208:0-229:1 *)
 let rec list_nth_shared_loop_pair_loop
   (t : Type0) (ls0 : list_t t) (ls1 : list_t t) (i : u32) :
   Tot (result (t & t))
@@ -316,13 +335,13 @@ let rec list_nth_shared_loop_pair_loop
   end
 
 (** [loops::list_nth_shared_loop_pair]:
-    Source: 'src/loops.rs', lines 198:0-202:19 *)
+    Source: 'src/loops.rs', lines 208:0-212:19 *)
 let list_nth_shared_loop_pair
   (t : Type0) (ls0 : list_t t) (ls1 : list_t t) (i : u32) : result (t & t) =
   list_nth_shared_loop_pair_loop t ls0 ls1 i
 
 (** [loops::list_nth_mut_loop_pair_merge]: loop 0:
-    Source: 'src/loops.rs', lines 223:0-238:1 *)
+    Source: 'src/loops.rs', lines 233:0-248:1 *)
 let rec list_nth_mut_loop_pair_merge_loop
   (t : Type0) (ls0 : list_t t) (ls1 : list_t t) (i : u32) :
   Tot (result ((t & t) & ((t & t) -> result ((list_t t) & (list_t t)))))
@@ -352,7 +371,7 @@ let rec list_nth_mut_loop_pair_merge_loop
   end
 
 (** [loops::list_nth_mut_loop_pair_merge]:
-    Source: 'src/loops.rs', lines 223:0-227:27 *)
+    Source: 'src/loops.rs', lines 233:0-237:27 *)
 let list_nth_mut_loop_pair_merge
   (t : Type0) (ls0 : list_t t) (ls1 : list_t t) (i : u32) :
   result ((t & t) & ((t & t) -> result ((list_t t) & (list_t t))))
@@ -361,7 +380,7 @@ let list_nth_mut_loop_pair_merge
   Return (p, back_'a)
 
 (** [loops::list_nth_shared_loop_pair_merge]: loop 0:
-    Source: 'src/loops.rs', lines 241:0-256:1 *)
+    Source: 'src/loops.rs', lines 251:0-266:1 *)
 let rec list_nth_shared_loop_pair_merge_loop
   (t : Type0) (ls0 : list_t t) (ls1 : list_t t) (i : u32) :
   Tot (result (t & t))
@@ -382,13 +401,13 @@ let rec list_nth_shared_loop_pair_merge_loop
   end
 
 (** [loops::list_nth_shared_loop_pair_merge]:
-    Source: 'src/loops.rs', lines 241:0-245:19 *)
+    Source: 'src/loops.rs', lines 251:0-255:19 *)
 let list_nth_shared_loop_pair_merge
   (t : Type0) (ls0 : list_t t) (ls1 : list_t t) (i : u32) : result (t & t) =
   list_nth_shared_loop_pair_merge_loop t ls0 ls1 i
 
 (** [loops::list_nth_mut_shared_loop_pair]: loop 0:
-    Source: 'src/loops.rs', lines 259:0-274:1 *)
+    Source: 'src/loops.rs', lines 269:0-284:1 *)
 let rec list_nth_mut_shared_loop_pair_loop
   (t : Type0) (ls0 : list_t t) (ls1 : list_t t) (i : u32) :
   Tot (result ((t & t) & (t -> result (list_t t))))
@@ -414,7 +433,7 @@ let rec list_nth_mut_shared_loop_pair_loop
   end
 
 (** [loops::list_nth_mut_shared_loop_pair]:
-    Source: 'src/loops.rs', lines 259:0-263:23 *)
+    Source: 'src/loops.rs', lines 269:0-273:23 *)
 let list_nth_mut_shared_loop_pair
   (t : Type0) (ls0 : list_t t) (ls1 : list_t t) (i : u32) :
   result ((t & t) & (t -> result (list_t t)))
@@ -423,7 +442,7 @@ let list_nth_mut_shared_loop_pair
   Return (p, back_'a)
 
 (** [loops::list_nth_mut_shared_loop_pair_merge]: loop 0:
-    Source: 'src/loops.rs', lines 278:0-293:1 *)
+    Source: 'src/loops.rs', lines 288:0-303:1 *)
 let rec list_nth_mut_shared_loop_pair_merge_loop
   (t : Type0) (ls0 : list_t t) (ls1 : list_t t) (i : u32) :
   Tot (result ((t & t) & (t -> result (list_t t))))
@@ -450,7 +469,7 @@ let rec list_nth_mut_shared_loop_pair_merge_loop
   end
 
 (** [loops::list_nth_mut_shared_loop_pair_merge]:
-    Source: 'src/loops.rs', lines 278:0-282:23 *)
+    Source: 'src/loops.rs', lines 288:0-292:23 *)
 let list_nth_mut_shared_loop_pair_merge
   (t : Type0) (ls0 : list_t t) (ls1 : list_t t) (i : u32) :
   result ((t & t) & (t -> result (list_t t)))
@@ -459,7 +478,7 @@ let list_nth_mut_shared_loop_pair_merge
   Return (p, back_'a)
 
 (** [loops::list_nth_shared_mut_loop_pair]: loop 0:
-    Source: 'src/loops.rs', lines 297:0-312:1 *)
+    Source: 'src/loops.rs', lines 307:0-322:1 *)
 let rec list_nth_shared_mut_loop_pair_loop
   (t : Type0) (ls0 : list_t t) (ls1 : list_t t) (i : u32) :
   Tot (result ((t & t) & (t -> result (list_t t))))
@@ -485,7 +504,7 @@ let rec list_nth_shared_mut_loop_pair_loop
   end
 
 (** [loops::list_nth_shared_mut_loop_pair]:
-    Source: 'src/loops.rs', lines 297:0-301:23 *)
+    Source: 'src/loops.rs', lines 307:0-311:23 *)
 let list_nth_shared_mut_loop_pair
   (t : Type0) (ls0 : list_t t) (ls1 : list_t t) (i : u32) :
   result ((t & t) & (t -> result (list_t t)))
@@ -494,7 +513,7 @@ let list_nth_shared_mut_loop_pair
   Return (p, back_'b)
 
 (** [loops::list_nth_shared_mut_loop_pair_merge]: loop 0:
-    Source: 'src/loops.rs', lines 316:0-331:1 *)
+    Source: 'src/loops.rs', lines 326:0-341:1 *)
 let rec list_nth_shared_mut_loop_pair_merge_loop
   (t : Type0) (ls0 : list_t t) (ls1 : list_t t) (i : u32) :
   Tot (result ((t & t) & (t -> result (list_t t))))
@@ -521,7 +540,7 @@ let rec list_nth_shared_mut_loop_pair_merge_loop
   end
 
 (** [loops::list_nth_shared_mut_loop_pair_merge]:
-    Source: 'src/loops.rs', lines 316:0-320:23 *)
+    Source: 'src/loops.rs', lines 326:0-330:23 *)
 let list_nth_shared_mut_loop_pair_merge
   (t : Type0) (ls0 : list_t t) (ls1 : list_t t) (i : u32) :
   result ((t & t) & (t -> result (list_t t)))

--- a/tests/fstar/misc/Loops.Types.fst
+++ b/tests/fstar/misc/Loops.Types.fst
@@ -6,7 +6,7 @@ open Primitives
 #set-options "--z3rlimit 50 --fuel 1 --ifuel 1"
 
 (** [loops::List]
-    Source: 'src/loops.rs', lines 60:0-60:16 *)
+    Source: 'src/loops.rs', lines 70:0-70:16 *)
 type list_t (t : Type0) =
 | List_Cons : t -> list_t t -> list_t t
 | List_Nil : list_t t

--- a/tests/fstar/traits/Traits.fst
+++ b/tests/fstar/traits/Traits.fst
@@ -325,22 +325,14 @@ noeq type childTrait_t (self : Type0) = {
   parentTrait1SelfInst : parentTrait1_t self;
 }
 
-(** [traits::test_parent_trait0]:
-    Source: 'src/traits.rs', lines 208:0-208:57 *)
-let test_parent_trait0
-  (t : Type0) (parentTrait0TInst : parentTrait0_t t) (x : t) :
-  result parentTrait0TInst.tW
-  =
-  parentTrait0TInst.get_w x
-
 (** [traits::test_child_trait1]:
-    Source: 'src/traits.rs', lines 213:0-213:56 *)
+    Source: 'src/traits.rs', lines 209:0-209:56 *)
 let test_child_trait1
   (t : Type0) (childTraitTInst : childTrait_t t) (x : t) : result string =
   childTraitTInst.parentTrait0SelfInst.get_name x
 
 (** [traits::test_child_trait2]:
-    Source: 'src/traits.rs', lines 217:0-217:54 *)
+    Source: 'src/traits.rs', lines 213:0-213:54 *)
 let test_child_trait2
   (t : Type0) (childTraitTInst : childTrait_t t) (x : t) :
   result childTraitTInst.parentTrait0SelfInst.tW
@@ -348,7 +340,7 @@ let test_child_trait2
   childTraitTInst.parentTrait0SelfInst.get_w x
 
 (** [traits::order1]:
-    Source: 'src/traits.rs', lines 223:0-223:59 *)
+    Source: 'src/traits.rs', lines 219:0-219:59 *)
 let order1
   (t u : Type0) (parentTrait0TInst : parentTrait0_t t) (parentTrait0UInst :
   parentTrait0_t u) :
@@ -357,27 +349,27 @@ let order1
   Return ()
 
 (** Trait declaration: [traits::ChildTrait1]
-    Source: 'src/traits.rs', lines 226:0-226:35 *)
+    Source: 'src/traits.rs', lines 222:0-222:35 *)
 noeq type childTrait1_t (self : Type0) = {
   parentTrait1SelfInst : parentTrait1_t self;
 }
 
 (** Trait implementation: [traits::{usize#9}]
-    Source: 'src/traits.rs', lines 228:0-228:27 *)
+    Source: 'src/traits.rs', lines 224:0-224:27 *)
 let traits_ParentTrait1UsizeInst : parentTrait1_t usize = ()
 
 (** Trait implementation: [traits::{usize#10}]
-    Source: 'src/traits.rs', lines 229:0-229:26 *)
+    Source: 'src/traits.rs', lines 225:0-225:26 *)
 let traits_ChildTrait1UsizeInst : childTrait1_t usize = {
   parentTrait1SelfInst = traits_ParentTrait1UsizeInst;
 }
 
 (** Trait declaration: [traits::Iterator]
-    Source: 'src/traits.rs', lines 233:0-233:18 *)
+    Source: 'src/traits.rs', lines 229:0-229:18 *)
 noeq type iterator_t (self : Type0) = { tItem : Type0; }
 
 (** Trait declaration: [traits::IntoIterator]
-    Source: 'src/traits.rs', lines 237:0-237:22 *)
+    Source: 'src/traits.rs', lines 233:0-233:22 *)
 noeq type intoIterator_t (self : Type0) = {
   tItem : Type0;
   tIntoIter : Type0;
@@ -386,29 +378,29 @@ noeq type intoIterator_t (self : Type0) = {
 }
 
 (** Trait declaration: [traits::FromResidual]
-    Source: 'src/traits.rs', lines 254:0-254:21 *)
+    Source: 'src/traits.rs', lines 250:0-250:21 *)
 type fromResidual_t (self t : Type0) = unit
 
 (** Trait declaration: [traits::Try]
-    Source: 'src/traits.rs', lines 250:0-250:48 *)
+    Source: 'src/traits.rs', lines 246:0-246:48 *)
 noeq type try_t (self : Type0) = {
   tResidual : Type0;
   fromResidualSelftraitsTrySelfResidualInst : fromResidual_t self tResidual;
 }
 
 (** Trait declaration: [traits::WithTarget]
-    Source: 'src/traits.rs', lines 256:0-256:20 *)
+    Source: 'src/traits.rs', lines 252:0-252:20 *)
 noeq type withTarget_t (self : Type0) = { tTarget : Type0; }
 
 (** Trait declaration: [traits::ParentTrait2]
-    Source: 'src/traits.rs', lines 260:0-260:22 *)
+    Source: 'src/traits.rs', lines 256:0-256:22 *)
 noeq type parentTrait2_t (self : Type0) = {
   tU : Type0;
   tU_clause_0 : withTarget_t tU;
 }
 
 (** Trait declaration: [traits::ChildTrait2]
-    Source: 'src/traits.rs', lines 264:0-264:35 *)
+    Source: 'src/traits.rs', lines 260:0-260:35 *)
 noeq type childTrait2_t (self : Type0) = {
   parentTrait2SelfInst : parentTrait2_t self;
   convert : parentTrait2SelfInst.tU -> result
@@ -416,56 +408,56 @@ noeq type childTrait2_t (self : Type0) = {
 }
 
 (** Trait implementation: [traits::{u32#11}]
-    Source: 'src/traits.rs', lines 268:0-268:23 *)
+    Source: 'src/traits.rs', lines 264:0-264:23 *)
 let traits_WithTargetU32Inst : withTarget_t u32 = { tTarget = u32; }
 
 (** Trait implementation: [traits::{u32#12}]
-    Source: 'src/traits.rs', lines 272:0-272:25 *)
+    Source: 'src/traits.rs', lines 268:0-268:25 *)
 let traits_ParentTrait2U32Inst : parentTrait2_t u32 = {
   tU = u32;
   tU_clause_0 = traits_WithTargetU32Inst;
 }
 
 (** [traits::{u32#13}::convert]:
-    Source: 'src/traits.rs', lines 277:4-277:29 *)
+    Source: 'src/traits.rs', lines 273:4-273:29 *)
 let u32_convert (x : u32) : result u32 =
   Return x
 
 (** Trait implementation: [traits::{u32#13}]
-    Source: 'src/traits.rs', lines 276:0-276:24 *)
+    Source: 'src/traits.rs', lines 272:0-272:24 *)
 let traits_ChildTrait2U32Inst : childTrait2_t u32 = {
   parentTrait2SelfInst = traits_ParentTrait2U32Inst;
   convert = u32_convert;
 }
 
 (** Trait declaration: [traits::CFnOnce]
-    Source: 'src/traits.rs', lines 290:0-290:23 *)
+    Source: 'src/traits.rs', lines 286:0-286:23 *)
 noeq type cFnOnce_t (self args : Type0) = {
   tOutput : Type0;
   call_once : self -> args -> result tOutput;
 }
 
 (** Trait declaration: [traits::CFnMut]
-    Source: 'src/traits.rs', lines 296:0-296:37 *)
+    Source: 'src/traits.rs', lines 292:0-292:37 *)
 noeq type cFnMut_t (self args : Type0) = {
   cFnOnceSelfArgsInst : cFnOnce_t self args;
   call_mut : self -> args -> result (cFnOnceSelfArgsInst.tOutput & self);
 }
 
 (** Trait declaration: [traits::CFn]
-    Source: 'src/traits.rs', lines 300:0-300:33 *)
+    Source: 'src/traits.rs', lines 296:0-296:33 *)
 noeq type cFn_t (self args : Type0) = {
   cFnMutSelfArgsInst : cFnMut_t self args;
   call : self -> args -> result cFnMutSelfArgsInst.cFnOnceSelfArgsInst.tOutput;
 }
 
 (** Trait declaration: [traits::GetTrait]
-    Source: 'src/traits.rs', lines 304:0-304:18 *)
+    Source: 'src/traits.rs', lines 300:0-300:18 *)
 noeq type getTrait_t (self : Type0) = { tW : Type0; get_w : self -> result tW;
 }
 
 (** [traits::test_get_trait]:
-    Source: 'src/traits.rs', lines 309:0-309:49 *)
+    Source: 'src/traits.rs', lines 305:0-305:49 *)
 let test_get_trait
   (t : Type0) (getTraitTInst : getTrait_t t) (x : t) :
   result getTraitTInst.tW

--- a/tests/lean/Loops.lean
+++ b/tests/lean/Loops.lean
@@ -54,8 +54,26 @@ divergent def sum_with_shared_borrows_loop
 def sum_with_shared_borrows (max : U32) : Result U32 :=
   sum_with_shared_borrows_loop max 0#u32 0#u32
 
+/- [loops::sum_array]: loop 0:
+   Source: 'src/loops.rs', lines 50:0-58:1 -/
+divergent def sum_array_loop
+  (N : Usize) (a : Array U32 N) (i : Usize) (s : U32) : Result U32 :=
+  if i < N
+  then
+    do
+    let i1 ← Array.index_usize U32 N a i
+    let s1 ← s + i1
+    let i2 ← i + 1#usize
+    sum_array_loop N a i2 s1
+  else Result.ret s
+
+/- [loops::sum_array]:
+   Source: 'src/loops.rs', lines 50:0-50:52 -/
+def sum_array (N : Usize) (a : Array U32 N) : Result U32 :=
+  sum_array_loop N a 0#usize 0#u32
+
 /- [loops::clear]: loop 0:
-   Source: 'src/loops.rs', lines 52:0-58:1 -/
+   Source: 'src/loops.rs', lines 62:0-68:1 -/
 divergent def clear_loop
   (v : alloc.vec.Vec U32) (i : Usize) : Result (alloc.vec.Vec U32) :=
   let i1 := alloc.vec.Vec.len U32 v
@@ -71,18 +89,18 @@ divergent def clear_loop
   else Result.ret v
 
 /- [loops::clear]:
-   Source: 'src/loops.rs', lines 52:0-52:30 -/
+   Source: 'src/loops.rs', lines 62:0-62:30 -/
 def clear (v : alloc.vec.Vec U32) : Result (alloc.vec.Vec U32) :=
   clear_loop v 0#usize
 
 /- [loops::List]
-   Source: 'src/loops.rs', lines 60:0-60:16 -/
+   Source: 'src/loops.rs', lines 70:0-70:16 -/
 inductive List (T : Type) :=
 | Cons : T → List T → List T
 | Nil : List T
 
 /- [loops::list_mem]: loop 0:
-   Source: 'src/loops.rs', lines 66:0-75:1 -/
+   Source: 'src/loops.rs', lines 76:0-85:1 -/
 divergent def list_mem_loop (x : U32) (ls : List U32) : Result Bool :=
   match ls with
   | List.Cons y tl => if y = x
@@ -91,12 +109,12 @@ divergent def list_mem_loop (x : U32) (ls : List U32) : Result Bool :=
   | List.Nil => Result.ret false
 
 /- [loops::list_mem]:
-   Source: 'src/loops.rs', lines 66:0-66:52 -/
+   Source: 'src/loops.rs', lines 76:0-76:52 -/
 def list_mem (x : U32) (ls : List U32) : Result Bool :=
   list_mem_loop x ls
 
 /- [loops::list_nth_mut_loop]: loop 0:
-   Source: 'src/loops.rs', lines 78:0-88:1 -/
+   Source: 'src/loops.rs', lines 88:0-98:1 -/
 divergent def list_nth_mut_loop_loop
   (T : Type) (ls : List T) (i : U32) : Result (T × (T → Result (List T))) :=
   match ls with
@@ -117,7 +135,7 @@ divergent def list_nth_mut_loop_loop
   | List.Nil => Result.fail .panic
 
 /- [loops::list_nth_mut_loop]:
-   Source: 'src/loops.rs', lines 78:0-78:71 -/
+   Source: 'src/loops.rs', lines 88:0-88:71 -/
 def list_nth_mut_loop
   (T : Type) (ls : List T) (i : U32) : Result (T × (T → Result (List T))) :=
   do
@@ -125,7 +143,7 @@ def list_nth_mut_loop
   Result.ret (t, back)
 
 /- [loops::list_nth_shared_loop]: loop 0:
-   Source: 'src/loops.rs', lines 91:0-101:1 -/
+   Source: 'src/loops.rs', lines 101:0-111:1 -/
 divergent def list_nth_shared_loop_loop
   (T : Type) (ls : List T) (i : U32) : Result T :=
   match ls with
@@ -138,12 +156,12 @@ divergent def list_nth_shared_loop_loop
   | List.Nil => Result.fail .panic
 
 /- [loops::list_nth_shared_loop]:
-   Source: 'src/loops.rs', lines 91:0-91:66 -/
+   Source: 'src/loops.rs', lines 101:0-101:66 -/
 def list_nth_shared_loop (T : Type) (ls : List T) (i : U32) : Result T :=
   list_nth_shared_loop_loop T ls i
 
 /- [loops::get_elem_mut]: loop 0:
-   Source: 'src/loops.rs', lines 103:0-117:1 -/
+   Source: 'src/loops.rs', lines 113:0-127:1 -/
 divergent def get_elem_mut_loop
   (x : Usize) (ls : List Usize) :
   Result (Usize × (Usize → Result (List Usize)))
@@ -165,7 +183,7 @@ divergent def get_elem_mut_loop
   | List.Nil => Result.fail .panic
 
 /- [loops::get_elem_mut]:
-   Source: 'src/loops.rs', lines 103:0-103:73 -/
+   Source: 'src/loops.rs', lines 113:0-113:73 -/
 def get_elem_mut
   (slots : alloc.vec.Vec (List Usize)) (x : Usize) :
   Result (Usize × (Usize → Result (alloc.vec.Vec (List Usize))))
@@ -181,7 +199,7 @@ def get_elem_mut
   Result.ret (i, back1)
 
 /- [loops::get_elem_shared]: loop 0:
-   Source: 'src/loops.rs', lines 119:0-133:1 -/
+   Source: 'src/loops.rs', lines 129:0-143:1 -/
 divergent def get_elem_shared_loop
   (x : Usize) (ls : List Usize) : Result Usize :=
   match ls with
@@ -191,7 +209,7 @@ divergent def get_elem_shared_loop
   | List.Nil => Result.fail .panic
 
 /- [loops::get_elem_shared]:
-   Source: 'src/loops.rs', lines 119:0-119:68 -/
+   Source: 'src/loops.rs', lines 129:0-129:68 -/
 def get_elem_shared
   (slots : alloc.vec.Vec (List Usize)) (x : Usize) : Result Usize :=
   do
@@ -201,7 +219,7 @@ def get_elem_shared
   get_elem_shared_loop x l
 
 /- [loops::id_mut]:
-   Source: 'src/loops.rs', lines 135:0-135:50 -/
+   Source: 'src/loops.rs', lines 145:0-145:50 -/
 def id_mut
   (T : Type) (ls : List T) :
   Result ((List T) × (List T → Result (List T)))
@@ -209,12 +227,12 @@ def id_mut
   Result.ret (ls, Result.ret)
 
 /- [loops::id_shared]:
-   Source: 'src/loops.rs', lines 139:0-139:45 -/
+   Source: 'src/loops.rs', lines 149:0-149:45 -/
 def id_shared (T : Type) (ls : List T) : Result (List T) :=
   Result.ret ls
 
 /- [loops::list_nth_mut_loop_with_id]: loop 0:
-   Source: 'src/loops.rs', lines 144:0-155:1 -/
+   Source: 'src/loops.rs', lines 154:0-165:1 -/
 divergent def list_nth_mut_loop_with_id_loop
   (T : Type) (i : U32) (ls : List T) : Result (T × (T → Result (List T))) :=
   match ls with
@@ -235,7 +253,7 @@ divergent def list_nth_mut_loop_with_id_loop
   | List.Nil => Result.fail .panic
 
 /- [loops::list_nth_mut_loop_with_id]:
-   Source: 'src/loops.rs', lines 144:0-144:75 -/
+   Source: 'src/loops.rs', lines 154:0-154:75 -/
 def list_nth_mut_loop_with_id
   (T : Type) (ls : List T) (i : U32) : Result (T × (T → Result (List T))) :=
   do
@@ -247,7 +265,7 @@ def list_nth_mut_loop_with_id
   Result.ret (t, back1)
 
 /- [loops::list_nth_shared_loop_with_id]: loop 0:
-   Source: 'src/loops.rs', lines 158:0-169:1 -/
+   Source: 'src/loops.rs', lines 168:0-179:1 -/
 divergent def list_nth_shared_loop_with_id_loop
   (T : Type) (i : U32) (ls : List T) : Result T :=
   match ls with
@@ -260,7 +278,7 @@ divergent def list_nth_shared_loop_with_id_loop
   | List.Nil => Result.fail .panic
 
 /- [loops::list_nth_shared_loop_with_id]:
-   Source: 'src/loops.rs', lines 158:0-158:70 -/
+   Source: 'src/loops.rs', lines 168:0-168:70 -/
 def list_nth_shared_loop_with_id
   (T : Type) (ls : List T) (i : U32) : Result T :=
   do
@@ -268,7 +286,7 @@ def list_nth_shared_loop_with_id
   list_nth_shared_loop_with_id_loop T i ls1
 
 /- [loops::list_nth_mut_loop_pair]: loop 0:
-   Source: 'src/loops.rs', lines 174:0-195:1 -/
+   Source: 'src/loops.rs', lines 184:0-205:1 -/
 divergent def list_nth_mut_loop_pair_loop
   (T : Type) (ls0 : List T) (ls1 : List T) (i : U32) :
   Result ((T × T) × (T → Result (List T)) × (T → Result (List T)))
@@ -299,7 +317,7 @@ divergent def list_nth_mut_loop_pair_loop
   | List.Nil => Result.fail .panic
 
 /- [loops::list_nth_mut_loop_pair]:
-   Source: 'src/loops.rs', lines 174:0-178:27 -/
+   Source: 'src/loops.rs', lines 184:0-188:27 -/
 def list_nth_mut_loop_pair
   (T : Type) (ls0 : List T) (ls1 : List T) (i : U32) :
   Result ((T × T) × (T → Result (List T)) × (T → Result (List T)))
@@ -309,7 +327,7 @@ def list_nth_mut_loop_pair
   Result.ret (p, back_'a, back_'b)
 
 /- [loops::list_nth_shared_loop_pair]: loop 0:
-   Source: 'src/loops.rs', lines 198:0-219:1 -/
+   Source: 'src/loops.rs', lines 208:0-229:1 -/
 divergent def list_nth_shared_loop_pair_loop
   (T : Type) (ls0 : List T) (ls1 : List T) (i : U32) : Result (T × T) :=
   match ls0 with
@@ -325,13 +343,13 @@ divergent def list_nth_shared_loop_pair_loop
   | List.Nil => Result.fail .panic
 
 /- [loops::list_nth_shared_loop_pair]:
-   Source: 'src/loops.rs', lines 198:0-202:19 -/
+   Source: 'src/loops.rs', lines 208:0-212:19 -/
 def list_nth_shared_loop_pair
   (T : Type) (ls0 : List T) (ls1 : List T) (i : U32) : Result (T × T) :=
   list_nth_shared_loop_pair_loop T ls0 ls1 i
 
 /- [loops::list_nth_mut_loop_pair_merge]: loop 0:
-   Source: 'src/loops.rs', lines 223:0-238:1 -/
+   Source: 'src/loops.rs', lines 233:0-248:1 -/
 divergent def list_nth_mut_loop_pair_merge_loop
   (T : Type) (ls0 : List T) (ls1 : List T) (i : U32) :
   Result ((T × T) × ((T × T) → Result ((List T) × (List T))))
@@ -361,7 +379,7 @@ divergent def list_nth_mut_loop_pair_merge_loop
   | List.Nil => Result.fail .panic
 
 /- [loops::list_nth_mut_loop_pair_merge]:
-   Source: 'src/loops.rs', lines 223:0-227:27 -/
+   Source: 'src/loops.rs', lines 233:0-237:27 -/
 def list_nth_mut_loop_pair_merge
   (T : Type) (ls0 : List T) (ls1 : List T) (i : U32) :
   Result ((T × T) × ((T × T) → Result ((List T) × (List T))))
@@ -371,7 +389,7 @@ def list_nth_mut_loop_pair_merge
   Result.ret (p, back_'a)
 
 /- [loops::list_nth_shared_loop_pair_merge]: loop 0:
-   Source: 'src/loops.rs', lines 241:0-256:1 -/
+   Source: 'src/loops.rs', lines 251:0-266:1 -/
 divergent def list_nth_shared_loop_pair_merge_loop
   (T : Type) (ls0 : List T) (ls1 : List T) (i : U32) : Result (T × T) :=
   match ls0 with
@@ -388,13 +406,13 @@ divergent def list_nth_shared_loop_pair_merge_loop
   | List.Nil => Result.fail .panic
 
 /- [loops::list_nth_shared_loop_pair_merge]:
-   Source: 'src/loops.rs', lines 241:0-245:19 -/
+   Source: 'src/loops.rs', lines 251:0-255:19 -/
 def list_nth_shared_loop_pair_merge
   (T : Type) (ls0 : List T) (ls1 : List T) (i : U32) : Result (T × T) :=
   list_nth_shared_loop_pair_merge_loop T ls0 ls1 i
 
 /- [loops::list_nth_mut_shared_loop_pair]: loop 0:
-   Source: 'src/loops.rs', lines 259:0-274:1 -/
+   Source: 'src/loops.rs', lines 269:0-284:1 -/
 divergent def list_nth_mut_shared_loop_pair_loop
   (T : Type) (ls0 : List T) (ls1 : List T) (i : U32) :
   Result ((T × T) × (T → Result (List T)))
@@ -420,7 +438,7 @@ divergent def list_nth_mut_shared_loop_pair_loop
   | List.Nil => Result.fail .panic
 
 /- [loops::list_nth_mut_shared_loop_pair]:
-   Source: 'src/loops.rs', lines 259:0-263:23 -/
+   Source: 'src/loops.rs', lines 269:0-273:23 -/
 def list_nth_mut_shared_loop_pair
   (T : Type) (ls0 : List T) (ls1 : List T) (i : U32) :
   Result ((T × T) × (T → Result (List T)))
@@ -430,7 +448,7 @@ def list_nth_mut_shared_loop_pair
   Result.ret (p, back_'a)
 
 /- [loops::list_nth_mut_shared_loop_pair_merge]: loop 0:
-   Source: 'src/loops.rs', lines 278:0-293:1 -/
+   Source: 'src/loops.rs', lines 288:0-303:1 -/
 divergent def list_nth_mut_shared_loop_pair_merge_loop
   (T : Type) (ls0 : List T) (ls1 : List T) (i : U32) :
   Result ((T × T) × (T → Result (List T)))
@@ -457,7 +475,7 @@ divergent def list_nth_mut_shared_loop_pair_merge_loop
   | List.Nil => Result.fail .panic
 
 /- [loops::list_nth_mut_shared_loop_pair_merge]:
-   Source: 'src/loops.rs', lines 278:0-282:23 -/
+   Source: 'src/loops.rs', lines 288:0-292:23 -/
 def list_nth_mut_shared_loop_pair_merge
   (T : Type) (ls0 : List T) (ls1 : List T) (i : U32) :
   Result ((T × T) × (T → Result (List T)))
@@ -467,7 +485,7 @@ def list_nth_mut_shared_loop_pair_merge
   Result.ret (p, back_'a)
 
 /- [loops::list_nth_shared_mut_loop_pair]: loop 0:
-   Source: 'src/loops.rs', lines 297:0-312:1 -/
+   Source: 'src/loops.rs', lines 307:0-322:1 -/
 divergent def list_nth_shared_mut_loop_pair_loop
   (T : Type) (ls0 : List T) (ls1 : List T) (i : U32) :
   Result ((T × T) × (T → Result (List T)))
@@ -493,7 +511,7 @@ divergent def list_nth_shared_mut_loop_pair_loop
   | List.Nil => Result.fail .panic
 
 /- [loops::list_nth_shared_mut_loop_pair]:
-   Source: 'src/loops.rs', lines 297:0-301:23 -/
+   Source: 'src/loops.rs', lines 307:0-311:23 -/
 def list_nth_shared_mut_loop_pair
   (T : Type) (ls0 : List T) (ls1 : List T) (i : U32) :
   Result ((T × T) × (T → Result (List T)))
@@ -503,7 +521,7 @@ def list_nth_shared_mut_loop_pair
   Result.ret (p, back_'b)
 
 /- [loops::list_nth_shared_mut_loop_pair_merge]: loop 0:
-   Source: 'src/loops.rs', lines 316:0-331:1 -/
+   Source: 'src/loops.rs', lines 326:0-341:1 -/
 divergent def list_nth_shared_mut_loop_pair_merge_loop
   (T : Type) (ls0 : List T) (ls1 : List T) (i : U32) :
   Result ((T × T) × (T → Result (List T)))
@@ -530,7 +548,7 @@ divergent def list_nth_shared_mut_loop_pair_merge_loop
   | List.Nil => Result.fail .panic
 
 /- [loops::list_nth_shared_mut_loop_pair_merge]:
-   Source: 'src/loops.rs', lines 316:0-320:23 -/
+   Source: 'src/loops.rs', lines 326:0-330:23 -/
 def list_nth_shared_mut_loop_pair_merge
   (T : Type) (ls0 : List T) (ls1 : List T) (i : U32) :
   Result ((T × T) × (T → Result (List T)))

--- a/tests/lean/Traits.lean
+++ b/tests/lean/Traits.lean
@@ -338,22 +338,14 @@ structure ChildTrait (Self : Type) where
   ParentTrait0SelfInst : ParentTrait0 Self
   ParentTrait1SelfInst : ParentTrait1 Self
 
-/- [traits::test_parent_trait0]:
-   Source: 'src/traits.rs', lines 208:0-208:57 -/
-def test_parent_trait0
-  (T : Type) (ParentTrait0TInst : ParentTrait0 T) (x : T) :
-  Result ParentTrait0TInst.W
-  :=
-  ParentTrait0TInst.get_w x
-
 /- [traits::test_child_trait1]:
-   Source: 'src/traits.rs', lines 213:0-213:56 -/
+   Source: 'src/traits.rs', lines 209:0-209:56 -/
 def test_child_trait1
   (T : Type) (ChildTraitTInst : ChildTrait T) (x : T) : Result String :=
   ChildTraitTInst.ParentTrait0SelfInst.get_name x
 
 /- [traits::test_child_trait2]:
-   Source: 'src/traits.rs', lines 217:0-217:54 -/
+   Source: 'src/traits.rs', lines 213:0-213:54 -/
 def test_child_trait2
   (T : Type) (ChildTraitTInst : ChildTrait T) (x : T) :
   Result ChildTraitTInst.ParentTrait0SelfInst.W
@@ -361,7 +353,7 @@ def test_child_trait2
   ChildTraitTInst.ParentTrait0SelfInst.get_w x
 
 /- [traits::order1]:
-   Source: 'src/traits.rs', lines 223:0-223:59 -/
+   Source: 'src/traits.rs', lines 219:0-219:59 -/
 def order1
   (T U : Type) (ParentTrait0TInst : ParentTrait0 T) (ParentTrait0UInst :
   ParentTrait0 U) :
@@ -370,28 +362,28 @@ def order1
   Result.ret ()
 
 /- Trait declaration: [traits::ChildTrait1]
-   Source: 'src/traits.rs', lines 226:0-226:35 -/
+   Source: 'src/traits.rs', lines 222:0-222:35 -/
 structure ChildTrait1 (Self : Type) where
   ParentTrait1SelfInst : ParentTrait1 Self
 
 /- Trait implementation: [traits::{usize#9}]
-   Source: 'src/traits.rs', lines 228:0-228:27 -/
+   Source: 'src/traits.rs', lines 224:0-224:27 -/
 def traits.ParentTrait1UsizeInst : ParentTrait1 Usize := {
 }
 
 /- Trait implementation: [traits::{usize#10}]
-   Source: 'src/traits.rs', lines 229:0-229:26 -/
+   Source: 'src/traits.rs', lines 225:0-225:26 -/
 def traits.ChildTrait1UsizeInst : ChildTrait1 Usize := {
   ParentTrait1SelfInst := traits.ParentTrait1UsizeInst
 }
 
 /- Trait declaration: [traits::Iterator]
-   Source: 'src/traits.rs', lines 233:0-233:18 -/
+   Source: 'src/traits.rs', lines 229:0-229:18 -/
 structure Iterator (Self : Type) where
   Item : Type
 
 /- Trait declaration: [traits::IntoIterator]
-   Source: 'src/traits.rs', lines 237:0-237:22 -/
+   Source: 'src/traits.rs', lines 233:0-233:22 -/
 structure IntoIterator (Self : Type) where
   Item : Type
   IntoIter : Type
@@ -399,84 +391,84 @@ structure IntoIterator (Self : Type) where
   into_iter : Self → Result IntoIter
 
 /- Trait declaration: [traits::FromResidual]
-   Source: 'src/traits.rs', lines 254:0-254:21 -/
+   Source: 'src/traits.rs', lines 250:0-250:21 -/
 structure FromResidual (Self T : Type) where
 
 /- Trait declaration: [traits::Try]
-   Source: 'src/traits.rs', lines 250:0-250:48 -/
+   Source: 'src/traits.rs', lines 246:0-246:48 -/
 structure Try (Self : Type) where
   Residual : Type
   FromResidualSelftraitsTrySelfResidualInst : FromResidual Self Residual
 
 /- Trait declaration: [traits::WithTarget]
-   Source: 'src/traits.rs', lines 256:0-256:20 -/
+   Source: 'src/traits.rs', lines 252:0-252:20 -/
 structure WithTarget (Self : Type) where
   Target : Type
 
 /- Trait declaration: [traits::ParentTrait2]
-   Source: 'src/traits.rs', lines 260:0-260:22 -/
+   Source: 'src/traits.rs', lines 256:0-256:22 -/
 structure ParentTrait2 (Self : Type) where
   U : Type
   U_clause_0 : WithTarget U
 
 /- Trait declaration: [traits::ChildTrait2]
-   Source: 'src/traits.rs', lines 264:0-264:35 -/
+   Source: 'src/traits.rs', lines 260:0-260:35 -/
 structure ChildTrait2 (Self : Type) where
   ParentTrait2SelfInst : ParentTrait2 Self
   convert : ParentTrait2SelfInst.U → Result
     ParentTrait2SelfInst.U_clause_0.Target
 
 /- Trait implementation: [traits::{u32#11}]
-   Source: 'src/traits.rs', lines 268:0-268:23 -/
+   Source: 'src/traits.rs', lines 264:0-264:23 -/
 def traits.WithTargetU32Inst : WithTarget U32 := {
   Target := U32
 }
 
 /- Trait implementation: [traits::{u32#12}]
-   Source: 'src/traits.rs', lines 272:0-272:25 -/
+   Source: 'src/traits.rs', lines 268:0-268:25 -/
 def traits.ParentTrait2U32Inst : ParentTrait2 U32 := {
   U := U32
   U_clause_0 := traits.WithTargetU32Inst
 }
 
 /- [traits::{u32#13}::convert]:
-   Source: 'src/traits.rs', lines 277:4-277:29 -/
+   Source: 'src/traits.rs', lines 273:4-273:29 -/
 def U32.convert (x : U32) : Result U32 :=
   Result.ret x
 
 /- Trait implementation: [traits::{u32#13}]
-   Source: 'src/traits.rs', lines 276:0-276:24 -/
+   Source: 'src/traits.rs', lines 272:0-272:24 -/
 def traits.ChildTrait2U32Inst : ChildTrait2 U32 := {
   ParentTrait2SelfInst := traits.ParentTrait2U32Inst
   convert := U32.convert
 }
 
 /- Trait declaration: [traits::CFnOnce]
-   Source: 'src/traits.rs', lines 290:0-290:23 -/
+   Source: 'src/traits.rs', lines 286:0-286:23 -/
 structure CFnOnce (Self Args : Type) where
   Output : Type
   call_once : Self → Args → Result Output
 
 /- Trait declaration: [traits::CFnMut]
-   Source: 'src/traits.rs', lines 296:0-296:37 -/
+   Source: 'src/traits.rs', lines 292:0-292:37 -/
 structure CFnMut (Self Args : Type) where
   CFnOnceSelfArgsInst : CFnOnce Self Args
   call_mut : Self → Args → Result (CFnOnceSelfArgsInst.Output × Self)
 
 /- Trait declaration: [traits::CFn]
-   Source: 'src/traits.rs', lines 300:0-300:33 -/
+   Source: 'src/traits.rs', lines 296:0-296:33 -/
 structure CFn (Self Args : Type) where
   CFnMutSelfArgsInst : CFnMut Self Args
   call : Self → Args → Result CFnMutSelfArgsInst.CFnOnceSelfArgsInst.Output
 
 /- Trait declaration: [traits::GetTrait]
-   Source: 'src/traits.rs', lines 304:0-304:18 -/
+   Source: 'src/traits.rs', lines 300:0-300:18 -/
 structure GetTrait (Self : Type) where
   W : Type
   get_w : Self → Result W
 
 /- [traits::test_get_trait]:
-   Source: 'src/traits.rs', lines 309:0-309:49 -/
+   Source: 'src/traits.rs', lines 305:0-305:49 -/
 def test_get_trait
   (T : Type) (GetTraitTInst : GetTrait T) (x : T) : Result GetTraitTInst.W :=
   GetTraitTInst.get_w x


### PR DESCRIPTION
The following example caused a crash:
```rust
pub struct BigInt<const N: usize>(pub [u64; N]);

impl<const N : usize> BigInt<N> {
  pub fn const_geq(&self, other: &Self) -> bool {
      let mut i = 0;
      while i < N {
          let a = self.0[i];
          i += 1;
      }
      false
  }
}
```

The reason is that when reorganizing the environment upon reaching the `continue` statement, we did not move some value to an anonymous value, while in the fixed-point environment this value was bottom. The matcher then failed upon matching those two environments.