### PR TITLE
compiler: map `core::mem::swap` to the pure swap

### DIFF
--- a/backends/lean/Base/Primitives/Base.lean
+++ b/backends/lean/Base/Primitives/Base.lean
@@ -130,6 +130,8 @@ def Result.attach {α: Type} (o : Result α): Result { x : α // o = ok x } :=
 ----------
 
 @[simp] def core.mem.replace (a : Type) (x : a) (_ : a) : a × a := (x, x)
+/- [core::mem::swap] -/
+@[simp] def core.mem.swap (T: Type) (a b: T): T × T := (b, a)
 
 /-- Aeneas-translated function -- useful to reduce non-recursive definitions.
  Use with `simp [ aeneas ]` -/

--- a/compiler/ExtractBuiltin.ml
+++ b/compiler/ExtractBuiltin.ml
@@ -287,6 +287,7 @@ let builtin_funs () : (pattern * bool list option * builtin_fun_info) list =
   in
   [
     mk_fun "core::mem::replace" None None;
+    mk_fun "core::mem::swap" None None;
     mk_fun "core::slice::{[@T]}::len"
       (Some (backend_choice "slice::len" "Slice::len"))
       None;
@@ -514,6 +515,7 @@ let builtin_fun_effects =
       "alloc::vec::{alloc::vec::Vec<@T, alloc::alloc::Global>}::new";
       "alloc::vec::{alloc::vec::Vec<@T, @A>}::len";
       "core::mem::replace";
+      "core::mem::swap";
       "core::mem::take";
       "core::clone::impls::{core::clone::Clone<bool>}::clone";
       "alloc::vec::{alloc::vec::Vec<@T, alloc::alloc::Global>}::with_capacity";


### PR DESCRIPTION
In the pure functional model, `swap` is mostly about borrow checking and should simplify to the pure swap in our backends.

Other backends than Lean are not done in this commit.

Fixes #137.