### PR TITLE
feat(nix): support non-Flakes users

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,16 @@
+# This file provides backward compatibility to nix < 2.4 clients
+{ system ? builtins.currentSystem }:
+let
+  lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+
+  inherit (lock.nodes.flake-compat.locked) owner repo rev narHash;
+
+  flake-compat = fetchTarball {
+    url = "https://github.com/${owner}/${repo}/archive/${rev}.tar.gz";
+    sha256 = narHash;
+  };
+
+  flake = import flake-compat { inherit system; src = ./.; };
+in
+flake.defaultNix
+

--- a/flake.lock
+++ b/flake.lock
@@ -42,6 +42,21 @@
         "type": "github"
       }
     },
+    "flake-compat": {
+      "locked": {
+        "lastModified": 1688025799,
+        "narHash": "sha256-ktpB4dRtnksm9F5WawoIkEneh1nrEvuxb5lJFt1iOyw=",
+        "owner": "nix-community",
+        "repo": "flake-compat",
+        "rev": "8bf105319d44f6b9f0d764efa4fdef9f1cc9ba1c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -221,6 +236,7 @@
     "root": {
       "inputs": {
         "charon": "charon",
+        "flake-compat": "flake-compat",
         "flake-utils": [
           "charon",
           "flake-utils"

--- a/flake.nix
+++ b/flake.nix
@@ -8,11 +8,12 @@
     flake-utils.follows = "charon/flake-utils";
     nixpkgs.follows = "charon/nixpkgs";
     hacl-nix.url = "github:hacl-star/hacl-nix";
+    flake-compat.url = "github:nix-community/flake-compat";
   };
 
   # Remark: keep the list of outputs in sync with the list of inputs above
   # (see above remark)
-  outputs = { self, charon, flake-utils, nixpkgs, hacl-nix }:
+  outputs = { self, charon, flake-utils, nixpkgs, hacl-nix, flake-compat }:
     flake-utils.lib.eachSystem [ "x86_64-linux" ] (system:
       let
         pkgs = import nixpkgs { inherit system; };

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,16 @@
+# This file provides backward compatibility to nix < 2.4 clients
+{ system ? builtins.currentSystem }:
+let
+  lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+
+  inherit (lock.nodes.flake-compat.locked) owner repo rev narHash;
+
+  flake-compat = fetchTarball {
+    url = "https://github.com/${owner}/${repo}/archive/${rev}.tar.gz";
+    sha256 = narHash;
+  };
+
+  flake = import flake-compat { inherit system; src = ./.; };
+in
+flake.shellNix
+


### PR DESCRIPTION
Not all Nix users can make use of Flakes.

This adds the compatibility for non-Flakes users.