### PR TITLE
Update flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -153,7 +153,14 @@
           default = aeneas;
         };
         devShells.default = pkgs.mkShell {
+          # By default, tests run some sanity checks which are pretty slow.
+          # This disables these checks when developping locally.
+          OPTIONS = "";
+
           packages = [
+            pkgs.ocamlPackages.ocaml
+            pkgs.ocamlPackages.ocamlformat
+            pkgs.ocamlPackages.menhir
             pkgs.ocamlPackages.odoc
           ];
 


### PR DESCRIPTION
It was missing some dependencies, and while we're at it we can disable sanity checks in tests.