### PR TITLE
Fix CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,10 @@ clean:
 
 # Test the project by translating test files to F*
 .PHONY: test
-test: build-dev test-no_nested_borrows test-paper \
+test: build-dev test-all
+
+.PHONY: test-all
+test-all: test-no_nested_borrows test-paper \
 	test-hashmap test-hashmap_main \
 	test-external test-constants \
 	testp-polonius_list testp-betree_main \

--- a/flake.nix
+++ b/flake.nix
@@ -82,7 +82,7 @@
             # files like lakefile.lean, and the user hand-written files)
 
             # Run the tests - remark: we could remove the file
-            make tests -j $NIX_BUILD_CORES
+            make test-all -j $NIX_BUILD_CORES
 
             # Check that there are no differences between the generated tests
             # and the original tests


### PR DESCRIPTION
`flake.nix` tried to run `make tests`, which doesn't exist (it's `make test` since https://github.com/AeneasVerif/aeneas/pull/93). This resulted in "nothing to be done for `tests`", which didn't error because there is a directory called `tests` x))