### PR TITLE
backend(/tests)/lean: 4.6.0-rc1 → 4.6.1

### DIFF
--- a/backends/lean/lean-toolchain
+++ b/backends/lean/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:v4.6.0-rc1
+leanprover/lean4:v4.6.1

--- a/tests/lean/lean-toolchain
+++ b/tests/lean/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:v4.6.0-rc1
+leanprover/lean4:v4.6.1


### PR DESCRIPTION
4.6.0 has been released in https://github.com/leanprover/lean4/releases/tag/v4.6.0.