### PR TITLE
compiler: map `core::option::Option::is_none` to `Option.isNone`

### DIFF
--- a/compiler/ExtractBuiltin.ml
+++ b/compiler/ExtractBuiltin.ml
@@ -290,6 +290,9 @@ let builtin_funs () : (pattern * bool list option * builtin_fun_info) list =
     mk_fun "core::slice::{[@T]}::len"
       (Some (backend_choice "slice::len" "Slice::len"))
       None;
+    mk_fun "core::option::{core::option::Option<@T>}::is_none"
+      (Some (backend_choice "option::is_none" "Option::isNone"))
+      (Some [ false ]);
     mk_fun "alloc::vec::{alloc::vec::Vec<@T, alloc::alloc::Global>}::new"
       (Some "alloc::vec::Vec::new") None;
     mk_fun "alloc::vec::{alloc::vec::Vec<@T, @A>}::push" None
@@ -515,6 +518,7 @@ let builtin_fun_effects =
       "alloc::vec::{alloc::vec::Vec<@T, @A>}::len";
       "core::mem::replace";
       "core::mem::take";
+      "core::option::{core::option::Option<@T>}::is_none";
       "core::clone::impls::{core::clone::Clone<bool>}::clone";
       "alloc::vec::{alloc::vec::Vec<@T, alloc::alloc::Global>}::with_capacity";
       "core::slice::{[@T]}::reverse";


### PR DESCRIPTION
This adds support for `Option.is_none` in Rust code which needs to be mapped to its backend equivalent.

Fixes #138.