### PR TITLE
Trust rustc regarding `Copy` bounds

### DIFF
--- a/compiler/InterpreterExpressions.ml
+++ b/compiler/InterpreterExpressions.ml
@@ -146,7 +146,7 @@ let rec copy_value (meta : Meta.meta) (allow_adt_copy : bool) (config : config)
             "Can't copy an assumed value other than Option"
       | TAdt (TAdtId _, _) as ty ->
           sanity_check __FILE__ __LINE__
-            (allow_adt_copy || ty_is_primitively_copyable ty)
+            (allow_adt_copy || ty_is_copyable ty)
             meta
       | TAdt (TTuple, _) -> () (* Ok *)
       | TAdt
@@ -158,7 +158,7 @@ let rec copy_value (meta : Meta.meta) (allow_adt_copy : bool) (config : config)
               trait_refs = [];
             } ) ->
           exec_assert __FILE__ __LINE__
-            (ty_is_primitively_copyable ty)
+            (ty_is_copyable ty)
             meta "The type is not primitively copyable"
       | _ -> exec_raise __FILE__ __LINE__ meta "Unreachable");
       let ctx, fields =
@@ -195,7 +195,7 @@ let rec copy_value (meta : Meta.meta) (allow_adt_copy : bool) (config : config)
        * thus requires calling the proper function. Here, we copy values
        * for very simple types such as integers, shared borrows, etc. *)
       cassert __FILE__ __LINE__
-        (ty_is_primitively_copyable (Substitute.erase_regions sp.sv_ty))
+        (ty_is_copyable (Substitute.erase_regions sp.sv_ty))
         meta "Not primitively copyable";
       (* If the type is copyable, we simply return the current value. Side
        * remark: what is important to look at when copying symbolic values
@@ -529,7 +529,7 @@ let eval_binary_op_concrete_compute (meta : Meta.meta) (binop : binop)
       "The arguments given to the binop don't have the same type";
     (* Equality/inequality check is primitive only for a subset of types *)
     exec_assert __FILE__ __LINE__
-      (ty_is_primitively_copyable v1.ty)
+      (ty_is_copyable v1.ty)
       meta "Type is not primitively copyable";
     let b = v1 = v2 in
     Ok { value = VLiteral (VBool b); ty = TLiteral TBool })
@@ -622,7 +622,7 @@ let eval_binary_op_symbolic (config : config) (meta : Meta.meta) (binop : binop)
         sanity_check __FILE__ __LINE__ (v1.ty = v2.ty) meta;
         (* Equality/inequality check is primitive only for a subset of types *)
         exec_assert __FILE__ __LINE__
-          (ty_is_primitively_copyable v1.ty)
+          (ty_is_copyable v1.ty)
           meta "The type is not primitively copyable";
         TLiteral TBool)
       else

--- a/compiler/Invariants.ml
+++ b/compiler/Invariants.ml
@@ -825,7 +825,7 @@ let check_symbolic_values (meta : Meta.meta) (ctx : eval_ctx) : unit =
      * it must be expanded first *)
     if ty_has_borrows ctx.type_ctx.type_infos info.ty then
       sanity_check __FILE__ __LINE__ (info.env_count <= 1) meta;
-    (* A duplicated symbolic value is necessarily primitively copyable *)
+    (* A duplicated symbolic value is necessarily copyable *)
     sanity_check __FILE__ __LINE__
       (info.env_count <= 1 || ty_is_copyable info.ty)
       meta;

--- a/compiler/Invariants.ml
+++ b/compiler/Invariants.ml
@@ -827,7 +827,7 @@ let check_symbolic_values (meta : Meta.meta) (ctx : eval_ctx) : unit =
       sanity_check __FILE__ __LINE__ (info.env_count <= 1) meta;
     (* A duplicated symbolic value is necessarily primitively copyable *)
     sanity_check __FILE__ __LINE__
-      (info.env_count <= 1 || ty_is_primitively_copyable info.ty)
+      (info.env_count <= 1 || ty_is_copyable info.ty)
       meta;
 
     sanity_check __FILE__ __LINE__

--- a/compiler/ValuesUtils.ml
+++ b/compiler/ValuesUtils.ml
@@ -160,7 +160,7 @@ let find_first_primitively_copyable_sv_with_borrows
 
       method! visit_VSymbolic _ sv =
         let ty = sv.sv_ty in
-        if ty_is_primitively_copyable ty && ty_has_borrows type_infos ty then
+        if ty_is_copyable ty && ty_has_borrows type_infos ty then
           raise (FoundSymbolicValue sv)
         else ()
     end

--- a/flake.lock
+++ b/flake.lock
@@ -8,16 +8,15 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1712760963,
-        "narHash": "sha256-KV8ZSHfnAn9bx1JA4k7Vj8yntfxMjjqIH05yHV9IDH0=",
+        "lastModified": 1712825631,
+        "narHash": "sha256-YC0QArtso4Z9iBgd63FXHsSopMtWof0kC7ZrYpE6yzg=",
         "owner": "aeneasverif",
         "repo": "charon",
-        "rev": "763aa8c3d308be619829939170af93624e4561f4",
+        "rev": "657de2521c285401d706ec69d588bb5778b18109",
         "type": "github"
       },
       "original": {
         "owner": "aeneasverif",
-        "ref": "generic-copy",
         "repo": "charon",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -8,15 +8,16 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1712233083,
-        "narHash": "sha256-KR4UwlgUzLWObSzQ1LIKITjRrYe4AuZXdvCK78qrip8=",
+        "lastModified": 1712760963,
+        "narHash": "sha256-KV8ZSHfnAn9bx1JA4k7Vj8yntfxMjjqIH05yHV9IDH0=",
         "owner": "aeneasverif",
         "repo": "charon",
-        "rev": "6e31313fdfd4830aa0fc795f6ab8b27600fcbbfb",
+        "rev": "763aa8c3d308be619829939170af93624e4561f4",
         "type": "github"
       },
       "original": {
         "owner": "aeneasverif",
+        "ref": "generic-copy",
         "repo": "charon",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -4,7 +4,7 @@
   inputs = {
     # Remark: when adding inputs here, don't forget to also add them in the list
     # of outputs below!
-    charon.url = "github:aeneasverif/charon";
+    charon.url = "github:aeneasverif/charon/generic-copy";
     flake-utils.follows = "charon/flake-utils";
     nixpkgs.follows = "charon/nixpkgs";
     hacl-nix.url = "github:hacl-star/hacl-nix";

--- a/flake.nix
+++ b/flake.nix
@@ -4,7 +4,7 @@
   inputs = {
     # Remark: when adding inputs here, don't forget to also add them in the list
     # of outputs below!
-    charon.url = "github:aeneasverif/charon/generic-copy";
+    charon.url = "github:aeneasverif/charon";
     flake-utils.follows = "charon/flake-utils";
     nixpkgs.follows = "charon/nixpkgs";
     hacl-nix.url = "github:hacl-star/hacl-nix";


### PR DESCRIPTION
Rustc's type checking guarantees that any `copy(..)` in LLBC applies to a type that has the `Copy` bound. Because `copy(..)` means "copying just the bits", there is no need to find the corresponding `Copy` implementation either, so https://github.com/AeneasVerif/charon/pull/111 makes `ty_is_copyable` always return `true`.

This bumps charon to https://github.com/AeneasVerif/charon/pull/111.

Fixes https://github.com/AeneasVerif/aeneas/issues/118