### PR TITLE
Fix some issues with the loops

### DIFF
--- a/compiler/Contexts.ml
+++ b/compiler/Contexts.ml
@@ -467,8 +467,8 @@ let env_find_abs (env : env) (pred : abs -> bool) : abs option =
   in
   lookup env
 
-let env_lookup_abs (env : env) (abs_id : AbstractionId.id) : abs =
-  Option.get (env_find_abs env (fun abs -> abs.abs_id = abs_id))
+let env_lookup_abs_opt (env : env) (abs_id : AbstractionId.id) : abs option =
+  env_find_abs env (fun abs -> abs.abs_id = abs_id)
 
 (** Remove an abstraction from the context, as well as all the references to
     this abstraction (for instance, remove the abs id from all the parent sets
@@ -524,8 +524,12 @@ let env_subst_abs (env : env) (abs_id : AbstractionId.id) (nabs : abs) :
   in
   update env
 
+let ctx_lookup_abs_opt (ctx : eval_ctx) (abs_id : AbstractionId.id) : abs option
+    =
+  env_lookup_abs_opt ctx.env abs_id
+
 let ctx_lookup_abs (ctx : eval_ctx) (abs_id : AbstractionId.id) : abs =
-  env_lookup_abs ctx.env abs_id
+  Option.get (ctx_lookup_abs_opt ctx abs_id)
 
 let ctx_find_abs (ctx : eval_ctx) (p : abs -> bool) : abs option =
   env_find_abs ctx.env p

--- a/compiler/Interpreter.ml
+++ b/compiler/Interpreter.ml
@@ -358,6 +358,7 @@ let evaluate_function_symbolic_synthesize_backward_from_return (config : config)
       in
       if not inside_loop then (Some fun_abs_id, true)
       else
+        (* We are inside a loop *)
         let pred (abs : abs) =
           match abs.kind with
           | Loop (_, rg_id', kind) ->

--- a/compiler/InterpreterLoops.ml
+++ b/compiler/InterpreterLoops.ml
@@ -191,7 +191,7 @@ let eval_loop_symbolic (config : config) (meta : meta)
        is important in {!SymbolicToPure}, where we expect the given back
        values to have a specific order.
     *)
-    let compute_abs_given_back_tys (abs : abs) : RegionId.Set.t * rty list =
+    let compute_abs_given_back_tys (abs : abs) : rty list =
       let is_borrow (av : typed_avalue) : bool =
         match av.value with
         | ABorrow _ -> true
@@ -239,7 +239,7 @@ let eval_loop_symbolic (config : config) (meta : meta)
       in
       assert (BorrowId.Map.is_empty !borrows);
 
-      (abs.regions, given_back_tys)
+      given_back_tys
     in
     let rg_to_given_back =
       RegionGroupId.Map.map compute_abs_given_back_tys rg_to_abs

--- a/compiler/InterpreterLoops.ml
+++ b/compiler/InterpreterLoops.ml
@@ -261,6 +261,10 @@ let eval_loop (config : config) (meta : meta) (eval_loop_body : st_cm_fun) :
   match config.mode with
   | ConcreteMode -> eval_loop_concrete eval_loop_body cf ctx
   | SymbolicMode ->
+      (* Simplify the context by ending the unnecessary borrows/loans and getting
+         rid of the useless symbolic values (which are in anonymous variables) *)
+      let cc = cleanup_fresh_values_and_abs config empty_ids_set in
+
       (* We want to make sure the loop will *not* manipulate shared avalues
          containing themselves shared loans (i.e., nested shared loans in
          the abstractions), because it complexifies the matches between values
@@ -279,5 +283,5 @@ let eval_loop (config : config) (meta : meta) (eval_loop_body : st_cm_fun) :
          introduce *fixed* abstractions, and again later to introduce
          *non-fixed* abstractions.
       *)
-      let cc = prepare_ashared_loans None in
+      let cc = comp cc (prepare_ashared_loans None) in
       comp cc (eval_loop_symbolic config meta eval_loop_body) cf ctx

--- a/compiler/InterpreterLoops.ml
+++ b/compiler/InterpreterLoops.ml
@@ -190,6 +190,9 @@ let eval_loop_symbolic (config : config) (meta : meta)
        Moreover, we list the borrows in the same order as the loans (this
        is important in {!SymbolicToPure}, where we expect the given back
        values to have a specific order.
+
+       Also, we filter the backward functions which and
+       return nothing.
     *)
     let compute_abs_given_back_tys (abs : abs) : rty list =
       let is_borrow (av : typed_avalue) : bool =

--- a/compiler/InterpreterLoops.ml
+++ b/compiler/InterpreterLoops.ml
@@ -97,8 +97,8 @@ let eval_loop_symbolic (config : config) (meta : meta)
     log#ldebug
       (lazy
         ("eval_loop_symbolic: about to reorganize the original context to \
-          match  the fixed-point ctx with it:\n\
-          - src ctx (fixed-point ctx)" ^ eval_ctx_to_string fp_ctx
+          match the fixed-point ctx with it:\n\
+          - src ctx (fixed-point ctx):\n" ^ eval_ctx_to_string fp_ctx
        ^ "\n\n-tgt ctx (original context):\n" ^ eval_ctx_to_string ctx));
 
     prepare_match_ctx_with_target config loop_id fixed_ids fp_ctx cf ctx

--- a/compiler/InterpreterLoopsCore.ml
+++ b/compiler/InterpreterLoopsCore.ml
@@ -12,6 +12,7 @@ type updt_env_kind =
   | AbsInRight of AbstractionId.id
   | LoanInRight of BorrowId.id
   | LoansInRight of BorrowId.Set.t
+[@@deriving show]
 
 (** Utility exception *)
 exception ValueMatchFailure of updt_env_kind

--- a/compiler/InterpreterLoopsFixedPoint.ml
+++ b/compiler/InterpreterLoopsFixedPoint.ml
@@ -620,12 +620,24 @@ let compute_loop_entry_fixed_point (config : config) (loop_id : LoopId.id)
           (* Retrieve the first id of the group *)
           match ids with
           | [] ->
-              (* We shouldn't get there: we actually introduce reborrows with
-                 {!prepare_ashared_loans} and in the [match_mut_borrows] function
-                 of {!MakeJoinMatcher} to introduce some fresh abstractions for
-                 this purpose.
+              (* We *can* get there, if the loop doesn't touch the borrowed
+                 values.
+                 For instance:
+                 {[
+                   pub fn iter_slice(a: &mut [u8]) {
+                       let len = a.len();
+                       let mut i = 0;
+                       while i < len {
+                           i += 1;
+                       }
+                   }
+                 ]}
               *)
-              raise (Failure "Unexpected")
+              log#ldebug
+                (lazy
+                  ("No loop region to end for the region group "
+                  ^ RegionGroupId.to_string rg_id));
+              ()
           | id0 :: ids ->
               let id0 = ref id0 in
               (* Add the proper region group into the abstraction *)

--- a/compiler/InterpreterLoopsFixedPoint.mli
+++ b/compiler/InterpreterLoopsFixedPoint.mli
@@ -56,6 +56,8 @@ val prepare_ashared_loans : loop_id option -> Cps.cm_fun
     - the map from region group id to the corresponding abstraction appearing
       in the fixed point (this is useful to compute the return type of the loop
       backward functions for instance).
+      Note that this is a partial map: the loop doesn't necessarily introduce
+      an abstraction for each input region of the function.
 
     Rem.: the list of symbolic values should be computable by simply exploring
     the fixed point environment and listing all the symbolic values we find.

--- a/compiler/InterpreterLoopsFixedPoint.mli
+++ b/compiler/InterpreterLoopsFixedPoint.mli
@@ -3,6 +3,18 @@ open Contexts
 open InterpreterUtils
 open InterpreterLoopsCore
 
+(** Repeat until we can't simplify the context anymore:
+   - explore the fresh anonymous values and replace all the values which are not
+     borrows/loans with ⊥
+   - also end the borrows which appear in fresh anonymous values and don't contain loans
+   - end the fresh region abstractions which can be ended (no loans)
+
+   Inputs:
+   - config
+   - fixed ids (the fixeds ids are the ids we consider as non-fresh)
+ *)
+val cleanup_fresh_values_and_abs : config -> ids_sets -> Cps.cm_fun
+
 (** Prepare the shared loans in the abstractions by moving them to fresh
     abstractions.
 

--- a/compiler/InterpreterLoopsMatchCtxs.mli
+++ b/compiler/InterpreterLoopsMatchCtxs.mli
@@ -137,6 +137,21 @@ val match_ctxs :
  *)
 val ctxs_are_equivalent : ids_sets -> eval_ctx -> eval_ctx -> bool
 
+(** Reorganize a target context so that we can match it with a source context
+    (remember that the source context is generally the fixed point context,
+    which results from joins during which we ended the loans which
+    were introduced during the loop iterations).
+
+   **Parameters**:
+   - [config]
+   - [loop_id]
+   - [fixed_ids]
+   - [src_ctx]
+
+ *)
+val prepare_match_ctx_with_target :
+  config -> LoopId.id -> ids_sets -> eval_ctx -> cm_fun
+
 (** Match a context with a target context.
 
     This is used to compute application of loop translations: we use this

--- a/compiler/InterpreterStatements.ml
+++ b/compiler/InterpreterStatements.ml
@@ -933,6 +933,11 @@ let rec eval_statement (config : config) (st : statement) : st_cm_fun =
   (* Evaluate *)
   let cf_eval_st cf : m_fun =
    fun ctx ->
+    log#ldebug
+      (lazy
+        ("\neval_statement: cf_eval_st: statement:\n"
+        ^ statement_to_string_with_tab ctx st
+        ^ "\n\n"));
     match st.content with
     | Assign (p, rvalue) -> (
         (* We handle global assignments separately *)
@@ -1520,8 +1525,10 @@ and eval_assumed_function_call_symbolic (config : config) (fid : assumed_fun_id)
 (** Evaluate a statement seen as a function body *)
 and eval_function_body (config : config) (body : statement) : st_cm_fun =
  fun cf ctx ->
+  log#ldebug (lazy "eval_function_body:");
   let cc = eval_statement config body in
   let cf_finish cf res =
+    log#ldebug (lazy "eval_function_body: cf_finish");
     (* Note that we *don't* check the result ({!Panic}, {!Return}, etc.): we
      * delegate the check to the caller. *)
     (* Expand the symbolic values if necessary - we need to do that before

--- a/compiler/InterpreterUtils.ml
+++ b/compiler/InterpreterUtils.ml
@@ -420,6 +420,8 @@ let compute_ctxs_ids (ctxl : eval_ctx list) : ids_sets * ids_to_values =
 let compute_ctx_ids (ctx : eval_ctx) : ids_sets * ids_to_values =
   compute_ctxs_ids [ ctx ]
 
+let empty_ids_set = fst (compute_ctxs_ids [])
+
 (** **WARNING**: this function doesn't compute the normalized types
     (for the trait type aliases). This should be computed afterwards.
  *)

--- a/compiler/Print.ml
+++ b/compiler/Print.ml
@@ -16,6 +16,10 @@ module Expressions = Charon.PrintExpressions
 let list_to_string (to_string : 'a -> string) (ls : 'a list) : string =
   "[" ^ String.concat "; " (List.map to_string ls) ^ "]"
 
+let pair_to_string (to_string0 : 'a -> string) (to_string1 : 'b -> string)
+    ((x, y) : 'a * 'b) : string =
+  "(" ^ to_string0 x ^ ", " ^ to_string1 y ^ ")"
+
 let bool_to_string (b : bool) : string = if b then "true" else "false"
 
 (** Pretty-printing for values *)

--- a/compiler/Print.ml
+++ b/compiler/Print.ml
@@ -88,19 +88,19 @@ module Values = struct
 
   and borrow_content_to_string (env : fmt_env) (bc : borrow_content) : string =
     match bc with
-    | VSharedBorrow bid -> "⌊shared@" ^ BorrowId.to_string bid ^ "⌋"
+    | VSharedBorrow bid -> "shared_borrow@" ^ BorrowId.to_string bid
     | VMutBorrow (bid, tv) ->
-        "&mut@" ^ BorrowId.to_string bid ^ " ("
+        "mut_borrow@" ^ BorrowId.to_string bid ^ " ("
         ^ typed_value_to_string env tv
         ^ ")"
-    | VReservedMutBorrow bid -> "⌊reserved_mut@" ^ BorrowId.to_string bid ^ "⌋"
+    | VReservedMutBorrow bid -> "reserved_borrow@" ^ BorrowId.to_string bid
 
   and loan_content_to_string (env : fmt_env) (lc : loan_content) : string =
     match lc with
     | VSharedLoan (loans, v) ->
         let loans = BorrowId.Set.to_string None loans in
         "@shared_loan(" ^ loans ^ ", " ^ typed_value_to_string env v ^ ")"
-    | VMutLoan bid -> "⌊mut@" ^ BorrowId.to_string bid ^ "⌋"
+    | VMutLoan bid -> "ml@" ^ BorrowId.to_string bid
 
   let abstract_shared_borrow_to_string (env : fmt_env)
       (abs : abstract_shared_borrow) : string =
@@ -184,9 +184,9 @@ module Values = struct
   and aloan_content_to_string (env : fmt_env) (lc : aloan_content) : string =
     match lc with
     | AMutLoan (bid, av) ->
-        "⌊mut@" ^ BorrowId.to_string bid ^ ", "
+        "@mut_loan(" ^ BorrowId.to_string bid ^ ", "
         ^ typed_avalue_to_string env av
-        ^ "⌋"
+        ^ ")"
     | ASharedLoan (loans, v, av) ->
         let loans = BorrowId.Set.to_string None loans in
         "@shared_loan(" ^ loans ^ ", "
@@ -225,10 +225,10 @@ module Values = struct
       =
     match bc with
     | AMutBorrow (bid, av) ->
-        "&mut@" ^ BorrowId.to_string bid ^ " ("
+        "mb@" ^ BorrowId.to_string bid ^ " ("
         ^ typed_avalue_to_string env av
         ^ ")"
-    | ASharedBorrow bid -> "⌊shared@" ^ BorrowId.to_string bid ^ "⌋"
+    | ASharedBorrow bid -> "sb@" ^ BorrowId.to_string bid
     | AIgnoredMutBorrow (opt_bid, av) ->
         "@ignored_mut_borrow("
         ^ option_to_string BorrowId.to_string opt_bid

--- a/compiler/SymbolicAst.ml
+++ b/compiler/SymbolicAst.ml
@@ -215,8 +215,7 @@ and loop = {
   input_svalues : symbolic_value list;  (** The input symbolic values *)
   fresh_svalues : symbolic_value_id_set;
       (** The symbolic values introduced by the loop fixed-point *)
-  rg_to_given_back_tys :
-    ((RegionId.Set.t * ty list) RegionGroupId.Map.t[@opaque]);
+  rg_to_given_back_tys : (ty list RegionGroupId.Map.t[@opaque]);
       (** The map from region group ids to the types of the values given back
           by the corresponding loop abstractions.
        *)

--- a/compiler/SymbolicAst.ml
+++ b/compiler/SymbolicAst.ml
@@ -197,16 +197,16 @@ type expression =
           The evaluation context is the context at the moment we introduce the
           [ForwardEnd], and is used to translate the input values (see the
           comments for the {!Return} variant).
+
+          This case also handles the case where we (re-)enter a loop (once
+          we enter a loop in symbolic mode, we don't get out: the loop is
+          responsible for the end of the function).
        *)
   | Loop of loop  (** Loop *)
   | ReturnWithLoop of loop_id * bool
-      (** End the function with a call to a loop function.
-
-          This encompasses the cases when we synthesize a function body
-          and enter a loop for the first time, or when we synthesize a
-          loop body and reach a [Continue].
-
-          The boolean is [is_continue].
+      (** We reach a return while inside a loop.
+          The boolean is [true].
+          TODO: merge this with Return.
        *)
   | Meta of emeta * expression  (** Meta information *)
 

--- a/compiler/SymbolicToPure.ml
+++ b/compiler/SymbolicToPure.ml
@@ -1890,7 +1890,7 @@ let rec translate_expression (e : S.expression) (ctx : bs_ctx) : texpression =
          Remark: we can't get there if we are inside a loop. *)
       translate_return ectx opt_v ctx
   | ReturnWithLoop (loop_id, is_continue) ->
-      (* We end the function with a call to a loop function. *)
+      (* We reached a return and are inside a loop. *)
       translate_return_with_loop loop_id is_continue ctx
   | Panic -> translate_panic ctx
   | FunCall (call, e) -> translate_function_call call e ctx
@@ -1902,7 +1902,10 @@ let rec translate_expression (e : S.expression) (ctx : bs_ctx) : texpression =
       translate_intro_symbolic ectx p sv v e ctx
   | Meta (meta, e) -> translate_emeta meta e ctx
   | ForwardEnd (ectx, loop_input_values, e, back_e) ->
-      (* Translate the end of a function, or the end of a loop *)
+      (* Translate the end of a function, or the end of a loop.
+
+         The case where we (re-)enter a loop is handled here.
+      *)
       translate_forward_end ectx loop_input_values e back_e ctx
   | Loop loop -> translate_loop loop ctx
 

--- a/compiler/SymbolicToPure.ml
+++ b/compiler/SymbolicToPure.ml
@@ -1988,7 +1988,13 @@ and translate_return_with_loop (loop_id : V.LoopId.id) (is_continue : bool)
         (* Backward *)
         (* Group the variables in which we stored the values we need to give back.
          * See the explanations for the [SynthInput] case in [translate_end_abstraction] *)
-        let backward_outputs = Option.get ctx.backward_outputs in
+        (* It can happen that we did not end any output abstraction, because the
+           loop didn't use borrows corresponding to the region we just ended.
+           If this happens, there are no backward outputs.
+        *)
+        let backward_outputs =
+          match ctx.backward_outputs with Some outputs -> outputs | None -> []
+        in
         let field_values = List.map mk_texpression_from_var backward_outputs in
         mk_simpl_tuple_texpression field_values
   in

--- a/compiler/SynthesizeSymbolic.ml
+++ b/compiler/SynthesizeSymbolic.ml
@@ -171,7 +171,7 @@ let synthesize_forward_end (ctx : Contexts.eval_ctx)
 
 let synthesize_loop (loop_id : LoopId.id) (input_svalues : symbolic_value list)
     (fresh_svalues : SymbolicValueId.Set.t)
-    (rg_to_given_back_tys : (RegionId.Set.t * ty list) RegionGroupId.Map.t)
+    (rg_to_given_back_tys : ty list RegionGroupId.Map.t)
     (end_expr : expression option) (loop_expr : expression option)
     (meta : Meta.meta) : expression option =
   match (end_expr, loop_expr) with

--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1707489322,
-        "narHash": "sha256-fnb4vyW3BxC4+ue4aLxIM0a5WmNdgdpdkSvwir8Zens=",
+        "lastModified": 1709941742,
+        "narHash": "sha256-iSi3HQBac+JSACClXRJBooQbPOtyqA/P//WzwLQH+tQ=",
         "owner": "aeneasverif",
         "repo": "charon",
-        "rev": "89cecf5d1074fae7e8007be7f6cdf2f38e9782b1",
+        "rev": "c1b3f94afb32ae0917a2abd09f0c6f8e31bed9d6",
         "type": "github"
       },
       "original": {
@@ -82,11 +82,11 @@
         "systems": "systems_3"
       },
       "locked": {
-        "lastModified": 1705309234,
-        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
+        "lastModified": 1709126324,
+        "narHash": "sha256-q6EQdSeUZOG26WelxqkmR7kArjgWCdw5sfJVHPH/7j8=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
+        "rev": "d465f4819400de7c8d874d50b982301f28a84605",
         "type": "github"
       },
       "original": {
@@ -131,11 +131,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1707271955,
-        "narHash": "sha256-OgPXUBx+sVwiENg4tH3GkdAvX+E67djqE/bTfjqPygU=",
+        "lastModified": 1708956704,
+        "narHash": "sha256-xT0V7oQwR0Zns9g/MvV30ILlAX6tcp92SqWPwej1+sI=",
         "owner": "fstarlang",
         "repo": "fstar",
-        "rev": "531185028c4add6ff183ca119ca8415cc2b375db",
+        "rev": "a48722f90e14be69b850f093b41fbbdfee7f6eb9",
         "type": "github"
       },
       "original": {
@@ -164,11 +164,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1707239346,
-        "narHash": "sha256-fCLBOwHv2RqWcDzCqpVzIS1Au5CnfvEqbKHyNUzDEwk=",
+        "lastModified": 1709029146,
+        "narHash": "sha256-xKqBQ1OdLnyng4Kl3XRU//borVLLet+h15mPQ5g0BEI=",
         "owner": "hacl-star",
         "repo": "hacl-star",
-        "rev": "9666f11923844fcdbca6a7af4b4b94fa47b5bb88",
+        "rev": "59723f7dde13bd7b7eb90491f1385b4e3ee2904f",
         "type": "github"
       },
       "original": {
@@ -194,11 +194,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1707354605,
-        "narHash": "sha256-ogIf8OwaCkZCFx3Niayd/zh2LTjNJrRDA6XuY11EqBg=",
+        "lastModified": 1709552015,
+        "narHash": "sha256-zwYbXYRAqKee+OtlWaSX3EhUyD5JLN+xxzcqYxyDnSI=",
         "owner": "hacl-star",
         "repo": "hacl-nix",
-        "rev": "e46ef04ad5120b35bc99eca3c77e039f8ca30a6f",
+        "rev": "96a3c4eaaa65beb0ac9e57fc9aa3e9e34aca12f5",
         "type": "github"
       },
       "original": {
@@ -223,11 +223,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1707198961,
-        "narHash": "sha256-HnOVG+lqfxTJnV+Dmi/UsHfHguWg7WgcC+k5qbBfYxw=",
+        "lastModified": 1709551385,
+        "narHash": "sha256-aryyJy49PlkZeIMO8Jg0qAUCjtre0r+rvmbH6OhH/sk=",
         "owner": "fstarlang",
         "repo": "karamel",
-        "rev": "da1e941b2fcb196aa5d1e34941aa00b4c67ac321",
+        "rev": "a1e1b1f2493ac24f8729f17ebedba7c4571f7c97",
         "type": "github"
       },
       "original": {
@@ -265,11 +265,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1707482772,
-        "narHash": "sha256-sewRgw1MhmoFJO33rDOyz5KH0CGWEnQmwns4uRkmF0U=",
+        "lastModified": 1709930258,
+        "narHash": "sha256-0oJSuzf3zSRMbfmtZ789sJqhg+pgbBZWo9mATpe/dsE=",
         "owner": "leanprover",
         "repo": "lean4",
-        "rev": "488bfe2128a1c5ff0e96c45cf6a382655dc7c703",
+        "rev": "b39042b32c00b6455153f9df26153680b2dc6d6f",
         "type": "github"
       },
       "original": {
@@ -318,11 +318,11 @@
         "nixpkgs": "nixpkgs_7"
       },
       "locked": {
-        "lastModified": 1707482772,
-        "narHash": "sha256-sewRgw1MhmoFJO33rDOyz5KH0CGWEnQmwns4uRkmF0U=",
+        "lastModified": 1709930258,
+        "narHash": "sha256-0oJSuzf3zSRMbfmtZ789sJqhg+pgbBZWo9mATpe/dsE=",
         "owner": "leanprover",
         "repo": "lean4",
-        "rev": "488bfe2128a1c5ff0e96c45cf6a382655dc7c703",
+        "rev": "b39042b32c00b6455153f9df26153680b2dc6d6f",
         "type": "github"
       },
       "original": {

--- a/tests/coq/arrays/Arrays.v
+++ b/tests/coq/arrays/Arrays.v
@@ -516,4 +516,73 @@ Definition ite : result unit :=
   Return tt
 .
 
+(** [arrays::zero_slice]: loop 0:
+    Source: 'src/arrays.rs', lines 303:0-310:1 *)
+Fixpoint zero_slice_loop
+  (n : nat) (a : slice u8) (i : usize) (len : usize) : result (slice u8) :=
+  match n with
+  | O => Fail_ OutOfFuel
+  | S n1 =>
+    if i s< len
+    then (
+      p <- slice_index_mut_usize u8 a i;
+      let (_, index_mut_back) := p in
+      i1 <- usize_add i 1%usize;
+      a1 <- index_mut_back 0%u8;
+      zero_slice_loop n1 a1 i1 len)
+    else Return a
+  end
+.
+
+(** [arrays::zero_slice]:
+    Source: 'src/arrays.rs', lines 303:0-303:31 *)
+Definition zero_slice (n : nat) (a : slice u8) : result (slice u8) :=
+  let len := slice_len u8 a in zero_slice_loop n a 0%usize len
+.
+
+(** [arrays::iter_mut_slice]: loop 0:
+    Source: 'src/arrays.rs', lines 312:0-318:1 *)
+Fixpoint iter_mut_slice_loop
+  (n : nat) (len : usize) (i : usize) : result unit :=
+  match n with
+  | O => Fail_ OutOfFuel
+  | S n1 =>
+    if i s< len
+    then (
+      i1 <- usize_add i 1%usize; _ <- iter_mut_slice_loop n1 len i1; Return tt)
+    else Return tt
+  end
+.
+
+(** [arrays::iter_mut_slice]:
+    Source: 'src/arrays.rs', lines 312:0-312:35 *)
+Definition iter_mut_slice (n : nat) (a : slice u8) : result (slice u8) :=
+  let len := slice_len u8 a in _ <- iter_mut_slice_loop n len 0%usize; Return a
+.
+
+(** [arrays::sum_mut_slice]: loop 0:
+    Source: 'src/arrays.rs', lines 320:0-328:1 *)
+Fixpoint sum_mut_slice_loop
+  (n : nat) (a : slice u32) (i : usize) (s : u32) : result u32 :=
+  match n with
+  | O => Fail_ OutOfFuel
+  | S n1 =>
+    let i1 := slice_len u32 a in
+    if i s< i1
+    then (
+      i2 <- slice_index_usize u32 a i;
+      s1 <- u32_add s i2;
+      i3 <- usize_add i 1%usize;
+      sum_mut_slice_loop n1 a i3 s1)
+    else Return s
+  end
+.
+
+(** [arrays::sum_mut_slice]:
+    Source: 'src/arrays.rs', lines 320:0-320:42 *)
+Definition sum_mut_slice
+  (n : nat) (a : slice u32) : result (u32 * (slice u32)) :=
+  i <- sum_mut_slice_loop n a 0%usize 0%u32; Return (i, a)
+.
+
 End Arrays.

--- a/tests/coq/misc/Loops.v
+++ b/tests/coq/misc/Loops.v
@@ -688,4 +688,68 @@ Definition list_nth_shared_mut_loop_pair_merge
   Return (p1, back_'a)
 .
 
+(** [loops::ignore_input_mut_borrow]: loop 0:
+    Source: 'src/loops.rs', lines 345:0-349:1 *)
+Fixpoint ignore_input_mut_borrow_loop (n : nat) (i : u32) : result unit :=
+  match n with
+  | O => Fail_ OutOfFuel
+  | S n1 =>
+    if i s> 0%u32
+    then (
+      i1 <- u32_sub i 1%u32; _ <- ignore_input_mut_borrow_loop n1 i1; Return tt)
+    else Return tt
+  end
+.
+
+(** [loops::ignore_input_mut_borrow]:
+    Source: 'src/loops.rs', lines 345:0-345:56 *)
+Definition ignore_input_mut_borrow
+  (n : nat) (_a : u32) (i : u32) : result u32 :=
+  _ <- ignore_input_mut_borrow_loop n i; Return _a
+.
+
+(** [loops::incr_ignore_input_mut_borrow]: loop 0:
+    Source: 'src/loops.rs', lines 353:0-358:1 *)
+Fixpoint incr_ignore_input_mut_borrow_loop (n : nat) (i : u32) : result unit :=
+  match n with
+  | O => Fail_ OutOfFuel
+  | S n1 =>
+    if i s> 0%u32
+    then (
+      i1 <- u32_sub i 1%u32;
+      _ <- incr_ignore_input_mut_borrow_loop n1 i1;
+      Return tt)
+    else Return tt
+  end
+.
+
+(** [loops::incr_ignore_input_mut_borrow]:
+    Source: 'src/loops.rs', lines 353:0-353:60 *)
+Definition incr_ignore_input_mut_borrow
+  (n : nat) (a : u32) (i : u32) : result u32 :=
+  a1 <- u32_add a 1%u32; _ <- incr_ignore_input_mut_borrow_loop n i; Return a1
+.
+
+(** [loops::ignore_input_shared_borrow]: loop 0:
+    Source: 'src/loops.rs', lines 362:0-366:1 *)
+Fixpoint ignore_input_shared_borrow_loop (n : nat) (i : u32) : result unit :=
+  match n with
+  | O => Fail_ OutOfFuel
+  | S n1 =>
+    if i s> 0%u32
+    then (
+      i1 <- u32_sub i 1%u32;
+      _ <- ignore_input_shared_borrow_loop n1 i1;
+      Return tt)
+    else Return tt
+  end
+.
+
+(** [loops::ignore_input_shared_borrow]:
+    Source: 'src/loops.rs', lines 362:0-362:59 *)
+Definition ignore_input_shared_borrow
+  (n : nat) (_a : u32) (i : u32) : result u32 :=
+  _ <- ignore_input_shared_borrow_loop n i; Return _a
+.
+
 End Loops.

--- a/tests/fstar/arrays/Arrays.Clauses.Template.fst
+++ b/tests/fstar/arrays/Arrays.Clauses.Template.fst
@@ -19,3 +19,20 @@ let sum2_loop_decreases (s : slice u32) (s2 : slice u32) (sum1 : u32)
   (i : usize) : nat =
   admit ()
 
+(** [arrays::zero_slice]: decreases clause
+    Source: 'src/arrays.rs', lines 303:0-310:1 *)
+unfold
+let zero_slice_loop_decreases (a : slice u8) (i : usize) (len : usize) : nat =
+  admit ()
+
+(** [arrays::iter_mut_slice]: decreases clause
+    Source: 'src/arrays.rs', lines 312:0-318:1 *)
+unfold
+let iter_mut_slice_loop_decreases (len : usize) (i : usize) : nat = admit ()
+
+(** [arrays::sum_mut_slice]: decreases clause
+    Source: 'src/arrays.rs', lines 320:0-328:1 *)
+unfold
+let sum_mut_slice_loop_decreases (a : slice u32) (i : usize) (s : u32) : nat =
+  admit ()
+

--- a/tests/fstar/arrays/Arrays.Clauses.fst
+++ b/tests/fstar/arrays/Arrays.Clauses.fst
@@ -17,3 +17,21 @@ let sum2_loop_decreases (s : slice u32) (s2 : slice u32) (sum : u32)
   (i : usize) : nat =
   if i < length s then length s - i else 0
 
+(** [arrays::zero_slice]: decreases clause
+    Source: 'src/arrays.rs', lines 303:0-310:1 *)
+unfold
+let zero_slice_loop_decreases (a : slice u8) (i : usize) (len : usize) : nat =
+  if i < len then len - i else 0
+
+(** [arrays::iter_mut_slice]: decreases clause
+    Source: 'src/arrays.rs', lines 312:0-318:1 *)
+unfold
+let iter_mut_slice_loop_decreases (len : usize) (i : usize) : nat =
+  if i < len then len - i else 0
+
+(** [arrays::sum_mut_slice]: decreases clause
+    Source: 'src/arrays.rs', lines 320:0-328:1 *)
+unfold
+let sum_mut_slice_loop_decreases (a : slice u32) (i : usize) (s : u32) : nat =
+  if i < slice_len u32 a then slice_len u32 a - i else 0
+

--- a/tests/fstar/arrays/Arrays.Funs.fst
+++ b/tests/fstar/arrays/Arrays.Funs.fst
@@ -418,3 +418,58 @@ let ite : result unit =
   let* _ = to_slice_mut_back s1 in
   Return ()
 
+(** [arrays::zero_slice]: loop 0:
+    Source: 'src/arrays.rs', lines 303:0-310:1 *)
+let rec zero_slice_loop
+  (a : slice u8) (i : usize) (len : usize) :
+  Tot (result (slice u8)) (decreases (zero_slice_loop_decreases a i len))
+  =
+  if i < len
+  then
+    let* (_, index_mut_back) = slice_index_mut_usize u8 a i in
+    let* i1 = usize_add i 1 in
+    let* a1 = index_mut_back 0 in
+    zero_slice_loop a1 i1 len
+  else Return a
+
+(** [arrays::zero_slice]:
+    Source: 'src/arrays.rs', lines 303:0-303:31 *)
+let zero_slice (a : slice u8) : result (slice u8) =
+  let len = slice_len u8 a in zero_slice_loop a 0 len
+
+(** [arrays::iter_mut_slice]: loop 0:
+    Source: 'src/arrays.rs', lines 312:0-318:1 *)
+let rec iter_mut_slice_loop
+  (len : usize) (i : usize) :
+  Tot (result unit) (decreases (iter_mut_slice_loop_decreases len i))
+  =
+  if i < len
+  then
+    let* i1 = usize_add i 1 in let* _ = iter_mut_slice_loop len i1 in Return ()
+  else Return ()
+
+(** [arrays::iter_mut_slice]:
+    Source: 'src/arrays.rs', lines 312:0-312:35 *)
+let iter_mut_slice (a : slice u8) : result (slice u8) =
+  let len = slice_len u8 a in let* _ = iter_mut_slice_loop len 0 in Return a
+
+(** [arrays::sum_mut_slice]: loop 0:
+    Source: 'src/arrays.rs', lines 320:0-328:1 *)
+let rec sum_mut_slice_loop
+  (a : slice u32) (i : usize) (s : u32) :
+  Tot (result u32) (decreases (sum_mut_slice_loop_decreases a i s))
+  =
+  let i1 = slice_len u32 a in
+  if i < i1
+  then
+    let* i2 = slice_index_usize u32 a i in
+    let* s1 = u32_add s i2 in
+    let* i3 = usize_add i 1 in
+    sum_mut_slice_loop a i3 s1
+  else Return s
+
+(** [arrays::sum_mut_slice]:
+    Source: 'src/arrays.rs', lines 320:0-320:42 *)
+let sum_mut_slice (a : slice u32) : result (u32 & (slice u32)) =
+  let* i = sum_mut_slice_loop a 0 0 in Return (i, a)
+

--- a/tests/fstar/misc/Loops.Clauses.Template.fst
+++ b/tests/fstar/misc/Loops.Clauses.Template.fst
@@ -136,3 +136,16 @@ let list_nth_shared_mut_loop_pair_merge_loop_decreases (t : Type0)
   (ls0 : list_t t) (ls1 : list_t t) (i : u32) : nat =
   admit ()
 
+(** [loops::ignore_input_mut_borrow]: decreases clause
+    Source: 'src/loops.rs', lines 345:0-349:1 *)
+unfold let ignore_input_mut_borrow_loop_decreases (i : u32) : nat = admit ()
+
+(** [loops::incr_ignore_input_mut_borrow]: decreases clause
+    Source: 'src/loops.rs', lines 353:0-358:1 *)
+unfold
+let incr_ignore_input_mut_borrow_loop_decreases (i : u32) : nat = admit ()
+
+(** [loops::ignore_input_shared_borrow]: decreases clause
+    Source: 'src/loops.rs', lines 362:0-366:1 *)
+unfold let ignore_input_shared_borrow_loop_decreases (i : u32) : nat = admit ()
+

--- a/tests/fstar/misc/Loops.Clauses.fst
+++ b/tests/fstar/misc/Loops.Clauses.fst
@@ -110,3 +110,17 @@ unfold
 let list_nth_shared_mut_loop_pair_merge_loop_decreases (t : Type0) (l : list_t t)
   (l0 : list_t t) (i : u32) : list_t t =
   l
+
+(** [loops::ignore_input_mut_borrow]: decreases clause
+    Source: 'src/loops.rs', lines 345:0-349:1 *)
+unfold let ignore_input_mut_borrow_loop_decreases (i : u32) : nat = i
+
+(** [loops::incr_ignore_input_mut_borrow]: decreases clause
+    Source: 'src/loops.rs', lines 353:0-358:1 *)
+unfold
+let incr_ignore_input_mut_borrow_loop_decreases (i : u32) : nat = i
+
+(** [loops::ignore_input_shared_borrow]: decreases clause
+    Source: 'src/loops.rs', lines 362:0-366:1 *)
+unfold let ignore_input_shared_borrow_loop_decreases (i : u32) : nat = i
+

--- a/tests/fstar/misc/Loops.Funs.fst
+++ b/tests/fstar/misc/Loops.Funs.fst
@@ -548,3 +548,59 @@ let list_nth_shared_mut_loop_pair_merge
   let* (p, back_'a) = list_nth_shared_mut_loop_pair_merge_loop t ls0 ls1 i in
   Return (p, back_'a)
 
+(** [loops::ignore_input_mut_borrow]: loop 0:
+    Source: 'src/loops.rs', lines 345:0-349:1 *)
+let rec ignore_input_mut_borrow_loop
+  (i : u32) :
+  Tot (result unit) (decreases (ignore_input_mut_borrow_loop_decreases i))
+  =
+  if i > 0
+  then
+    let* i1 = u32_sub i 1 in
+    let* _ = ignore_input_mut_borrow_loop i1 in
+    Return ()
+  else Return ()
+
+(** [loops::ignore_input_mut_borrow]:
+    Source: 'src/loops.rs', lines 345:0-345:56 *)
+let ignore_input_mut_borrow (_a : u32) (i : u32) : result u32 =
+  let* _ = ignore_input_mut_borrow_loop i in Return _a
+
+(** [loops::incr_ignore_input_mut_borrow]: loop 0:
+    Source: 'src/loops.rs', lines 353:0-358:1 *)
+let rec incr_ignore_input_mut_borrow_loop
+  (i : u32) :
+  Tot (result unit) (decreases (incr_ignore_input_mut_borrow_loop_decreases i))
+  =
+  if i > 0
+  then
+    let* i1 = u32_sub i 1 in
+    let* _ = incr_ignore_input_mut_borrow_loop i1 in
+    Return ()
+  else Return ()
+
+(** [loops::incr_ignore_input_mut_borrow]:
+    Source: 'src/loops.rs', lines 353:0-353:60 *)
+let incr_ignore_input_mut_borrow (a : u32) (i : u32) : result u32 =
+  let* a1 = u32_add a 1 in
+  let* _ = incr_ignore_input_mut_borrow_loop i in
+  Return a1
+
+(** [loops::ignore_input_shared_borrow]: loop 0:
+    Source: 'src/loops.rs', lines 362:0-366:1 *)
+let rec ignore_input_shared_borrow_loop
+  (i : u32) :
+  Tot (result unit) (decreases (ignore_input_shared_borrow_loop_decreases i))
+  =
+  if i > 0
+  then
+    let* i1 = u32_sub i 1 in
+    let* _ = ignore_input_shared_borrow_loop i1 in
+    Return ()
+  else Return ()
+
+(** [loops::ignore_input_shared_borrow]:
+    Source: 'src/loops.rs', lines 362:0-362:59 *)
+let ignore_input_shared_borrow (_a : u32) (i : u32) : result u32 =
+  let* _ = ignore_input_shared_borrow_loop i in Return _a
+

--- a/tests/lean/Arrays.lean
+++ b/tests/lean/Arrays.lean
@@ -473,4 +473,63 @@ def ite : Result Unit :=
   let _ ← to_slice_mut_back s1
   Result.ret ()
 
+/- [arrays::zero_slice]: loop 0:
+   Source: 'src/arrays.rs', lines 303:0-310:1 -/
+divergent def zero_slice_loop
+  (a : Slice U8) (i : Usize) (len : Usize) : Result (Slice U8) :=
+  if i < len
+  then
+    do
+    let (_, index_mut_back) ← Slice.index_mut_usize U8 a i
+    let i1 ← i + 1#usize
+    let a1 ← index_mut_back 0#u8
+    zero_slice_loop a1 i1 len
+  else Result.ret a
+
+/- [arrays::zero_slice]:
+   Source: 'src/arrays.rs', lines 303:0-303:31 -/
+def zero_slice (a : Slice U8) : Result (Slice U8) :=
+  let len := Slice.len U8 a
+  zero_slice_loop a 0#usize len
+
+/- [arrays::iter_mut_slice]: loop 0:
+   Source: 'src/arrays.rs', lines 312:0-318:1 -/
+divergent def iter_mut_slice_loop (len : Usize) (i : Usize) : Result Unit :=
+  if i < len
+  then
+    do
+    let i1 ← i + 1#usize
+    let _ ← iter_mut_slice_loop len i1
+    Result.ret ()
+  else Result.ret ()
+
+/- [arrays::iter_mut_slice]:
+   Source: 'src/arrays.rs', lines 312:0-312:35 -/
+def iter_mut_slice (a : Slice U8) : Result (Slice U8) :=
+  do
+  let len := Slice.len U8 a
+  let _ ← iter_mut_slice_loop len 0#usize
+  Result.ret a
+
+/- [arrays::sum_mut_slice]: loop 0:
+   Source: 'src/arrays.rs', lines 320:0-328:1 -/
+divergent def sum_mut_slice_loop
+  (a : Slice U32) (i : Usize) (s : U32) : Result U32 :=
+  let i1 := Slice.len U32 a
+  if i < i1
+  then
+    do
+    let i2 ← Slice.index_usize U32 a i
+    let s1 ← s + i2
+    let i3 ← i + 1#usize
+    sum_mut_slice_loop a i3 s1
+  else Result.ret s
+
+/- [arrays::sum_mut_slice]:
+   Source: 'src/arrays.rs', lines 320:0-320:42 -/
+def sum_mut_slice (a : Slice U32) : Result (U32 × (Slice U32)) :=
+  do
+  let i ← sum_mut_slice_loop a 0#usize 0#u32
+  Result.ret (i, a)
+
 end arrays

--- a/tests/lean/Loops.lean
+++ b/tests/lean/Loops.lean
@@ -557,4 +557,59 @@ def list_nth_shared_mut_loop_pair_merge
   let (p, back_'a) ← list_nth_shared_mut_loop_pair_merge_loop T ls0 ls1 i
   Result.ret (p, back_'a)
 
+/- [loops::ignore_input_mut_borrow]: loop 0:
+   Source: 'src/loops.rs', lines 345:0-349:1 -/
+divergent def ignore_input_mut_borrow_loop (i : U32) : Result Unit :=
+  if i > 0#u32
+  then
+    do
+    let i1 ← i - 1#u32
+    let _ ← ignore_input_mut_borrow_loop i1
+    Result.ret ()
+  else Result.ret ()
+
+/- [loops::ignore_input_mut_borrow]:
+   Source: 'src/loops.rs', lines 345:0-345:56 -/
+def ignore_input_mut_borrow (_a : U32) (i : U32) : Result U32 :=
+  do
+  let _ ← ignore_input_mut_borrow_loop i
+  Result.ret _a
+
+/- [loops::incr_ignore_input_mut_borrow]: loop 0:
+   Source: 'src/loops.rs', lines 353:0-358:1 -/
+divergent def incr_ignore_input_mut_borrow_loop (i : U32) : Result Unit :=
+  if i > 0#u32
+  then
+    do
+    let i1 ← i - 1#u32
+    let _ ← incr_ignore_input_mut_borrow_loop i1
+    Result.ret ()
+  else Result.ret ()
+
+/- [loops::incr_ignore_input_mut_borrow]:
+   Source: 'src/loops.rs', lines 353:0-353:60 -/
+def incr_ignore_input_mut_borrow (a : U32) (i : U32) : Result U32 :=
+  do
+  let a1 ← a + 1#u32
+  let _ ← incr_ignore_input_mut_borrow_loop i
+  Result.ret a1
+
+/- [loops::ignore_input_shared_borrow]: loop 0:
+   Source: 'src/loops.rs', lines 362:0-366:1 -/
+divergent def ignore_input_shared_borrow_loop (i : U32) : Result Unit :=
+  if i > 0#u32
+  then
+    do
+    let i1 ← i - 1#u32
+    let _ ← ignore_input_shared_borrow_loop i1
+    Result.ret ()
+  else Result.ret ()
+
+/- [loops::ignore_input_shared_borrow]:
+   Source: 'src/loops.rs', lines 362:0-362:59 -/
+def ignore_input_shared_borrow (_a : U32) (i : U32) : Result U32 :=
+  do
+  let _ ← ignore_input_shared_borrow_loop i
+  Result.ret _a
+
 end loops


### PR DESCRIPTION
This PR addresses https://github.com/AeneasVerif/aeneas/issues/69

There were two issues:
- when computing loop fixed points, I did not set some values to `⊥` before unifying environments. It was sound, but caused the fixed-point computation to fail in many situations where it should have succeeded (because unification failed).
- there was an improper handling of borrows which were not used inside of loop bodies (once again, it was sound, but led to failures)

I added some tests in a companion PR in Charon (https://github.com/AeneasVerif/charon/pull/81) to exercise some of the problematic patterns.