### PR TITLE
Downgrade the version of dune used in the test runner

### DIFF
--- a/tests/test_runner/dune-project
+++ b/tests/test_runner/dune-project
@@ -1,4 +1,4 @@
-(lang dune 3.12)
+(lang dune 3.7)
 
 (name aeneas_test_runner)
 


### PR DESCRIPTION
We don't need dune 3.12 for the test runner, and the compiler actually uses 3.7