### PR TITLE
Propagate handling of (unsupported) mutually recursive trait declarations

### DIFF
--- a/compiler/Translate.ml
+++ b/compiler/Translate.ml
@@ -798,7 +798,10 @@ let extract_definitions (fmt : Format.formatter) (config : gen_config)
         (* Translate *)
         export_functions_group pure_funs
     | GlobalGroup id -> export_global id
-    | TraitDeclGroup id ->
+    | TraitDeclGroup (RecGroup _ids) ->
+        craise_opt_meta __FILE__ __LINE__ None
+          "Mutually recursive trait declarations are not supported"
+    | TraitDeclGroup (NonRecGroup id) ->
         (* TODO: update to extract groups *)
         if config.extract_trait_decls && config.extract_transparent then (
           export_trait_decl_group id;

--- a/flake.lock
+++ b/flake.lock
@@ -9,11 +9,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1714483898,
-        "narHash": "sha256-R9c3HgcKZQq6VF7ZBjidiJTtxB2mYNJYxctD1JI7As0=",
+        "lastModified": 1715000450,
+        "narHash": "sha256-N7VGgAwoMeSEYblcKzo7TZWv6upuJdknrnZO1ZSwJWQ=",
         "owner": "aeneasverif",
         "repo": "charon",
-        "rev": "eb48f4a62ce7c330d44c1e3c870b2a7271bba73b",
+        "rev": "f8fab8d2f4f279f973057d0f7f58c2fd59146e30",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Companion PR of https://github.com/AeneasVerif/charon/pull/160

This PR propagates the extension of mutually recursive traits in Charon, now raising an error in Aeneas during translation as this feature is currently unsupported.

Marking this as draft for now for two reasons:
* The error reporting should likely be enhanced with meta information, however, I am not sure how to retrieve it in the current context (hence the temporary use of `craise_meta_opt`)
* As I extended the Charon traits tests with mutually recursive trait declarations, this leads to failures in Aeneas when running `make tests`. Maybe a better way is to split the Charon test file into what is supported and unsupported in Aeneas?