### PR TITLE
Use eachDefaultSystem in flake.nix, update charon in flake.lock

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -14,7 +14,7 @@
   # Remark: keep the list of outputs in sync with the list of inputs above
   # (see above remark)
   outputs = { self, charon, flake-utils, nixpkgs, hacl-nix, flake-compat }:
-    flake-utils.lib.eachSystem [ "x86_64-linux" ] (system:
+    flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = import nixpkgs { inherit system; };
         ocamlPackages = pkgs.ocamlPackages;


### PR DESCRIPTION
These changes enable MacOS (and potentially other platforms) to build Aeneas via nix (I need to use this workflow because my OCaml installation is horribly broken somehow).