### PR TITLE
Update the initial configuration

### DIFF
--- a/compiler/Config.ml
+++ b/compiler/Config.ml
@@ -368,4 +368,4 @@ let backend_has_tuple_projectors () =
 let use_nested_tuple_projectors = ref false
 
 (** Generate name patterns for the external definitions we encounter *)
-let extract_external_name_patterns = ref false
+let extract_external_name_patterns = ref true

--- a/compiler/Main.ml
+++ b/compiler/Main.ml
@@ -120,9 +120,6 @@ let () =
         Arg.Set use_nested_tuple_projectors,
         " Use nested projectors for tuples (e.g., (0, 1).snd.fst instead of \
          (0, 1).1)." );
-      ( "-ext-name-pats",
-        Arg.Set extract_external_name_patterns,
-        " Generate name patterns for the external definitions we find." );
     ]
   in
 


### PR DESCRIPTION
This PR updates the initial configuration so that we generate by default the name patterns for the external definitions.