### PR TITLE
feat(backend/lean): Raw Lean literals can be parsed into scalars automatically

### DIFF
--- a/backends/lean/Base/Primitives/Scalar.lean
+++ b/backends/lean/Base/Primitives/Scalar.lean
@@ -332,6 +332,11 @@ instance [Decide (Scalar.cMin ty ≤ v ∧ v ≤ Scalar.cMax ty)] : InBounds ty 
 @[simp] abbrev Scalar.check_bounds (ty : ScalarTy) (x : Int) : Bool :=
   (Scalar.cMin ty ≤ x || Scalar.min ty ≤ x) ∧ (x ≤ Scalar.cMax ty || x ≤ Scalar.max ty)
 
+-- TODO(raitobezarius): the inbounds constraint is a bit ugly as we can pretty trivially
+-- discharge the lhs on ≥ 0.
+instance {ty: ScalarTy} [InBounds ty (Int.ofNat n)]: OfNat (Scalar ty) (n: ℕ) where
+  ofNat := Scalar.ofInt n
+
 theorem Scalar.check_bounds_imp_in_bounds {ty : ScalarTy} {x : Int}
   (h: Scalar.check_bounds ty x) :
   Scalar.in_bounds ty x := by


### PR DESCRIPTION
We can use coercion to go to integers, build a scalar out of an int via
unification and let the user clear up bounds or let Lean decide them.

Untested yet.

Signed-off-by: Ryan Lahfa <ryan.lahfa@inria.fr>
