### PR TITLE
Fix tuple indexing for Lean backend

### DIFF
--- a/backends/lean/Base/IList/IList.lean
+++ b/backends/lean/Base/IList/IList.lean
@@ -33,7 +33,7 @@ def indexOpt (ls : List α) (i : Int) : Option α :=
 @[simp] theorem indexOpt_zero_cons : indexOpt ((x :: tl) : List α) 0 = some x := by simp [indexOpt]
 @[simp] theorem indexOpt_nzero_cons (hne : i ≠ 0) : indexOpt ((x :: tl) : List α) i = indexOpt tl (i - 1) := by simp [*, indexOpt]
 
--- Remark: if i < 0, then the result is the defaul element
+-- Remark: if i < 0, then the result is the default element
 def index [Inhabited α] (ls : List α) (i : Int) : α :=
   match ls with
   | [] => Inhabited.default

--- a/tests/lean/NoNestedBorrows.lean
+++ b/tests/lean/NoNestedBorrows.lean
@@ -643,7 +643,7 @@ def Tuple (T1 T2 : Type) := T1 × T2
 /- [no_nested_borrows::use_tuple_struct]:
    Source: 'src/no_nested_borrows.rs', lines 556:0-556:48 -/
 def use_tuple_struct (x : Tuple U32 U32) : Result (Tuple U32 U32) :=
-  Result.ret (1#u32, x.1)
+  Result.ret (1#u32, x.2)
 
 /- [no_nested_borrows::create_tuple_struct]:
    Source: 'src/no_nested_borrows.rs', lines 560:0-560:61 -/


### PR DESCRIPTION
A proposed fix for #76. This PR maps the field ID for tuple structs into the nested index for the Lean tuple.

For example, for the Rust tuple struct
```rust
struct Tuple(i32, bool, u8);
```
which gets translated to
```lean
def Tuple := I32 × Bool × U8
```
the indices map as follows:
| Rust | Lean |
| ----- | ----- |
| Tuple.0 | Tuple.1 |
| Tuple.1 | Tuple.2.1 |
| Tuple.2 | Tuple.2.2 |

Resolves #76 