### PR TITLE
Add magic comments to test runner

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,10 +159,6 @@ verify:
 INPUTS_LIST = $(wildcard $(INPUTS_DIR)/*)
 # Remove the directory prefix, replace with `test-`
 INPUTS_LIST := $(subst $(INPUTS_DIR)/,test-,$(INPUTS_LIST))
-# Remove some tests we don't want to run.
-# FIXME: move this information to the file itself
-INPUTS_LIST := $(filter-out test-hashmap_utils.rs,$(INPUTS_LIST))
-INPUTS_LIST := $(filter-out test-nested_borrows.rs,$(INPUTS_LIST))
 
 # Run all the tests we found.
 .PHONY: test-all

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,12 @@ build-test-verify: build test verify
 
 # Build the project, without formatting the code
 .PHONY: build-dev
+ifdef IN_CI
+build-dev:
+	@true
+else
 build-dev: build-bin build-lib build-bin-dir doc
+endif
 
 .PHONY: build-bin
 build-bin: check-charon
@@ -166,14 +171,13 @@ test-all: $(INPUTS_LIST)
 ifdef IN_CI
 # In CI we do extra sanity checks.
 test-%: AENEAS_OPTIONS += -checks
-else
-test-%: check-charon
 endif
 
 # Translate the given rust file to available backends. The test runner decides
 # which backends to use and sets test-specific options.
+# Note: the tests have the fulle file name: `test-arrays.rs`, `test-loops.rs`, `test-betree`.
 .PHONY: test-%
-test-%:
+test-%: build-dev
 	$(TEST_RUNNER_EXE) $(CHARON_EXE) $(AENEAS_EXE) $(LLBC_DIR) $(INPUTS_DIR)/"$*" $(AENEAS_OPTIONS)
 	echo "# Test $* done"
 

--- a/flake.nix
+++ b/flake.nix
@@ -80,6 +80,7 @@
           OCAMLPARAM = "_,warn-error=+A"; # Turn all warnings into errors.
           propagatedBuildInputs = (with ocamlPackages; [
             core_unix
+            ppx_deriving
           ]);
         };
 

--- a/tests/coq/arrays/Arrays.v
+++ b/tests/coq/arrays/Arrays.v
@@ -9,23 +9,23 @@ Local Open Scope Primitives_scope.
 Module Arrays.
 
 (** [arrays::AB]
-    Source: 'tests/src/arrays.rs', lines 3:0-3:11 *)
+    Source: 'tests/src/arrays.rs', lines 6:0-6:11 *)
 Inductive AB_t := | AB_A : AB_t | AB_B : AB_t.
 
 (** [arrays::incr]:
-    Source: 'tests/src/arrays.rs', lines 8:0-8:24 *)
+    Source: 'tests/src/arrays.rs', lines 11:0-11:24 *)
 Definition incr (x : u32) : result u32 :=
   u32_add x 1%u32.
 
 (** [arrays::array_to_shared_slice_]:
-    Source: 'tests/src/arrays.rs', lines 16:0-16:53 *)
+    Source: 'tests/src/arrays.rs', lines 19:0-19:53 *)
 Definition array_to_shared_slice_
   (T : Type) (s : array T 32%usize) : result (slice T) :=
   array_to_slice T 32%usize s
 .
 
 (** [arrays::array_to_mut_slice_]:
-    Source: 'tests/src/arrays.rs', lines 21:0-21:58 *)
+    Source: 'tests/src/arrays.rs', lines 24:0-24:58 *)
 Definition array_to_mut_slice_
   (T : Type) (s : array T 32%usize) :
   result ((slice T) * (slice T -> result (array T 32%usize)))
@@ -34,44 +34,44 @@ Definition array_to_mut_slice_
 .
 
 (** [arrays::array_len]:
-    Source: 'tests/src/arrays.rs', lines 25:0-25:40 *)
+    Source: 'tests/src/arrays.rs', lines 28:0-28:40 *)
 Definition array_len (T : Type) (s : array T 32%usize) : result usize :=
   s1 <- array_to_slice T 32%usize s; Ok (slice_len T s1)
 .
 
 (** [arrays::shared_array_len]:
-    Source: 'tests/src/arrays.rs', lines 29:0-29:48 *)
+    Source: 'tests/src/arrays.rs', lines 32:0-32:48 *)
 Definition shared_array_len (T : Type) (s : array T 32%usize) : result usize :=
   s1 <- array_to_slice T 32%usize s; Ok (slice_len T s1)
 .
 
 (** [arrays::shared_slice_len]:
-    Source: 'tests/src/arrays.rs', lines 33:0-33:44 *)
+    Source: 'tests/src/arrays.rs', lines 36:0-36:44 *)
 Definition shared_slice_len (T : Type) (s : slice T) : result usize :=
   Ok (slice_len T s)
 .
 
 (** [arrays::index_array_shared]:
-    Source: 'tests/src/arrays.rs', lines 37:0-37:57 *)
+    Source: 'tests/src/arrays.rs', lines 40:0-40:57 *)
 Definition index_array_shared
   (T : Type) (s : array T 32%usize) (i : usize) : result T :=
   array_index_usize T 32%usize s i
 .
 
 (** [arrays::index_array_u32]:
-    Source: 'tests/src/arrays.rs', lines 44:0-44:53 *)
+    Source: 'tests/src/arrays.rs', lines 47:0-47:53 *)
 Definition index_array_u32 (s : array u32 32%usize) (i : usize) : result u32 :=
   array_index_usize u32 32%usize s i
 .
 
 (** [arrays::index_array_copy]:
-    Source: 'tests/src/arrays.rs', lines 48:0-48:45 *)
+    Source: 'tests/src/arrays.rs', lines 51:0-51:45 *)
 Definition index_array_copy (x : array u32 32%usize) : result u32 :=
   array_index_usize u32 32%usize x 0%usize
 .
 
 (** [arrays::index_mut_array]:
-    Source: 'tests/src/arrays.rs', lines 52:0-52:62 *)
+    Source: 'tests/src/arrays.rs', lines 55:0-55:62 *)
 Definition index_mut_array
   (T : Type) (s : array T 32%usize) (i : usize) :
   result (T * (T -> result (array T 32%usize)))
@@ -80,13 +80,13 @@ Definition index_mut_array
 .
 
 (** [arrays::index_slice]:
-    Source: 'tests/src/arrays.rs', lines 56:0-56:46 *)
+    Source: 'tests/src/arrays.rs', lines 59:0-59:46 *)
 Definition index_slice (T : Type) (s : slice T) (i : usize) : result T :=
   slice_index_usize T s i
 .
 
 (** [arrays::index_mut_slice]:
-    Source: 'tests/src/arrays.rs', lines 60:0-60:58 *)
+    Source: 'tests/src/arrays.rs', lines 63:0-63:58 *)
 Definition index_mut_slice
   (T : Type) (s : slice T) (i : usize) :
   result (T * (T -> result (slice T)))
@@ -95,7 +95,7 @@ Definition index_mut_slice
 .
 
 (** [arrays::slice_subslice_shared_]:
-    Source: 'tests/src/arrays.rs', lines 64:0-64:70 *)
+    Source: 'tests/src/arrays.rs', lines 67:0-67:70 *)
 Definition slice_subslice_shared_
   (x : slice u32) (y : usize) (z : usize) : result (slice u32) :=
   core_slice_index_Slice_index u32 (core_ops_range_Range usize)
@@ -104,7 +104,7 @@ Definition slice_subslice_shared_
 .
 
 (** [arrays::slice_subslice_mut_]:
-    Source: 'tests/src/arrays.rs', lines 68:0-68:75 *)
+    Source: 'tests/src/arrays.rs', lines 71:0-71:75 *)
 Definition slice_subslice_mut_
   (x : slice u32) (y : usize) (z : usize) :
   result ((slice u32) * (slice u32 -> result (slice u32)))
@@ -118,14 +118,14 @@ Definition slice_subslice_mut_
 .
 
 (** [arrays::array_to_slice_shared_]:
-    Source: 'tests/src/arrays.rs', lines 72:0-72:54 *)
+    Source: 'tests/src/arrays.rs', lines 75:0-75:54 *)
 Definition array_to_slice_shared_
   (x : array u32 32%usize) : result (slice u32) :=
   array_to_slice u32 32%usize x
 .
 
 (** [arrays::array_to_slice_mut_]:
-    Source: 'tests/src/arrays.rs', lines 76:0-76:59 *)
+    Source: 'tests/src/arrays.rs', lines 79:0-79:59 *)
 Definition array_to_slice_mut_
   (x : array u32 32%usize) :
   result ((slice u32) * (slice u32 -> result (array u32 32%usize)))
@@ -134,7 +134,7 @@ Definition array_to_slice_mut_
 .
 
 (** [arrays::array_subslice_shared_]:
-    Source: 'tests/src/arrays.rs', lines 80:0-80:74 *)
+    Source: 'tests/src/arrays.rs', lines 83:0-83:74 *)
 Definition array_subslice_shared_
   (x : array u32 32%usize) (y : usize) (z : usize) : result (slice u32) :=
   core_array_Array_index u32 (core_ops_range_Range usize) 32%usize
@@ -144,7 +144,7 @@ Definition array_subslice_shared_
 .
 
 (** [arrays::array_subslice_mut_]:
-    Source: 'tests/src/arrays.rs', lines 84:0-84:79 *)
+    Source: 'tests/src/arrays.rs', lines 87:0-87:79 *)
 Definition array_subslice_mut_
   (x : array u32 32%usize) (y : usize) (z : usize) :
   result ((slice u32) * (slice u32 -> result (array u32 32%usize)))
@@ -159,19 +159,19 @@ Definition array_subslice_mut_
 .
 
 (** [arrays::index_slice_0]:
-    Source: 'tests/src/arrays.rs', lines 88:0-88:38 *)
+    Source: 'tests/src/arrays.rs', lines 91:0-91:38 *)
 Definition index_slice_0 (T : Type) (s : slice T) : result T :=
   slice_index_usize T s 0%usize
 .
 
 (** [arrays::index_array_0]:
-    Source: 'tests/src/arrays.rs', lines 92:0-92:42 *)
+    Source: 'tests/src/arrays.rs', lines 95:0-95:42 *)
 Definition index_array_0 (T : Type) (s : array T 32%usize) : result T :=
   array_index_usize T 32%usize s 0%usize
 .
 
 (** [arrays::index_index_array]:
-    Source: 'tests/src/arrays.rs', lines 103:0-103:71 *)
+    Source: 'tests/src/arrays.rs', lines 106:0-106:71 *)
 Definition index_index_array
   (s : array (array u32 32%usize) 32%usize) (i : usize) (j : usize) :
   result u32
@@ -181,7 +181,7 @@ Definition index_index_array
 .
 
 (** [arrays::update_update_array]:
-    Source: 'tests/src/arrays.rs', lines 114:0-114:70 *)
+    Source: 'tests/src/arrays.rs', lines 117:0-117:70 *)
 Definition update_update_array
   (s : array (array u32 32%usize) 32%usize) (i : usize) (j : usize) :
   result unit
@@ -196,46 +196,46 @@ Definition update_update_array
 .
 
 (** [arrays::array_local_deep_copy]:
-    Source: 'tests/src/arrays.rs', lines 118:0-118:43 *)
+    Source: 'tests/src/arrays.rs', lines 121:0-121:43 *)
 Definition array_local_deep_copy (x : array u32 32%usize) : result unit :=
   Ok tt
 .
 
 (** [arrays::take_array]:
-    Source: 'tests/src/arrays.rs', lines 122:0-122:30 *)
+    Source: 'tests/src/arrays.rs', lines 125:0-125:30 *)
 Definition take_array (a : array u32 2%usize) : result unit :=
   Ok tt.
 
 (** [arrays::take_array_borrow]:
-    Source: 'tests/src/arrays.rs', lines 123:0-123:38 *)
+    Source: 'tests/src/arrays.rs', lines 126:0-126:38 *)
 Definition take_array_borrow (a : array u32 2%usize) : result unit :=
   Ok tt.
 
 (** [arrays::take_slice]:
-    Source: 'tests/src/arrays.rs', lines 124:0-124:28 *)
+    Source: 'tests/src/arrays.rs', lines 127:0-127:28 *)
 Definition take_slice (s : slice u32) : result unit :=
   Ok tt.
 
 (** [arrays::take_mut_slice]:
-    Source: 'tests/src/arrays.rs', lines 125:0-125:36 *)
+    Source: 'tests/src/arrays.rs', lines 128:0-128:36 *)
 Definition take_mut_slice (s : slice u32) : result (slice u32) :=
   Ok s.
 
 (** [arrays::const_array]:
-    Source: 'tests/src/arrays.rs', lines 127:0-127:32 *)
+    Source: 'tests/src/arrays.rs', lines 130:0-130:32 *)
 Definition const_array : result (array u32 2%usize) :=
   Ok (mk_array u32 2%usize [ 0%u32; 0%u32 ])
 .
 
 (** [arrays::const_slice]:
-    Source: 'tests/src/arrays.rs', lines 131:0-131:20 *)
+    Source: 'tests/src/arrays.rs', lines 134:0-134:20 *)
 Definition const_slice : result unit :=
   _ <- array_to_slice u32 2%usize (mk_array u32 2%usize [ 0%u32; 0%u32 ]);
   Ok tt
 .
 
 (** [arrays::take_all]:
-    Source: 'tests/src/arrays.rs', lines 141:0-141:17 *)
+    Source: 'tests/src/arrays.rs', lines 144:0-144:17 *)
 Definition take_all : result unit :=
   _ <- take_array (mk_array u32 2%usize [ 0%u32; 0%u32 ]);
   _ <- take_array (mk_array u32 2%usize [ 0%u32; 0%u32 ]);
@@ -250,32 +250,32 @@ Definition take_all : result unit :=
 .
 
 (** [arrays::index_array]:
-    Source: 'tests/src/arrays.rs', lines 155:0-155:38 *)
+    Source: 'tests/src/arrays.rs', lines 158:0-158:38 *)
 Definition index_array (x : array u32 2%usize) : result u32 :=
   array_index_usize u32 2%usize x 0%usize
 .
 
 (** [arrays::index_array_borrow]:
-    Source: 'tests/src/arrays.rs', lines 158:0-158:46 *)
+    Source: 'tests/src/arrays.rs', lines 161:0-161:46 *)
 Definition index_array_borrow (x : array u32 2%usize) : result u32 :=
   array_index_usize u32 2%usize x 0%usize
 .
 
 (** [arrays::index_slice_u32_0]:
-    Source: 'tests/src/arrays.rs', lines 162:0-162:42 *)
+    Source: 'tests/src/arrays.rs', lines 165:0-165:42 *)
 Definition index_slice_u32_0 (x : slice u32) : result u32 :=
   slice_index_usize u32 x 0%usize
 .
 
 (** [arrays::index_mut_slice_u32_0]:
-    Source: 'tests/src/arrays.rs', lines 166:0-166:50 *)
+    Source: 'tests/src/arrays.rs', lines 169:0-169:50 *)
 Definition index_mut_slice_u32_0
   (x : slice u32) : result (u32 * (slice u32)) :=
   i <- slice_index_usize u32 x 0%usize; Ok (i, x)
 .
 
 (** [arrays::index_all]:
-    Source: 'tests/src/arrays.rs', lines 170:0-170:25 *)
+    Source: 'tests/src/arrays.rs', lines 173:0-173:25 *)
 Definition index_all : result u32 :=
   i <- index_array (mk_array u32 2%usize [ 0%u32; 0%u32 ]);
   i1 <- index_array (mk_array u32 2%usize [ 0%u32; 0%u32 ]);
@@ -295,7 +295,7 @@ Definition index_all : result u32 :=
 .
 
 (** [arrays::update_array]:
-    Source: 'tests/src/arrays.rs', lines 184:0-184:36 *)
+    Source: 'tests/src/arrays.rs', lines 187:0-187:36 *)
 Definition update_array (x : array u32 2%usize) : result unit :=
   p <- array_index_mut_usize u32 2%usize x 0%usize;
   let (_, index_mut_back) := p in
@@ -304,7 +304,7 @@ Definition update_array (x : array u32 2%usize) : result unit :=
 .
 
 (** [arrays::update_array_mut_borrow]:
-    Source: 'tests/src/arrays.rs', lines 187:0-187:48 *)
+    Source: 'tests/src/arrays.rs', lines 190:0-190:48 *)
 Definition update_array_mut_borrow
   (x : array u32 2%usize) : result (array u32 2%usize) :=
   p <- array_index_mut_usize u32 2%usize x 0%usize;
@@ -313,7 +313,7 @@ Definition update_array_mut_borrow
 .
 
 (** [arrays::update_mut_slice]:
-    Source: 'tests/src/arrays.rs', lines 190:0-190:38 *)
+    Source: 'tests/src/arrays.rs', lines 193:0-193:38 *)
 Definition update_mut_slice (x : slice u32) : result (slice u32) :=
   p <- slice_index_mut_usize u32 x 0%usize;
   let (_, index_mut_back) := p in
@@ -321,7 +321,7 @@ Definition update_mut_slice (x : slice u32) : result (slice u32) :=
 .
 
 (** [arrays::update_all]:
-    Source: 'tests/src/arrays.rs', lines 194:0-194:19 *)
+    Source: 'tests/src/arrays.rs', lines 197:0-197:19 *)
 Definition update_all : result unit :=
   _ <- update_array (mk_array u32 2%usize [ 0%u32; 0%u32 ]);
   _ <- update_array (mk_array u32 2%usize [ 0%u32; 0%u32 ]);
@@ -334,7 +334,7 @@ Definition update_all : result unit :=
 .
 
 (** [arrays::range_all]:
-    Source: 'tests/src/arrays.rs', lines 205:0-205:18 *)
+    Source: 'tests/src/arrays.rs', lines 208:0-208:18 *)
 Definition range_all : result unit :=
   p <-
     core_array_Array_index_mut u32 (core_ops_range_Range usize) 4%usize
@@ -352,31 +352,31 @@ Definition range_all : result unit :=
 .
 
 (** [arrays::deref_array_borrow]:
-    Source: 'tests/src/arrays.rs', lines 214:0-214:46 *)
+    Source: 'tests/src/arrays.rs', lines 217:0-217:46 *)
 Definition deref_array_borrow (x : array u32 2%usize) : result u32 :=
   array_index_usize u32 2%usize x 0%usize
 .
 
 (** [arrays::deref_array_mut_borrow]:
-    Source: 'tests/src/arrays.rs', lines 219:0-219:54 *)
+    Source: 'tests/src/arrays.rs', lines 222:0-222:54 *)
 Definition deref_array_mut_borrow
   (x : array u32 2%usize) : result (u32 * (array u32 2%usize)) :=
   i <- array_index_usize u32 2%usize x 0%usize; Ok (i, x)
 .
 
 (** [arrays::take_array_t]:
-    Source: 'tests/src/arrays.rs', lines 227:0-227:31 *)
+    Source: 'tests/src/arrays.rs', lines 230:0-230:31 *)
 Definition take_array_t (a : array AB_t 2%usize) : result unit :=
   Ok tt.
 
 (** [arrays::non_copyable_array]:
-    Source: 'tests/src/arrays.rs', lines 229:0-229:27 *)
+    Source: 'tests/src/arrays.rs', lines 232:0-232:27 *)
 Definition non_copyable_array : result unit :=
   take_array_t (mk_array AB_t 2%usize [ AB_A; AB_B ])
 .
 
 (** [arrays::sum]: loop 0:
-    Source: 'tests/src/arrays.rs', lines 242:0-250:1 *)
+    Source: 'tests/src/arrays.rs', lines 245:0-253:1 *)
 Fixpoint sum_loop
   (n : nat) (s : slice u32) (sum1 : u32) (i : usize) : result u32 :=
   match n with
@@ -394,13 +394,13 @@ Fixpoint sum_loop
 .
 
 (** [arrays::sum]:
-    Source: 'tests/src/arrays.rs', lines 242:0-242:28 *)
+    Source: 'tests/src/arrays.rs', lines 245:0-245:28 *)
 Definition sum (n : nat) (s : slice u32) : result u32 :=
   sum_loop n s 0%u32 0%usize
 .
 
 (** [arrays::sum2]: loop 0:
-    Source: 'tests/src/arrays.rs', lines 252:0-261:1 *)
+    Source: 'tests/src/arrays.rs', lines 255:0-264:1 *)
 Fixpoint sum2_loop
   (n : nat) (s : slice u32) (s2 : slice u32) (sum1 : u32) (i : usize) :
   result u32
@@ -422,7 +422,7 @@ Fixpoint sum2_loop
 .
 
 (** [arrays::sum2]:
-    Source: 'tests/src/arrays.rs', lines 252:0-252:41 *)
+    Source: 'tests/src/arrays.rs', lines 255:0-255:41 *)
 Definition sum2 (n : nat) (s : slice u32) (s2 : slice u32) : result u32 :=
   let i := slice_len u32 s in
   let i1 := slice_len u32 s2 in
@@ -430,7 +430,7 @@ Definition sum2 (n : nat) (s : slice u32) (s2 : slice u32) : result u32 :=
 .
 
 (** [arrays::f0]:
-    Source: 'tests/src/arrays.rs', lines 263:0-263:11 *)
+    Source: 'tests/src/arrays.rs', lines 266:0-266:11 *)
 Definition f0 : result unit :=
   p <- array_to_slice_mut u32 2%usize (mk_array u32 2%usize [ 1%u32; 2%u32 ]);
   let (s, to_slice_mut_back) := p in
@@ -442,7 +442,7 @@ Definition f0 : result unit :=
 .
 
 (** [arrays::f1]:
-    Source: 'tests/src/arrays.rs', lines 268:0-268:11 *)
+    Source: 'tests/src/arrays.rs', lines 271:0-271:11 *)
 Definition f1 : result unit :=
   p <-
     array_index_mut_usize u32 2%usize (mk_array u32 2%usize [ 1%u32; 2%u32 ])
@@ -453,12 +453,12 @@ Definition f1 : result unit :=
 .
 
 (** [arrays::f2]:
-    Source: 'tests/src/arrays.rs', lines 273:0-273:17 *)
+    Source: 'tests/src/arrays.rs', lines 276:0-276:17 *)
 Definition f2 (i : u32) : result unit :=
   Ok tt.
 
 (** [arrays::f4]:
-    Source: 'tests/src/arrays.rs', lines 282:0-282:54 *)
+    Source: 'tests/src/arrays.rs', lines 285:0-285:54 *)
 Definition f4
   (x : array u32 32%usize) (y : usize) (z : usize) : result (slice u32) :=
   core_array_Array_index u32 (core_ops_range_Range usize) 32%usize
@@ -468,7 +468,7 @@ Definition f4
 .
 
 (** [arrays::f3]:
-    Source: 'tests/src/arrays.rs', lines 275:0-275:18 *)
+    Source: 'tests/src/arrays.rs', lines 278:0-278:18 *)
 Definition f3 (n : nat) : result u32 :=
   i <-
     array_index_usize u32 2%usize (mk_array u32 2%usize [ 1%u32; 2%u32 ])
@@ -481,18 +481,18 @@ Definition f3 (n : nat) : result u32 :=
 .
 
 (** [arrays::SZ]
-    Source: 'tests/src/arrays.rs', lines 286:0-286:19 *)
+    Source: 'tests/src/arrays.rs', lines 289:0-289:19 *)
 Definition sz_body : result usize := Ok 32%usize.
 Definition sz : usize := sz_body%global.
 
 (** [arrays::f5]:
-    Source: 'tests/src/arrays.rs', lines 289:0-289:31 *)
+    Source: 'tests/src/arrays.rs', lines 292:0-292:31 *)
 Definition f5 (x : array u32 32%usize) : result u32 :=
   array_index_usize u32 32%usize x 0%usize
 .
 
 (** [arrays::ite]:
-    Source: 'tests/src/arrays.rs', lines 294:0-294:12 *)
+    Source: 'tests/src/arrays.rs', lines 297:0-297:12 *)
 Definition ite : result unit :=
   p <- array_to_slice_mut u32 2%usize (mk_array u32 2%usize [ 0%u32; 0%u32 ]);
   let (s, to_slice_mut_back) := p in
@@ -508,7 +508,7 @@ Definition ite : result unit :=
 .
 
 (** [arrays::zero_slice]: loop 0:
-    Source: 'tests/src/arrays.rs', lines 303:0-310:1 *)
+    Source: 'tests/src/arrays.rs', lines 306:0-313:1 *)
 Fixpoint zero_slice_loop
   (n : nat) (a : slice u8) (i : usize) (len : usize) : result (slice u8) :=
   match n with
@@ -526,13 +526,13 @@ Fixpoint zero_slice_loop
 .
 
 (** [arrays::zero_slice]:
-    Source: 'tests/src/arrays.rs', lines 303:0-303:31 *)
+    Source: 'tests/src/arrays.rs', lines 306:0-306:31 *)
 Definition zero_slice (n : nat) (a : slice u8) : result (slice u8) :=
   let len := slice_len u8 a in zero_slice_loop n a 0%usize len
 .
 
 (** [arrays::iter_mut_slice]: loop 0:
-    Source: 'tests/src/arrays.rs', lines 312:0-318:1 *)
+    Source: 'tests/src/arrays.rs', lines 315:0-321:1 *)
 Fixpoint iter_mut_slice_loop
   (n : nat) (len : usize) (i : usize) : result unit :=
   match n with
@@ -545,13 +545,13 @@ Fixpoint iter_mut_slice_loop
 .
 
 (** [arrays::iter_mut_slice]:
-    Source: 'tests/src/arrays.rs', lines 312:0-312:35 *)
+    Source: 'tests/src/arrays.rs', lines 315:0-315:35 *)
 Definition iter_mut_slice (n : nat) (a : slice u8) : result (slice u8) :=
   let len := slice_len u8 a in _ <- iter_mut_slice_loop n len 0%usize; Ok a
 .
 
 (** [arrays::sum_mut_slice]: loop 0:
-    Source: 'tests/src/arrays.rs', lines 320:0-328:1 *)
+    Source: 'tests/src/arrays.rs', lines 323:0-331:1 *)
 Fixpoint sum_mut_slice_loop
   (n : nat) (a : slice u32) (i : usize) (s : u32) : result u32 :=
   match n with
@@ -569,7 +569,7 @@ Fixpoint sum_mut_slice_loop
 .
 
 (** [arrays::sum_mut_slice]:
-    Source: 'tests/src/arrays.rs', lines 320:0-320:42 *)
+    Source: 'tests/src/arrays.rs', lines 323:0-323:42 *)
 Definition sum_mut_slice
   (n : nat) (a : slice u32) : result (u32 * (slice u32)) :=
   i <- sum_mut_slice_loop n a 0%usize 0%u32; Ok (i, a)

--- a/tests/coq/demo/Demo.v
+++ b/tests/coq/demo/Demo.v
@@ -9,7 +9,7 @@ Local Open Scope Primitives_scope.
 Module Demo.
 
 (** [demo::choose]:
-    Source: 'tests/src/demo.rs', lines 5:0-5:70 *)
+    Source: 'tests/src/demo.rs', lines 6:0-6:70 *)
 Definition choose
   (T : Type) (b : bool) (x : T) (y : T) : result (T * (T -> result (T * T))) :=
   if b
@@ -18,30 +18,30 @@ Definition choose
 .
 
 (** [demo::mul2_add1]:
-    Source: 'tests/src/demo.rs', lines 13:0-13:31 *)
+    Source: 'tests/src/demo.rs', lines 14:0-14:31 *)
 Definition mul2_add1 (x : u32) : result u32 :=
   i <- u32_add x x; u32_add i 1%u32
 .
 
 (** [demo::use_mul2_add1]:
-    Source: 'tests/src/demo.rs', lines 17:0-17:43 *)
+    Source: 'tests/src/demo.rs', lines 18:0-18:43 *)
 Definition use_mul2_add1 (x : u32) (y : u32) : result u32 :=
   i <- mul2_add1 x; u32_add i y
 .
 
 (** [demo::incr]:
-    Source: 'tests/src/demo.rs', lines 21:0-21:31 *)
+    Source: 'tests/src/demo.rs', lines 22:0-22:31 *)
 Definition incr (x : u32) : result u32 :=
   u32_add x 1%u32.
 
 (** [demo::use_incr]:
-    Source: 'tests/src/demo.rs', lines 25:0-25:17 *)
+    Source: 'tests/src/demo.rs', lines 26:0-26:17 *)
 Definition use_incr : result unit :=
   x <- incr 0%u32; x1 <- incr x; _ <- incr x1; Ok tt
 .
 
 (** [demo::CList]
-    Source: 'tests/src/demo.rs', lines 34:0-34:17 *)
+    Source: 'tests/src/demo.rs', lines 35:0-35:17 *)
 Inductive CList_t (T : Type) :=
 | CList_CCons : T -> CList_t T -> CList_t T
 | CList_CNil : CList_t T
@@ -51,7 +51,7 @@ Arguments CList_CCons { _ }.
 Arguments CList_CNil { _ }.
 
 (** [demo::list_nth]:
-    Source: 'tests/src/demo.rs', lines 39:0-39:56 *)
+    Source: 'tests/src/demo.rs', lines 40:0-40:56 *)
 Fixpoint list_nth (T : Type) (n : nat) (l : CList_t T) (i : u32) : result T :=
   match n with
   | O => Fail_ OutOfFuel
@@ -65,7 +65,7 @@ Fixpoint list_nth (T : Type) (n : nat) (l : CList_t T) (i : u32) : result T :=
 .
 
 (** [demo::list_nth_mut]:
-    Source: 'tests/src/demo.rs', lines 54:0-54:68 *)
+    Source: 'tests/src/demo.rs', lines 55:0-55:68 *)
 Fixpoint list_nth_mut
   (T : Type) (n : nat) (l : CList_t T) (i : u32) :
   result (T * (T -> result (CList_t T)))
@@ -91,7 +91,7 @@ Fixpoint list_nth_mut
 .
 
 (** [demo::list_nth_mut1]: loop 0:
-    Source: 'tests/src/demo.rs', lines 69:0-78:1 *)
+    Source: 'tests/src/demo.rs', lines 70:0-79:1 *)
 Fixpoint list_nth_mut1_loop
   (T : Type) (n : nat) (l : CList_t T) (i : u32) :
   result (T * (T -> result (CList_t T)))
@@ -116,7 +116,7 @@ Fixpoint list_nth_mut1_loop
 .
 
 (** [demo::list_nth_mut1]:
-    Source: 'tests/src/demo.rs', lines 69:0-69:77 *)
+    Source: 'tests/src/demo.rs', lines 70:0-70:77 *)
 Definition list_nth_mut1
   (T : Type) (n : nat) (l : CList_t T) (i : u32) :
   result (T * (T -> result (CList_t T)))
@@ -125,7 +125,7 @@ Definition list_nth_mut1
 .
 
 (** [demo::i32_id]:
-    Source: 'tests/src/demo.rs', lines 80:0-80:28 *)
+    Source: 'tests/src/demo.rs', lines 81:0-81:28 *)
 Fixpoint i32_id (n : nat) (i : i32) : result i32 :=
   match n with
   | O => Fail_ OutOfFuel
@@ -137,7 +137,7 @@ Fixpoint i32_id (n : nat) (i : i32) : result i32 :=
 .
 
 (** [demo::list_tail]:
-    Source: 'tests/src/demo.rs', lines 88:0-88:64 *)
+    Source: 'tests/src/demo.rs', lines 89:0-89:64 *)
 Fixpoint list_tail
   (T : Type) (n : nat) (l : CList_t T) :
   result ((CList_t T) * (CList_t T -> result (CList_t T)))
@@ -159,7 +159,7 @@ Fixpoint list_tail
 .
 
 (** Trait declaration: [demo::Counter]
-    Source: 'tests/src/demo.rs', lines 97:0-97:17 *)
+    Source: 'tests/src/demo.rs', lines 98:0-98:17 *)
 Record Counter_t (Self : Type) := mkCounter_t {
   Counter_t_incr : Self -> result (usize * Self);
 }.
@@ -168,19 +168,19 @@ Arguments mkCounter_t { _ }.
 Arguments Counter_t_incr { _ }.
 
 (** [demo::{(demo::Counter for usize)}::incr]:
-    Source: 'tests/src/demo.rs', lines 102:4-102:31 *)
+    Source: 'tests/src/demo.rs', lines 103:4-103:31 *)
 Definition counterUsize_incr (self : usize) : result (usize * usize) :=
   self1 <- usize_add self 1%usize; Ok (self, self1)
 .
 
 (** Trait implementation: [demo::{(demo::Counter for usize)}]
-    Source: 'tests/src/demo.rs', lines 101:0-101:22 *)
+    Source: 'tests/src/demo.rs', lines 102:0-102:22 *)
 Definition CounterUsize : Counter_t usize := {|
   Counter_t_incr := counterUsize_incr;
 |}.
 
 (** [demo::use_counter]:
-    Source: 'tests/src/demo.rs', lines 109:0-109:59 *)
+    Source: 'tests/src/demo.rs', lines 110:0-110:59 *)
 Definition use_counter
   (T : Type) (counterInst : Counter_t T) (cnt : T) : result (usize * T) :=
   counterInst.(Counter_t_incr) cnt

--- a/tests/coq/hashmap/Hashmap_Funs.v
+++ b/tests/coq/hashmap/Hashmap_Funs.v
@@ -11,12 +11,12 @@ Include Hashmap_Types.
 Module Hashmap_Funs.
 
 (** [hashmap::hash_key]:
-    Source: 'tests/src/hashmap.rs', lines 27:0-27:32 *)
+    Source: 'tests/src/hashmap.rs', lines 35:0-35:32 *)
 Definition hash_key (k : usize) : result usize :=
   Ok k.
 
 (** [hashmap::{hashmap::HashMap<T>}::allocate_slots]: loop 0:
-    Source: 'tests/src/hashmap.rs', lines 50:4-56:5 *)
+    Source: 'tests/src/hashmap.rs', lines 58:4-64:5 *)
 Fixpoint hashMap_allocate_slots_loop
   (T : Type) (n : nat) (slots : alloc_vec_Vec (List_t T)) (n1 : usize) :
   result (alloc_vec_Vec (List_t T))
@@ -34,7 +34,7 @@ Fixpoint hashMap_allocate_slots_loop
 .
 
 (** [hashmap::{hashmap::HashMap<T>}::allocate_slots]:
-    Source: 'tests/src/hashmap.rs', lines 50:4-50:76 *)
+    Source: 'tests/src/hashmap.rs', lines 58:4-58:76 *)
 Definition hashMap_allocate_slots
   (T : Type) (n : nat) (slots : alloc_vec_Vec (List_t T)) (n1 : usize) :
   result (alloc_vec_Vec (List_t T))
@@ -43,7 +43,7 @@ Definition hashMap_allocate_slots
 .
 
 (** [hashmap::{hashmap::HashMap<T>}::new_with_capacity]:
-    Source: 'tests/src/hashmap.rs', lines 59:4-63:13 *)
+    Source: 'tests/src/hashmap.rs', lines 67:4-71:13 *)
 Definition hashMap_new_with_capacity
   (T : Type) (n : nat) (capacity : usize) (max_load_dividend : usize)
   (max_load_divisor : usize) :
@@ -62,13 +62,13 @@ Definition hashMap_new_with_capacity
 .
 
 (** [hashmap::{hashmap::HashMap<T>}::new]:
-    Source: 'tests/src/hashmap.rs', lines 75:4-75:24 *)
+    Source: 'tests/src/hashmap.rs', lines 83:4-83:24 *)
 Definition hashMap_new (T : Type) (n : nat) : result (HashMap_t T) :=
   hashMap_new_with_capacity T n 32%usize 4%usize 5%usize
 .
 
 (** [hashmap::{hashmap::HashMap<T>}::clear]: loop 0:
-    Source: 'tests/src/hashmap.rs', lines 80:4-88:5 *)
+    Source: 'tests/src/hashmap.rs', lines 88:4-96:5 *)
 Fixpoint hashMap_clear_loop
   (T : Type) (n : nat) (slots : alloc_vec_Vec (List_t T)) (i : usize) :
   result (alloc_vec_Vec (List_t T))
@@ -91,7 +91,7 @@ Fixpoint hashMap_clear_loop
 .
 
 (** [hashmap::{hashmap::HashMap<T>}::clear]:
-    Source: 'tests/src/hashmap.rs', lines 80:4-80:27 *)
+    Source: 'tests/src/hashmap.rs', lines 88:4-88:27 *)
 Definition hashMap_clear
   (T : Type) (n : nat) (self : HashMap_t T) : result (HashMap_t T) :=
   hm <- hashMap_clear_loop T n self.(hashMap_slots) 0%usize;
@@ -105,13 +105,13 @@ Definition hashMap_clear
 .
 
 (** [hashmap::{hashmap::HashMap<T>}::len]:
-    Source: 'tests/src/hashmap.rs', lines 90:4-90:30 *)
+    Source: 'tests/src/hashmap.rs', lines 98:4-98:30 *)
 Definition hashMap_len (T : Type) (self : HashMap_t T) : result usize :=
   Ok self.(hashMap_num_entries)
 .
 
 (** [hashmap::{hashmap::HashMap<T>}::insert_in_list]: loop 0:
-    Source: 'tests/src/hashmap.rs', lines 97:4-114:5 *)
+    Source: 'tests/src/hashmap.rs', lines 105:4-122:5 *)
 Fixpoint hashMap_insert_in_list_loop
   (T : Type) (n : nat) (key : usize) (value : T) (ls : List_t T) :
   result (bool * (List_t T))
@@ -133,7 +133,7 @@ Fixpoint hashMap_insert_in_list_loop
 .
 
 (** [hashmap::{hashmap::HashMap<T>}::insert_in_list]:
-    Source: 'tests/src/hashmap.rs', lines 97:4-97:71 *)
+    Source: 'tests/src/hashmap.rs', lines 105:4-105:71 *)
 Definition hashMap_insert_in_list
   (T : Type) (n : nat) (key : usize) (value : T) (ls : List_t T) :
   result (bool * (List_t T))
@@ -142,7 +142,7 @@ Definition hashMap_insert_in_list
 .
 
 (** [hashmap::{hashmap::HashMap<T>}::insert_no_resize]:
-    Source: 'tests/src/hashmap.rs', lines 117:4-117:54 *)
+    Source: 'tests/src/hashmap.rs', lines 125:4-125:54 *)
 Definition hashMap_insert_no_resize
   (T : Type) (n : nat) (self : HashMap_t T) (key : usize) (value : T) :
   result (HashMap_t T)
@@ -180,7 +180,7 @@ Definition hashMap_insert_no_resize
 .
 
 (** [hashmap::{hashmap::HashMap<T>}::move_elements_from_list]: loop 0:
-    Source: 'tests/src/hashmap.rs', lines 183:4-196:5 *)
+    Source: 'tests/src/hashmap.rs', lines 191:4-204:5 *)
 Fixpoint hashMap_move_elements_from_list_loop
   (T : Type) (n : nat) (ntable : HashMap_t T) (ls : List_t T) :
   result (HashMap_t T)
@@ -198,7 +198,7 @@ Fixpoint hashMap_move_elements_from_list_loop
 .
 
 (** [hashmap::{hashmap::HashMap<T>}::move_elements_from_list]:
-    Source: 'tests/src/hashmap.rs', lines 183:4-183:72 *)
+    Source: 'tests/src/hashmap.rs', lines 191:4-191:72 *)
 Definition hashMap_move_elements_from_list
   (T : Type) (n : nat) (ntable : HashMap_t T) (ls : List_t T) :
   result (HashMap_t T)
@@ -207,7 +207,7 @@ Definition hashMap_move_elements_from_list
 .
 
 (** [hashmap::{hashmap::HashMap<T>}::move_elements]: loop 0:
-    Source: 'tests/src/hashmap.rs', lines 171:4-180:5 *)
+    Source: 'tests/src/hashmap.rs', lines 179:4-188:5 *)
 Fixpoint hashMap_move_elements_loop
   (T : Type) (n : nat) (ntable : HashMap_t T)
   (slots : alloc_vec_Vec (List_t T)) (i : usize) :
@@ -233,7 +233,7 @@ Fixpoint hashMap_move_elements_loop
 .
 
 (** [hashmap::{hashmap::HashMap<T>}::move_elements]:
-    Source: 'tests/src/hashmap.rs', lines 171:4-171:95 *)
+    Source: 'tests/src/hashmap.rs', lines 179:4-179:95 *)
 Definition hashMap_move_elements
   (T : Type) (n : nat) (ntable : HashMap_t T)
   (slots : alloc_vec_Vec (List_t T)) (i : usize) :
@@ -243,7 +243,7 @@ Definition hashMap_move_elements
 .
 
 (** [hashmap::{hashmap::HashMap<T>}::try_resize]:
-    Source: 'tests/src/hashmap.rs', lines 140:4-140:28 *)
+    Source: 'tests/src/hashmap.rs', lines 148:4-148:28 *)
 Definition hashMap_try_resize
   (T : Type) (n : nat) (self : HashMap_t T) : result (HashMap_t T) :=
   max_usize <- scalar_cast U32 Usize core_u32_max;
@@ -275,7 +275,7 @@ Definition hashMap_try_resize
 .
 
 (** [hashmap::{hashmap::HashMap<T>}::insert]:
-    Source: 'tests/src/hashmap.rs', lines 129:4-129:48 *)
+    Source: 'tests/src/hashmap.rs', lines 137:4-137:48 *)
 Definition hashMap_insert
   (T : Type) (n : nat) (self : HashMap_t T) (key : usize) (value : T) :
   result (HashMap_t T)
@@ -288,7 +288,7 @@ Definition hashMap_insert
 .
 
 (** [hashmap::{hashmap::HashMap<T>}::contains_key_in_list]: loop 0:
-    Source: 'tests/src/hashmap.rs', lines 206:4-219:5 *)
+    Source: 'tests/src/hashmap.rs', lines 214:4-227:5 *)
 Fixpoint hashMap_contains_key_in_list_loop
   (T : Type) (n : nat) (key : usize) (ls : List_t T) : result bool :=
   match n with
@@ -305,14 +305,14 @@ Fixpoint hashMap_contains_key_in_list_loop
 .
 
 (** [hashmap::{hashmap::HashMap<T>}::contains_key_in_list]:
-    Source: 'tests/src/hashmap.rs', lines 206:4-206:68 *)
+    Source: 'tests/src/hashmap.rs', lines 214:4-214:68 *)
 Definition hashMap_contains_key_in_list
   (T : Type) (n : nat) (key : usize) (ls : List_t T) : result bool :=
   hashMap_contains_key_in_list_loop T n key ls
 .
 
 (** [hashmap::{hashmap::HashMap<T>}::contains_key]:
-    Source: 'tests/src/hashmap.rs', lines 199:4-199:49 *)
+    Source: 'tests/src/hashmap.rs', lines 207:4-207:49 *)
 Definition hashMap_contains_key
   (T : Type) (n : nat) (self : HashMap_t T) (key : usize) : result bool :=
   hash <- hash_key key;
@@ -326,7 +326,7 @@ Definition hashMap_contains_key
 .
 
 (** [hashmap::{hashmap::HashMap<T>}::get_in_list]: loop 0:
-    Source: 'tests/src/hashmap.rs', lines 224:4-237:5 *)
+    Source: 'tests/src/hashmap.rs', lines 232:4-245:5 *)
 Fixpoint hashMap_get_in_list_loop
   (T : Type) (n : nat) (key : usize) (ls : List_t T) : result T :=
   match n with
@@ -341,14 +341,14 @@ Fixpoint hashMap_get_in_list_loop
 .
 
 (** [hashmap::{hashmap::HashMap<T>}::get_in_list]:
-    Source: 'tests/src/hashmap.rs', lines 224:4-224:70 *)
+    Source: 'tests/src/hashmap.rs', lines 232:4-232:70 *)
 Definition hashMap_get_in_list
   (T : Type) (n : nat) (key : usize) (ls : List_t T) : result T :=
   hashMap_get_in_list_loop T n key ls
 .
 
 (** [hashmap::{hashmap::HashMap<T>}::get]:
-    Source: 'tests/src/hashmap.rs', lines 239:4-239:55 *)
+    Source: 'tests/src/hashmap.rs', lines 247:4-247:55 *)
 Definition hashMap_get
   (T : Type) (n : nat) (self : HashMap_t T) (key : usize) : result T :=
   hash <- hash_key key;
@@ -362,7 +362,7 @@ Definition hashMap_get
 .
 
 (** [hashmap::{hashmap::HashMap<T>}::get_mut_in_list]: loop 0:
-    Source: 'tests/src/hashmap.rs', lines 245:4-254:5 *)
+    Source: 'tests/src/hashmap.rs', lines 253:4-262:5 *)
 Fixpoint hashMap_get_mut_in_list_loop
   (T : Type) (n : nat) (ls : List_t T) (key : usize) :
   result (T * (T -> result (List_t T)))
@@ -388,7 +388,7 @@ Fixpoint hashMap_get_mut_in_list_loop
 .
 
 (** [hashmap::{hashmap::HashMap<T>}::get_mut_in_list]:
-    Source: 'tests/src/hashmap.rs', lines 245:4-245:86 *)
+    Source: 'tests/src/hashmap.rs', lines 253:4-253:86 *)
 Definition hashMap_get_mut_in_list
   (T : Type) (n : nat) (ls : List_t T) (key : usize) :
   result (T * (T -> result (List_t T)))
@@ -397,7 +397,7 @@ Definition hashMap_get_mut_in_list
 .
 
 (** [hashmap::{hashmap::HashMap<T>}::get_mut]:
-    Source: 'tests/src/hashmap.rs', lines 257:4-257:67 *)
+    Source: 'tests/src/hashmap.rs', lines 265:4-265:67 *)
 Definition hashMap_get_mut
   (T : Type) (n : nat) (self : HashMap_t T) (key : usize) :
   result (T * (T -> result (HashMap_t T)))
@@ -427,7 +427,7 @@ Definition hashMap_get_mut
 .
 
 (** [hashmap::{hashmap::HashMap<T>}::remove_from_list]: loop 0:
-    Source: 'tests/src/hashmap.rs', lines 265:4-291:5 *)
+    Source: 'tests/src/hashmap.rs', lines 273:4-299:5 *)
 Fixpoint hashMap_remove_from_list_loop
   (T : Type) (n : nat) (key : usize) (ls : List_t T) :
   result ((option T) * (List_t T))
@@ -455,7 +455,7 @@ Fixpoint hashMap_remove_from_list_loop
 .
 
 (** [hashmap::{hashmap::HashMap<T>}::remove_from_list]:
-    Source: 'tests/src/hashmap.rs', lines 265:4-265:69 *)
+    Source: 'tests/src/hashmap.rs', lines 273:4-273:69 *)
 Definition hashMap_remove_from_list
   (T : Type) (n : nat) (key : usize) (ls : List_t T) :
   result ((option T) * (List_t T))
@@ -464,7 +464,7 @@ Definition hashMap_remove_from_list
 .
 
 (** [hashmap::{hashmap::HashMap<T>}::remove]:
-    Source: 'tests/src/hashmap.rs', lines 294:4-294:52 *)
+    Source: 'tests/src/hashmap.rs', lines 302:4-302:52 *)
 Definition hashMap_remove
   (T : Type) (n : nat) (self : HashMap_t T) (key : usize) :
   result ((option T) * (HashMap_t T))
@@ -503,7 +503,7 @@ Definition hashMap_remove
 .
 
 (** [hashmap::test1]:
-    Source: 'tests/src/hashmap.rs', lines 315:0-315:10 *)
+    Source: 'tests/src/hashmap.rs', lines 323:0-323:10 *)
 Definition test1 (n : nat) : result unit :=
   hm <- hashMap_new u64 n;
   hm1 <- hashMap_insert u64 n hm 0%usize 42%u64;

--- a/tests/coq/hashmap/Hashmap_Types.v
+++ b/tests/coq/hashmap/Hashmap_Types.v
@@ -9,7 +9,7 @@ Local Open Scope Primitives_scope.
 Module Hashmap_Types.
 
 (** [hashmap::List]
-    Source: 'tests/src/hashmap.rs', lines 19:0-19:16 *)
+    Source: 'tests/src/hashmap.rs', lines 27:0-27:16 *)
 Inductive List_t (T : Type) :=
 | List_Cons : usize -> T -> List_t T -> List_t T
 | List_Nil : List_t T
@@ -19,7 +19,7 @@ Arguments List_Cons { _ }.
 Arguments List_Nil { _ }.
 
 (** [hashmap::HashMap]
-    Source: 'tests/src/hashmap.rs', lines 35:0-35:21 *)
+    Source: 'tests/src/hashmap.rs', lines 43:0-43:21 *)
 Record HashMap_t (T : Type) :=
 mkHashMap_t {
   hashMap_num_entries : usize;

--- a/tests/coq/hashmap_on_disk/HashmapMain_Funs.v
+++ b/tests/coq/hashmap_on_disk/HashmapMain_Funs.v
@@ -13,12 +13,12 @@ Include HashmapMain_FunsExternal.
 Module HashmapMain_Funs.
 
 (** [hashmap_main::hashmap::hash_key]:
-    Source: 'tests/src/hashmap.rs', lines 27:0-27:32 *)
+    Source: 'tests/src/hashmap.rs', lines 35:0-35:32 *)
 Definition hashmap_hash_key (k : usize) : result usize :=
   Ok k.
 
 (** [hashmap_main::hashmap::{hashmap_main::hashmap::HashMap<T>}::allocate_slots]: loop 0:
-    Source: 'tests/src/hashmap.rs', lines 50:4-56:5 *)
+    Source: 'tests/src/hashmap.rs', lines 58:4-64:5 *)
 Fixpoint hashmap_HashMap_allocate_slots_loop
   (T : Type) (n : nat) (slots : alloc_vec_Vec (hashmap_List_t T)) (n1 : usize)
   :
@@ -37,7 +37,7 @@ Fixpoint hashmap_HashMap_allocate_slots_loop
 .
 
 (** [hashmap_main::hashmap::{hashmap_main::hashmap::HashMap<T>}::allocate_slots]:
-    Source: 'tests/src/hashmap.rs', lines 50:4-50:76 *)
+    Source: 'tests/src/hashmap.rs', lines 58:4-58:76 *)
 Definition hashmap_HashMap_allocate_slots
   (T : Type) (n : nat) (slots : alloc_vec_Vec (hashmap_List_t T)) (n1 : usize)
   :
@@ -47,7 +47,7 @@ Definition hashmap_HashMap_allocate_slots
 .
 
 (** [hashmap_main::hashmap::{hashmap_main::hashmap::HashMap<T>}::new_with_capacity]:
-    Source: 'tests/src/hashmap.rs', lines 59:4-63:13 *)
+    Source: 'tests/src/hashmap.rs', lines 67:4-71:13 *)
 Definition hashmap_HashMap_new_with_capacity
   (T : Type) (n : nat) (capacity : usize) (max_load_dividend : usize)
   (max_load_divisor : usize) :
@@ -68,14 +68,14 @@ Definition hashmap_HashMap_new_with_capacity
 .
 
 (** [hashmap_main::hashmap::{hashmap_main::hashmap::HashMap<T>}::new]:
-    Source: 'tests/src/hashmap.rs', lines 75:4-75:24 *)
+    Source: 'tests/src/hashmap.rs', lines 83:4-83:24 *)
 Definition hashmap_HashMap_new
   (T : Type) (n : nat) : result (hashmap_HashMap_t T) :=
   hashmap_HashMap_new_with_capacity T n 32%usize 4%usize 5%usize
 .
 
 (** [hashmap_main::hashmap::{hashmap_main::hashmap::HashMap<T>}::clear]: loop 0:
-    Source: 'tests/src/hashmap.rs', lines 80:4-88:5 *)
+    Source: 'tests/src/hashmap.rs', lines 88:4-96:5 *)
 Fixpoint hashmap_HashMap_clear_loop
   (T : Type) (n : nat) (slots : alloc_vec_Vec (hashmap_List_t T)) (i : usize) :
   result (alloc_vec_Vec (hashmap_List_t T))
@@ -99,7 +99,7 @@ Fixpoint hashmap_HashMap_clear_loop
 .
 
 (** [hashmap_main::hashmap::{hashmap_main::hashmap::HashMap<T>}::clear]:
-    Source: 'tests/src/hashmap.rs', lines 80:4-80:27 *)
+    Source: 'tests/src/hashmap.rs', lines 88:4-88:27 *)
 Definition hashmap_HashMap_clear
   (T : Type) (n : nat) (self : hashmap_HashMap_t T) :
   result (hashmap_HashMap_t T)
@@ -115,14 +115,14 @@ Definition hashmap_HashMap_clear
 .
 
 (** [hashmap_main::hashmap::{hashmap_main::hashmap::HashMap<T>}::len]:
-    Source: 'tests/src/hashmap.rs', lines 90:4-90:30 *)
+    Source: 'tests/src/hashmap.rs', lines 98:4-98:30 *)
 Definition hashmap_HashMap_len
   (T : Type) (self : hashmap_HashMap_t T) : result usize :=
   Ok self.(hashmap_HashMap_num_entries)
 .
 
 (** [hashmap_main::hashmap::{hashmap_main::hashmap::HashMap<T>}::insert_in_list]: loop 0:
-    Source: 'tests/src/hashmap.rs', lines 97:4-114:5 *)
+    Source: 'tests/src/hashmap.rs', lines 105:4-122:5 *)
 Fixpoint hashmap_HashMap_insert_in_list_loop
   (T : Type) (n : nat) (key : usize) (value : T) (ls : hashmap_List_t T) :
   result (bool * (hashmap_List_t T))
@@ -145,7 +145,7 @@ Fixpoint hashmap_HashMap_insert_in_list_loop
 .
 
 (** [hashmap_main::hashmap::{hashmap_main::hashmap::HashMap<T>}::insert_in_list]:
-    Source: 'tests/src/hashmap.rs', lines 97:4-97:71 *)
+    Source: 'tests/src/hashmap.rs', lines 105:4-105:71 *)
 Definition hashmap_HashMap_insert_in_list
   (T : Type) (n : nat) (key : usize) (value : T) (ls : hashmap_List_t T) :
   result (bool * (hashmap_List_t T))
@@ -154,7 +154,7 @@ Definition hashmap_HashMap_insert_in_list
 .
 
 (** [hashmap_main::hashmap::{hashmap_main::hashmap::HashMap<T>}::insert_no_resize]:
-    Source: 'tests/src/hashmap.rs', lines 117:4-117:54 *)
+    Source: 'tests/src/hashmap.rs', lines 125:4-125:54 *)
 Definition hashmap_HashMap_insert_no_resize
   (T : Type) (n : nat) (self : hashmap_HashMap_t T) (key : usize) (value : T) :
   result (hashmap_HashMap_t T)
@@ -194,7 +194,7 @@ Definition hashmap_HashMap_insert_no_resize
 .
 
 (** [hashmap_main::hashmap::{hashmap_main::hashmap::HashMap<T>}::move_elements_from_list]: loop 0:
-    Source: 'tests/src/hashmap.rs', lines 183:4-196:5 *)
+    Source: 'tests/src/hashmap.rs', lines 191:4-204:5 *)
 Fixpoint hashmap_HashMap_move_elements_from_list_loop
   (T : Type) (n : nat) (ntable : hashmap_HashMap_t T) (ls : hashmap_List_t T) :
   result (hashmap_HashMap_t T)
@@ -212,7 +212,7 @@ Fixpoint hashmap_HashMap_move_elements_from_list_loop
 .
 
 (** [hashmap_main::hashmap::{hashmap_main::hashmap::HashMap<T>}::move_elements_from_list]:
-    Source: 'tests/src/hashmap.rs', lines 183:4-183:72 *)
+    Source: 'tests/src/hashmap.rs', lines 191:4-191:72 *)
 Definition hashmap_HashMap_move_elements_from_list
   (T : Type) (n : nat) (ntable : hashmap_HashMap_t T) (ls : hashmap_List_t T) :
   result (hashmap_HashMap_t T)
@@ -221,7 +221,7 @@ Definition hashmap_HashMap_move_elements_from_list
 .
 
 (** [hashmap_main::hashmap::{hashmap_main::hashmap::HashMap<T>}::move_elements]: loop 0:
-    Source: 'tests/src/hashmap.rs', lines 171:4-180:5 *)
+    Source: 'tests/src/hashmap.rs', lines 179:4-188:5 *)
 Fixpoint hashmap_HashMap_move_elements_loop
   (T : Type) (n : nat) (ntable : hashmap_HashMap_t T)
   (slots : alloc_vec_Vec (hashmap_List_t T)) (i : usize) :
@@ -248,7 +248,7 @@ Fixpoint hashmap_HashMap_move_elements_loop
 .
 
 (** [hashmap_main::hashmap::{hashmap_main::hashmap::HashMap<T>}::move_elements]:
-    Source: 'tests/src/hashmap.rs', lines 171:4-171:95 *)
+    Source: 'tests/src/hashmap.rs', lines 179:4-179:95 *)
 Definition hashmap_HashMap_move_elements
   (T : Type) (n : nat) (ntable : hashmap_HashMap_t T)
   (slots : alloc_vec_Vec (hashmap_List_t T)) (i : usize) :
@@ -258,7 +258,7 @@ Definition hashmap_HashMap_move_elements
 .
 
 (** [hashmap_main::hashmap::{hashmap_main::hashmap::HashMap<T>}::try_resize]:
-    Source: 'tests/src/hashmap.rs', lines 140:4-140:28 *)
+    Source: 'tests/src/hashmap.rs', lines 148:4-148:28 *)
 Definition hashmap_HashMap_try_resize
   (T : Type) (n : nat) (self : hashmap_HashMap_t T) :
   result (hashmap_HashMap_t T)
@@ -295,7 +295,7 @@ Definition hashmap_HashMap_try_resize
 .
 
 (** [hashmap_main::hashmap::{hashmap_main::hashmap::HashMap<T>}::insert]:
-    Source: 'tests/src/hashmap.rs', lines 129:4-129:48 *)
+    Source: 'tests/src/hashmap.rs', lines 137:4-137:48 *)
 Definition hashmap_HashMap_insert
   (T : Type) (n : nat) (self : hashmap_HashMap_t T) (key : usize) (value : T) :
   result (hashmap_HashMap_t T)
@@ -308,7 +308,7 @@ Definition hashmap_HashMap_insert
 .
 
 (** [hashmap_main::hashmap::{hashmap_main::hashmap::HashMap<T>}::contains_key_in_list]: loop 0:
-    Source: 'tests/src/hashmap.rs', lines 206:4-219:5 *)
+    Source: 'tests/src/hashmap.rs', lines 214:4-227:5 *)
 Fixpoint hashmap_HashMap_contains_key_in_list_loop
   (T : Type) (n : nat) (key : usize) (ls : hashmap_List_t T) : result bool :=
   match n with
@@ -325,14 +325,14 @@ Fixpoint hashmap_HashMap_contains_key_in_list_loop
 .
 
 (** [hashmap_main::hashmap::{hashmap_main::hashmap::HashMap<T>}::contains_key_in_list]:
-    Source: 'tests/src/hashmap.rs', lines 206:4-206:68 *)
+    Source: 'tests/src/hashmap.rs', lines 214:4-214:68 *)
 Definition hashmap_HashMap_contains_key_in_list
   (T : Type) (n : nat) (key : usize) (ls : hashmap_List_t T) : result bool :=
   hashmap_HashMap_contains_key_in_list_loop T n key ls
 .
 
 (** [hashmap_main::hashmap::{hashmap_main::hashmap::HashMap<T>}::contains_key]:
-    Source: 'tests/src/hashmap.rs', lines 199:4-199:49 *)
+    Source: 'tests/src/hashmap.rs', lines 207:4-207:49 *)
 Definition hashmap_HashMap_contains_key
   (T : Type) (n : nat) (self : hashmap_HashMap_t T) (key : usize) :
   result bool
@@ -348,7 +348,7 @@ Definition hashmap_HashMap_contains_key
 .
 
 (** [hashmap_main::hashmap::{hashmap_main::hashmap::HashMap<T>}::get_in_list]: loop 0:
-    Source: 'tests/src/hashmap.rs', lines 224:4-237:5 *)
+    Source: 'tests/src/hashmap.rs', lines 232:4-245:5 *)
 Fixpoint hashmap_HashMap_get_in_list_loop
   (T : Type) (n : nat) (key : usize) (ls : hashmap_List_t T) : result T :=
   match n with
@@ -365,14 +365,14 @@ Fixpoint hashmap_HashMap_get_in_list_loop
 .
 
 (** [hashmap_main::hashmap::{hashmap_main::hashmap::HashMap<T>}::get_in_list]:
-    Source: 'tests/src/hashmap.rs', lines 224:4-224:70 *)
+    Source: 'tests/src/hashmap.rs', lines 232:4-232:70 *)
 Definition hashmap_HashMap_get_in_list
   (T : Type) (n : nat) (key : usize) (ls : hashmap_List_t T) : result T :=
   hashmap_HashMap_get_in_list_loop T n key ls
 .
 
 (** [hashmap_main::hashmap::{hashmap_main::hashmap::HashMap<T>}::get]:
-    Source: 'tests/src/hashmap.rs', lines 239:4-239:55 *)
+    Source: 'tests/src/hashmap.rs', lines 247:4-247:55 *)
 Definition hashmap_HashMap_get
   (T : Type) (n : nat) (self : hashmap_HashMap_t T) (key : usize) : result T :=
   hash <- hashmap_hash_key key;
@@ -386,7 +386,7 @@ Definition hashmap_HashMap_get
 .
 
 (** [hashmap_main::hashmap::{hashmap_main::hashmap::HashMap<T>}::get_mut_in_list]: loop 0:
-    Source: 'tests/src/hashmap.rs', lines 245:4-254:5 *)
+    Source: 'tests/src/hashmap.rs', lines 253:4-262:5 *)
 Fixpoint hashmap_HashMap_get_mut_in_list_loop
   (T : Type) (n : nat) (ls : hashmap_List_t T) (key : usize) :
   result (T * (T -> result (hashmap_List_t T)))
@@ -413,7 +413,7 @@ Fixpoint hashmap_HashMap_get_mut_in_list_loop
 .
 
 (** [hashmap_main::hashmap::{hashmap_main::hashmap::HashMap<T>}::get_mut_in_list]:
-    Source: 'tests/src/hashmap.rs', lines 245:4-245:86 *)
+    Source: 'tests/src/hashmap.rs', lines 253:4-253:86 *)
 Definition hashmap_HashMap_get_mut_in_list
   (T : Type) (n : nat) (ls : hashmap_List_t T) (key : usize) :
   result (T * (T -> result (hashmap_List_t T)))
@@ -422,7 +422,7 @@ Definition hashmap_HashMap_get_mut_in_list
 .
 
 (** [hashmap_main::hashmap::{hashmap_main::hashmap::HashMap<T>}::get_mut]:
-    Source: 'tests/src/hashmap.rs', lines 257:4-257:67 *)
+    Source: 'tests/src/hashmap.rs', lines 265:4-265:67 *)
 Definition hashmap_HashMap_get_mut
   (T : Type) (n : nat) (self : hashmap_HashMap_t T) (key : usize) :
   result (T * (T -> result (hashmap_HashMap_t T)))
@@ -453,7 +453,7 @@ Definition hashmap_HashMap_get_mut
 .
 
 (** [hashmap_main::hashmap::{hashmap_main::hashmap::HashMap<T>}::remove_from_list]: loop 0:
-    Source: 'tests/src/hashmap.rs', lines 265:4-291:5 *)
+    Source: 'tests/src/hashmap.rs', lines 273:4-299:5 *)
 Fixpoint hashmap_HashMap_remove_from_list_loop
   (T : Type) (n : nat) (key : usize) (ls : hashmap_List_t T) :
   result ((option T) * (hashmap_List_t T))
@@ -482,7 +482,7 @@ Fixpoint hashmap_HashMap_remove_from_list_loop
 .
 
 (** [hashmap_main::hashmap::{hashmap_main::hashmap::HashMap<T>}::remove_from_list]:
-    Source: 'tests/src/hashmap.rs', lines 265:4-265:69 *)
+    Source: 'tests/src/hashmap.rs', lines 273:4-273:69 *)
 Definition hashmap_HashMap_remove_from_list
   (T : Type) (n : nat) (key : usize) (ls : hashmap_List_t T) :
   result ((option T) * (hashmap_List_t T))
@@ -491,7 +491,7 @@ Definition hashmap_HashMap_remove_from_list
 .
 
 (** [hashmap_main::hashmap::{hashmap_main::hashmap::HashMap<T>}::remove]:
-    Source: 'tests/src/hashmap.rs', lines 294:4-294:52 *)
+    Source: 'tests/src/hashmap.rs', lines 302:4-302:52 *)
 Definition hashmap_HashMap_remove
   (T : Type) (n : nat) (self : hashmap_HashMap_t T) (key : usize) :
   result ((option T) * (hashmap_HashMap_t T))
@@ -532,7 +532,7 @@ Definition hashmap_HashMap_remove
 .
 
 (** [hashmap_main::hashmap::test1]:
-    Source: 'tests/src/hashmap.rs', lines 315:0-315:10 *)
+    Source: 'tests/src/hashmap.rs', lines 323:0-323:10 *)
 Definition hashmap_test1 (n : nat) : result unit :=
   hm <- hashmap_HashMap_new u64 n;
   hm1 <- hashmap_HashMap_insert u64 n hm 0%usize 42%u64;
@@ -572,7 +572,7 @@ Definition hashmap_test1 (n : nat) : result unit :=
 .
 
 (** [hashmap_main::insert_on_disk]:
-    Source: 'tests/src/hashmap_main.rs', lines 7:0-7:43 *)
+    Source: 'tests/src/hashmap_main.rs', lines 13:0-13:43 *)
 Definition insert_on_disk
   (n : nat) (key : usize) (value : u64) (st : state) : result (state * unit) :=
   p <- hashmap_utils_deserialize st;
@@ -582,7 +582,7 @@ Definition insert_on_disk
 .
 
 (** [hashmap_main::main]:
-    Source: 'tests/src/hashmap_main.rs', lines 16:0-16:13 *)
+    Source: 'tests/src/hashmap_main.rs', lines 22:0-22:13 *)
 Definition main : result unit :=
   Ok tt.
 

--- a/tests/coq/hashmap_on_disk/HashmapMain_FunsExternal_Template.v
+++ b/tests/coq/hashmap_on_disk/HashmapMain_FunsExternal_Template.v
@@ -12,13 +12,13 @@ Include HashmapMain_Types.
 Module HashmapMain_FunsExternal_Template.
 
 (** [hashmap_main::hashmap_utils::deserialize]:
-    Source: 'tests/src/hashmap_utils.rs', lines 10:0-10:43 *)
+    Source: 'tests/src/hashmap_utils.rs', lines 11:0-11:43 *)
 Axiom hashmap_utils_deserialize
   : state -> result (state * (hashmap_HashMap_t u64))
 .
 
 (** [hashmap_main::hashmap_utils::serialize]:
-    Source: 'tests/src/hashmap_utils.rs', lines 5:0-5:42 *)
+    Source: 'tests/src/hashmap_utils.rs', lines 6:0-6:42 *)
 Axiom hashmap_utils_serialize
   : hashmap_HashMap_t u64 -> state -> result (state * unit)
 .

--- a/tests/coq/hashmap_on_disk/HashmapMain_Types.v
+++ b/tests/coq/hashmap_on_disk/HashmapMain_Types.v
@@ -11,7 +11,7 @@ Include HashmapMain_TypesExternal.
 Module HashmapMain_Types.
 
 (** [hashmap_main::hashmap::List]
-    Source: 'tests/src/hashmap.rs', lines 19:0-19:16 *)
+    Source: 'tests/src/hashmap.rs', lines 27:0-27:16 *)
 Inductive hashmap_List_t (T : Type) :=
 | Hashmap_List_Cons : usize -> T -> hashmap_List_t T -> hashmap_List_t T
 | Hashmap_List_Nil : hashmap_List_t T
@@ -21,7 +21,7 @@ Arguments Hashmap_List_Cons { _ }.
 Arguments Hashmap_List_Nil { _ }.
 
 (** [hashmap_main::hashmap::HashMap]
-    Source: 'tests/src/hashmap.rs', lines 35:0-35:21 *)
+    Source: 'tests/src/hashmap.rs', lines 43:0-43:21 *)
 Record hashmap_HashMap_t (T : Type) :=
 mkhashmap_HashMap_t {
   hashmap_HashMap_num_entries : usize;

--- a/tests/coq/misc/Bitwise.v
+++ b/tests/coq/misc/Bitwise.v
@@ -9,29 +9,29 @@ Local Open Scope Primitives_scope.
 Module Bitwise.
 
 (** [bitwise::shift_u32]:
-    Source: 'tests/src/bitwise.rs', lines 3:0-3:31 *)
+    Source: 'tests/src/bitwise.rs', lines 4:0-4:31 *)
 Definition shift_u32 (a : u32) : result u32 :=
   t <- u32_shr a 16%usize; u32_shl t 16%usize
 .
 
 (** [bitwise::shift_i32]:
-    Source: 'tests/src/bitwise.rs', lines 10:0-10:31 *)
+    Source: 'tests/src/bitwise.rs', lines 11:0-11:31 *)
 Definition shift_i32 (a : i32) : result i32 :=
   t <- i32_shr a 16%isize; i32_shl t 16%isize
 .
 
 (** [bitwise::xor_u32]:
-    Source: 'tests/src/bitwise.rs', lines 17:0-17:37 *)
+    Source: 'tests/src/bitwise.rs', lines 18:0-18:37 *)
 Definition xor_u32 (a : u32) (b : u32) : result u32 :=
   Ok (u32_xor a b).
 
 (** [bitwise::or_u32]:
-    Source: 'tests/src/bitwise.rs', lines 21:0-21:36 *)
+    Source: 'tests/src/bitwise.rs', lines 22:0-22:36 *)
 Definition or_u32 (a : u32) (b : u32) : result u32 :=
   Ok (u32_or a b).
 
 (** [bitwise::and_u32]:
-    Source: 'tests/src/bitwise.rs', lines 25:0-25:37 *)
+    Source: 'tests/src/bitwise.rs', lines 26:0-26:37 *)
 Definition and_u32 (a : u32) (b : u32) : result u32 :=
   Ok (u32_and a b).
 

--- a/tests/coq/misc/Constants.v
+++ b/tests/coq/misc/Constants.v
@@ -9,37 +9,37 @@ Local Open Scope Primitives_scope.
 Module Constants.
 
 (** [constants::X0]
-    Source: 'tests/src/constants.rs', lines 5:0-5:17 *)
+    Source: 'tests/src/constants.rs', lines 7:0-7:17 *)
 Definition x0_body : result u32 := Ok 0%u32.
 Definition x0 : u32 := x0_body%global.
 
 (** [constants::X1]
-    Source: 'tests/src/constants.rs', lines 7:0-7:17 *)
+    Source: 'tests/src/constants.rs', lines 9:0-9:17 *)
 Definition x1_body : result u32 := Ok core_u32_max.
 Definition x1 : u32 := x1_body%global.
 
 (** [constants::X2]
-    Source: 'tests/src/constants.rs', lines 10:0-10:17 *)
+    Source: 'tests/src/constants.rs', lines 12:0-12:17 *)
 Definition x2_body : result u32 := Ok 3%u32.
 Definition x2 : u32 := x2_body%global.
 
 (** [constants::incr]:
-    Source: 'tests/src/constants.rs', lines 17:0-17:32 *)
+    Source: 'tests/src/constants.rs', lines 19:0-19:32 *)
 Definition incr (n : u32) : result u32 :=
   u32_add n 1%u32.
 
 (** [constants::X3]
-    Source: 'tests/src/constants.rs', lines 15:0-15:17 *)
+    Source: 'tests/src/constants.rs', lines 17:0-17:17 *)
 Definition x3_body : result u32 := incr 32%u32.
 Definition x3 : u32 := x3_body%global.
 
 (** [constants::mk_pair0]:
-    Source: 'tests/src/constants.rs', lines 23:0-23:51 *)
+    Source: 'tests/src/constants.rs', lines 25:0-25:51 *)
 Definition mk_pair0 (x : u32) (y1 : u32) : result (u32 * u32) :=
   Ok (x, y1).
 
 (** [constants::Pair]
-    Source: 'tests/src/constants.rs', lines 36:0-36:23 *)
+    Source: 'tests/src/constants.rs', lines 38:0-38:23 *)
 Record Pair_t (T1 T2 : Type) := mkPair_t { pair_x : T1; pair_y : T2; }.
 
 Arguments mkPair_t { _ _ }.
@@ -47,130 +47,130 @@ Arguments pair_x { _ _ }.
 Arguments pair_y { _ _ }.
 
 (** [constants::mk_pair1]:
-    Source: 'tests/src/constants.rs', lines 27:0-27:55 *)
+    Source: 'tests/src/constants.rs', lines 29:0-29:55 *)
 Definition mk_pair1 (x : u32) (y1 : u32) : result (Pair_t u32 u32) :=
   Ok {| pair_x := x; pair_y := y1 |}
 .
 
 (** [constants::P0]
-    Source: 'tests/src/constants.rs', lines 31:0-31:24 *)
+    Source: 'tests/src/constants.rs', lines 33:0-33:24 *)
 Definition p0_body : result (u32 * u32) := mk_pair0 0%u32 1%u32.
 Definition p0 : (u32 * u32) := p0_body%global.
 
 (** [constants::P1]
-    Source: 'tests/src/constants.rs', lines 32:0-32:28 *)
+    Source: 'tests/src/constants.rs', lines 34:0-34:28 *)
 Definition p1_body : result (Pair_t u32 u32) := mk_pair1 0%u32 1%u32.
 Definition p1 : Pair_t u32 u32 := p1_body%global.
 
 (** [constants::P2]
-    Source: 'tests/src/constants.rs', lines 33:0-33:24 *)
+    Source: 'tests/src/constants.rs', lines 35:0-35:24 *)
 Definition p2_body : result (u32 * u32) := Ok (0%u32, 1%u32).
 Definition p2 : (u32 * u32) := p2_body%global.
 
 (** [constants::P3]
-    Source: 'tests/src/constants.rs', lines 34:0-34:28 *)
+    Source: 'tests/src/constants.rs', lines 36:0-36:28 *)
 Definition p3_body : result (Pair_t u32 u32) :=
   Ok {| pair_x := 0%u32; pair_y := 1%u32 |}
 .
 Definition p3 : Pair_t u32 u32 := p3_body%global.
 
 (** [constants::Wrap]
-    Source: 'tests/src/constants.rs', lines 49:0-49:18 *)
+    Source: 'tests/src/constants.rs', lines 51:0-51:18 *)
 Record Wrap_t (T : Type) := mkWrap_t { wrap_value : T; }.
 
 Arguments mkWrap_t { _ }.
 Arguments wrap_value { _ }.
 
 (** [constants::{constants::Wrap<T>}::new]:
-    Source: 'tests/src/constants.rs', lines 54:4-54:41 *)
+    Source: 'tests/src/constants.rs', lines 56:4-56:41 *)
 Definition wrap_new (T : Type) (value : T) : result (Wrap_t T) :=
   Ok {| wrap_value := value |}
 .
 
 (** [constants::Y]
-    Source: 'tests/src/constants.rs', lines 41:0-41:22 *)
+    Source: 'tests/src/constants.rs', lines 43:0-43:22 *)
 Definition y_body : result (Wrap_t i32) := wrap_new i32 2%i32.
 Definition y : Wrap_t i32 := y_body%global.
 
 (** [constants::unwrap_y]:
-    Source: 'tests/src/constants.rs', lines 43:0-43:30 *)
+    Source: 'tests/src/constants.rs', lines 45:0-45:30 *)
 Definition unwrap_y : result i32 :=
   Ok y.(wrap_value).
 
 (** [constants::YVAL]
-    Source: 'tests/src/constants.rs', lines 47:0-47:19 *)
+    Source: 'tests/src/constants.rs', lines 49:0-49:19 *)
 Definition yval_body : result i32 := unwrap_y.
 Definition yval : i32 := yval_body%global.
 
 (** [constants::get_z1::Z1]
-    Source: 'tests/src/constants.rs', lines 62:4-62:17 *)
+    Source: 'tests/src/constants.rs', lines 64:4-64:17 *)
 Definition get_z1_z1_body : result i32 := Ok 3%i32.
 Definition get_z1_z1 : i32 := get_z1_z1_body%global.
 
 (** [constants::get_z1]:
-    Source: 'tests/src/constants.rs', lines 61:0-61:28 *)
+    Source: 'tests/src/constants.rs', lines 63:0-63:28 *)
 Definition get_z1 : result i32 :=
   Ok get_z1_z1.
 
 (** [constants::add]:
-    Source: 'tests/src/constants.rs', lines 66:0-66:39 *)
+    Source: 'tests/src/constants.rs', lines 68:0-68:39 *)
 Definition add (a : i32) (b : i32) : result i32 :=
   i32_add a b.
 
 (** [constants::Q1]
-    Source: 'tests/src/constants.rs', lines 74:0-74:17 *)
+    Source: 'tests/src/constants.rs', lines 76:0-76:17 *)
 Definition q1_body : result i32 := Ok 5%i32.
 Definition q1 : i32 := q1_body%global.
 
 (** [constants::Q2]
-    Source: 'tests/src/constants.rs', lines 75:0-75:17 *)
+    Source: 'tests/src/constants.rs', lines 77:0-77:17 *)
 Definition q2_body : result i32 := Ok q1.
 Definition q2 : i32 := q2_body%global.
 
 (** [constants::Q3]
-    Source: 'tests/src/constants.rs', lines 76:0-76:17 *)
+    Source: 'tests/src/constants.rs', lines 78:0-78:17 *)
 Definition q3_body : result i32 := add q2 3%i32.
 Definition q3 : i32 := q3_body%global.
 
 (** [constants::get_z2]:
-    Source: 'tests/src/constants.rs', lines 70:0-70:28 *)
+    Source: 'tests/src/constants.rs', lines 72:0-72:28 *)
 Definition get_z2 : result i32 :=
   i <- get_z1; i1 <- add i q3; add q1 i1.
 
 (** [constants::S1]
-    Source: 'tests/src/constants.rs', lines 80:0-80:18 *)
+    Source: 'tests/src/constants.rs', lines 82:0-82:18 *)
 Definition s1_body : result u32 := Ok 6%u32.
 Definition s1 : u32 := s1_body%global.
 
 (** [constants::S2]
-    Source: 'tests/src/constants.rs', lines 81:0-81:18 *)
+    Source: 'tests/src/constants.rs', lines 83:0-83:18 *)
 Definition s2_body : result u32 := incr s1.
 Definition s2 : u32 := s2_body%global.
 
 (** [constants::S3]
-    Source: 'tests/src/constants.rs', lines 82:0-82:29 *)
+    Source: 'tests/src/constants.rs', lines 84:0-84:29 *)
 Definition s3_body : result (Pair_t u32 u32) := Ok p3.
 Definition s3 : Pair_t u32 u32 := s3_body%global.
 
 (** [constants::S4]
-    Source: 'tests/src/constants.rs', lines 83:0-83:29 *)
+    Source: 'tests/src/constants.rs', lines 85:0-85:29 *)
 Definition s4_body : result (Pair_t u32 u32) := mk_pair1 7%u32 8%u32.
 Definition s4 : Pair_t u32 u32 := s4_body%global.
 
 (** [constants::V]
-    Source: 'tests/src/constants.rs', lines 86:0-86:31 *)
+    Source: 'tests/src/constants.rs', lines 88:0-88:31 *)
 Record V_t (T : Type) (N : usize) := mkV_t { v_x : array T N; }.
 
 Arguments mkV_t { _ _ }.
 Arguments v_x { _ _ }.
 
 (** [constants::{constants::V<T, N>#1}::LEN]
-    Source: 'tests/src/constants.rs', lines 91:4-91:24 *)
+    Source: 'tests/src/constants.rs', lines 93:4-93:24 *)
 Definition v_len_body (T : Type) (N : usize) : result usize := Ok N.
 Definition v_len (T : Type) (N : usize) : usize := (v_len_body T N)%global.
 
 (** [constants::use_v]:
-    Source: 'tests/src/constants.rs', lines 94:0-94:42 *)
+    Source: 'tests/src/constants.rs', lines 96:0-96:42 *)
 Definition use_v (T : Type) (N : usize) : result usize :=
   Ok (v_len T N).
 

--- a/tests/coq/misc/External_Funs.v
+++ b/tests/coq/misc/External_Funs.v
@@ -20,14 +20,14 @@ Definition core_marker_CopyU32 : core_marker_Copy_t u32 := {|
 |}.
 
 (** [external::use_get]:
-    Source: 'tests/src/external.rs', lines 5:0-5:37 *)
+    Source: 'tests/src/external.rs', lines 8:0-8:37 *)
 Definition use_get
   (rc : core_cell_Cell_t u32) (st : state) : result (state * u32) :=
   core_cell_Cell_get u32 core_marker_CopyU32 rc st
 .
 
 (** [external::incr]:
-    Source: 'tests/src/external.rs', lines 9:0-9:31 *)
+    Source: 'tests/src/external.rs', lines 12:0-12:31 *)
 Definition incr
   (rc : core_cell_Cell_t u32) (st : state) :
   result (state * (core_cell_Cell_t u32))

--- a/tests/coq/misc/Loops.v
+++ b/tests/coq/misc/Loops.v
@@ -9,7 +9,7 @@ Local Open Scope Primitives_scope.
 Module Loops.
 
 (** [loops::sum]: loop 0:
-    Source: 'tests/src/loops.rs', lines 4:0-14:1 *)
+    Source: 'tests/src/loops.rs', lines 7:0-17:1 *)
 Fixpoint sum_loop (n : nat) (max : u32) (i : u32) (s : u32) : result u32 :=
   match n with
   | O => Fail_ OutOfFuel
@@ -21,13 +21,13 @@ Fixpoint sum_loop (n : nat) (max : u32) (i : u32) (s : u32) : result u32 :=
 .
 
 (** [loops::sum]:
-    Source: 'tests/src/loops.rs', lines 4:0-4:27 *)
+    Source: 'tests/src/loops.rs', lines 7:0-7:27 *)
 Definition sum (n : nat) (max : u32) : result u32 :=
   sum_loop n max 0%u32 0%u32
 .
 
 (** [loops::sum_with_mut_borrows]: loop 0:
-    Source: 'tests/src/loops.rs', lines 19:0-31:1 *)
+    Source: 'tests/src/loops.rs', lines 22:0-34:1 *)
 Fixpoint sum_with_mut_borrows_loop
   (n : nat) (max : u32) (i : u32) (s : u32) : result u32 :=
   match n with
@@ -43,13 +43,13 @@ Fixpoint sum_with_mut_borrows_loop
 .
 
 (** [loops::sum_with_mut_borrows]:
-    Source: 'tests/src/loops.rs', lines 19:0-19:44 *)
+    Source: 'tests/src/loops.rs', lines 22:0-22:44 *)
 Definition sum_with_mut_borrows (n : nat) (max : u32) : result u32 :=
   sum_with_mut_borrows_loop n max 0%u32 0%u32
 .
 
 (** [loops::sum_with_shared_borrows]: loop 0:
-    Source: 'tests/src/loops.rs', lines 34:0-48:1 *)
+    Source: 'tests/src/loops.rs', lines 37:0-51:1 *)
 Fixpoint sum_with_shared_borrows_loop
   (n : nat) (max : u32) (i : u32) (s : u32) : result u32 :=
   match n with
@@ -65,13 +65,13 @@ Fixpoint sum_with_shared_borrows_loop
 .
 
 (** [loops::sum_with_shared_borrows]:
-    Source: 'tests/src/loops.rs', lines 34:0-34:47 *)
+    Source: 'tests/src/loops.rs', lines 37:0-37:47 *)
 Definition sum_with_shared_borrows (n : nat) (max : u32) : result u32 :=
   sum_with_shared_borrows_loop n max 0%u32 0%u32
 .
 
 (** [loops::sum_array]: loop 0:
-    Source: 'tests/src/loops.rs', lines 50:0-58:1 *)
+    Source: 'tests/src/loops.rs', lines 53:0-61:1 *)
 Fixpoint sum_array_loop
   (N : usize) (n : nat) (a : array u32 N) (i : usize) (s : u32) : result u32 :=
   match n with
@@ -88,13 +88,13 @@ Fixpoint sum_array_loop
 .
 
 (** [loops::sum_array]:
-    Source: 'tests/src/loops.rs', lines 50:0-50:52 *)
+    Source: 'tests/src/loops.rs', lines 53:0-53:52 *)
 Definition sum_array (N : usize) (n : nat) (a : array u32 N) : result u32 :=
   sum_array_loop N n a 0%usize 0%u32
 .
 
 (** [loops::clear]: loop 0:
-    Source: 'tests/src/loops.rs', lines 62:0-68:1 *)
+    Source: 'tests/src/loops.rs', lines 65:0-71:1 *)
 Fixpoint clear_loop
   (n : nat) (v : alloc_vec_Vec u32) (i : usize) : result (alloc_vec_Vec u32) :=
   match n with
@@ -115,14 +115,14 @@ Fixpoint clear_loop
 .
 
 (** [loops::clear]:
-    Source: 'tests/src/loops.rs', lines 62:0-62:30 *)
+    Source: 'tests/src/loops.rs', lines 65:0-65:30 *)
 Definition clear
   (n : nat) (v : alloc_vec_Vec u32) : result (alloc_vec_Vec u32) :=
   clear_loop n v 0%usize
 .
 
 (** [loops::List]
-    Source: 'tests/src/loops.rs', lines 70:0-70:16 *)
+    Source: 'tests/src/loops.rs', lines 73:0-73:16 *)
 Inductive List_t (T : Type) :=
 | List_Cons : T -> List_t T -> List_t T
 | List_Nil : List_t T
@@ -132,7 +132,7 @@ Arguments List_Cons { _ }.
 Arguments List_Nil { _ }.
 
 (** [loops::list_mem]: loop 0:
-    Source: 'tests/src/loops.rs', lines 76:0-85:1 *)
+    Source: 'tests/src/loops.rs', lines 79:0-88:1 *)
 Fixpoint list_mem_loop (n : nat) (x : u32) (ls : List_t u32) : result bool :=
   match n with
   | O => Fail_ OutOfFuel
@@ -145,13 +145,13 @@ Fixpoint list_mem_loop (n : nat) (x : u32) (ls : List_t u32) : result bool :=
 .
 
 (** [loops::list_mem]:
-    Source: 'tests/src/loops.rs', lines 76:0-76:52 *)
+    Source: 'tests/src/loops.rs', lines 79:0-79:52 *)
 Definition list_mem (n : nat) (x : u32) (ls : List_t u32) : result bool :=
   list_mem_loop n x ls
 .
 
 (** [loops::list_nth_mut_loop]: loop 0:
-    Source: 'tests/src/loops.rs', lines 88:0-98:1 *)
+    Source: 'tests/src/loops.rs', lines 91:0-101:1 *)
 Fixpoint list_nth_mut_loop_loop
   (T : Type) (n : nat) (ls : List_t T) (i : u32) :
   result (T * (T -> result (List_t T)))
@@ -175,7 +175,7 @@ Fixpoint list_nth_mut_loop_loop
 .
 
 (** [loops::list_nth_mut_loop]:
-    Source: 'tests/src/loops.rs', lines 88:0-88:71 *)
+    Source: 'tests/src/loops.rs', lines 91:0-91:71 *)
 Definition list_nth_mut_loop
   (T : Type) (n : nat) (ls : List_t T) (i : u32) :
   result (T * (T -> result (List_t T)))
@@ -184,7 +184,7 @@ Definition list_nth_mut_loop
 .
 
 (** [loops::list_nth_shared_loop]: loop 0:
-    Source: 'tests/src/loops.rs', lines 101:0-111:1 *)
+    Source: 'tests/src/loops.rs', lines 104:0-114:1 *)
 Fixpoint list_nth_shared_loop_loop
   (T : Type) (n : nat) (ls : List_t T) (i : u32) : result T :=
   match n with
@@ -201,14 +201,14 @@ Fixpoint list_nth_shared_loop_loop
 .
 
 (** [loops::list_nth_shared_loop]:
-    Source: 'tests/src/loops.rs', lines 101:0-101:66 *)
+    Source: 'tests/src/loops.rs', lines 104:0-104:66 *)
 Definition list_nth_shared_loop
   (T : Type) (n : nat) (ls : List_t T) (i : u32) : result T :=
   list_nth_shared_loop_loop T n ls i
 .
 
 (** [loops::get_elem_mut]: loop 0:
-    Source: 'tests/src/loops.rs', lines 113:0-127:1 *)
+    Source: 'tests/src/loops.rs', lines 116:0-130:1 *)
 Fixpoint get_elem_mut_loop
   (n : nat) (x : usize) (ls : List_t usize) :
   result (usize * (usize -> result (List_t usize)))
@@ -233,7 +233,7 @@ Fixpoint get_elem_mut_loop
 .
 
 (** [loops::get_elem_mut]:
-    Source: 'tests/src/loops.rs', lines 113:0-113:73 *)
+    Source: 'tests/src/loops.rs', lines 116:0-116:73 *)
 Definition get_elem_mut
   (n : nat) (slots : alloc_vec_Vec (List_t usize)) (x : usize) :
   result (usize * (usize -> result (alloc_vec_Vec (List_t usize))))
@@ -249,7 +249,7 @@ Definition get_elem_mut
 .
 
 (** [loops::get_elem_shared]: loop 0:
-    Source: 'tests/src/loops.rs', lines 129:0-143:1 *)
+    Source: 'tests/src/loops.rs', lines 132:0-146:1 *)
 Fixpoint get_elem_shared_loop
   (n : nat) (x : usize) (ls : List_t usize) : result usize :=
   match n with
@@ -263,7 +263,7 @@ Fixpoint get_elem_shared_loop
 .
 
 (** [loops::get_elem_shared]:
-    Source: 'tests/src/loops.rs', lines 129:0-129:68 *)
+    Source: 'tests/src/loops.rs', lines 132:0-132:68 *)
 Definition get_elem_shared
   (n : nat) (slots : alloc_vec_Vec (List_t usize)) (x : usize) :
   result usize
@@ -275,7 +275,7 @@ Definition get_elem_shared
 .
 
 (** [loops::id_mut]:
-    Source: 'tests/src/loops.rs', lines 145:0-145:50 *)
+    Source: 'tests/src/loops.rs', lines 148:0-148:50 *)
 Definition id_mut
   (T : Type) (ls : List_t T) :
   result ((List_t T) * (List_t T -> result (List_t T)))
@@ -284,12 +284,12 @@ Definition id_mut
 .
 
 (** [loops::id_shared]:
-    Source: 'tests/src/loops.rs', lines 149:0-149:45 *)
+    Source: 'tests/src/loops.rs', lines 152:0-152:45 *)
 Definition id_shared (T : Type) (ls : List_t T) : result (List_t T) :=
   Ok ls.
 
 (** [loops::list_nth_mut_loop_with_id]: loop 0:
-    Source: 'tests/src/loops.rs', lines 154:0-165:1 *)
+    Source: 'tests/src/loops.rs', lines 157:0-168:1 *)
 Fixpoint list_nth_mut_loop_with_id_loop
   (T : Type) (n : nat) (i : u32) (ls : List_t T) :
   result (T * (T -> result (List_t T)))
@@ -313,7 +313,7 @@ Fixpoint list_nth_mut_loop_with_id_loop
 .
 
 (** [loops::list_nth_mut_loop_with_id]:
-    Source: 'tests/src/loops.rs', lines 154:0-154:75 *)
+    Source: 'tests/src/loops.rs', lines 157:0-157:75 *)
 Definition list_nth_mut_loop_with_id
   (T : Type) (n : nat) (ls : List_t T) (i : u32) :
   result (T * (T -> result (List_t T)))
@@ -327,7 +327,7 @@ Definition list_nth_mut_loop_with_id
 .
 
 (** [loops::list_nth_shared_loop_with_id]: loop 0:
-    Source: 'tests/src/loops.rs', lines 168:0-179:1 *)
+    Source: 'tests/src/loops.rs', lines 171:0-182:1 *)
 Fixpoint list_nth_shared_loop_with_id_loop
   (T : Type) (n : nat) (i : u32) (ls : List_t T) : result T :=
   match n with
@@ -345,14 +345,14 @@ Fixpoint list_nth_shared_loop_with_id_loop
 .
 
 (** [loops::list_nth_shared_loop_with_id]:
-    Source: 'tests/src/loops.rs', lines 168:0-168:70 *)
+    Source: 'tests/src/loops.rs', lines 171:0-171:70 *)
 Definition list_nth_shared_loop_with_id
   (T : Type) (n : nat) (ls : List_t T) (i : u32) : result T :=
   ls1 <- id_shared T ls; list_nth_shared_loop_with_id_loop T n i ls1
 .
 
 (** [loops::list_nth_mut_loop_pair]: loop 0:
-    Source: 'tests/src/loops.rs', lines 184:0-205:1 *)
+    Source: 'tests/src/loops.rs', lines 187:0-208:1 *)
 Fixpoint list_nth_mut_loop_pair_loop
   (T : Type) (n : nat) (ls0 : List_t T) (ls1 : List_t T) (i : u32) :
   result ((T * T) * (T -> result (List_t T)) * (T -> result (List_t T)))
@@ -386,7 +386,7 @@ Fixpoint list_nth_mut_loop_pair_loop
 .
 
 (** [loops::list_nth_mut_loop_pair]:
-    Source: 'tests/src/loops.rs', lines 184:0-188:27 *)
+    Source: 'tests/src/loops.rs', lines 187:0-191:27 *)
 Definition list_nth_mut_loop_pair
   (T : Type) (n : nat) (ls0 : List_t T) (ls1 : List_t T) (i : u32) :
   result ((T * T) * (T -> result (List_t T)) * (T -> result (List_t T)))
@@ -395,7 +395,7 @@ Definition list_nth_mut_loop_pair
 .
 
 (** [loops::list_nth_shared_loop_pair]: loop 0:
-    Source: 'tests/src/loops.rs', lines 208:0-229:1 *)
+    Source: 'tests/src/loops.rs', lines 211:0-232:1 *)
 Fixpoint list_nth_shared_loop_pair_loop
   (T : Type) (n : nat) (ls0 : List_t T) (ls1 : List_t T) (i : u32) :
   result (T * T)
@@ -419,7 +419,7 @@ Fixpoint list_nth_shared_loop_pair_loop
 .
 
 (** [loops::list_nth_shared_loop_pair]:
-    Source: 'tests/src/loops.rs', lines 208:0-212:19 *)
+    Source: 'tests/src/loops.rs', lines 211:0-215:19 *)
 Definition list_nth_shared_loop_pair
   (T : Type) (n : nat) (ls0 : List_t T) (ls1 : List_t T) (i : u32) :
   result (T * T)
@@ -428,7 +428,7 @@ Definition list_nth_shared_loop_pair
 .
 
 (** [loops::list_nth_mut_loop_pair_merge]: loop 0:
-    Source: 'tests/src/loops.rs', lines 233:0-248:1 *)
+    Source: 'tests/src/loops.rs', lines 236:0-251:1 *)
 Fixpoint list_nth_mut_loop_pair_merge_loop
   (T : Type) (n : nat) (ls0 : List_t T) (ls1 : List_t T) (i : u32) :
   result ((T * T) * ((T * T) -> result ((List_t T) * (List_t T))))
@@ -464,7 +464,7 @@ Fixpoint list_nth_mut_loop_pair_merge_loop
 .
 
 (** [loops::list_nth_mut_loop_pair_merge]:
-    Source: 'tests/src/loops.rs', lines 233:0-237:27 *)
+    Source: 'tests/src/loops.rs', lines 236:0-240:27 *)
 Definition list_nth_mut_loop_pair_merge
   (T : Type) (n : nat) (ls0 : List_t T) (ls1 : List_t T) (i : u32) :
   result ((T * T) * ((T * T) -> result ((List_t T) * (List_t T))))
@@ -473,7 +473,7 @@ Definition list_nth_mut_loop_pair_merge
 .
 
 (** [loops::list_nth_shared_loop_pair_merge]: loop 0:
-    Source: 'tests/src/loops.rs', lines 251:0-266:1 *)
+    Source: 'tests/src/loops.rs', lines 254:0-269:1 *)
 Fixpoint list_nth_shared_loop_pair_merge_loop
   (T : Type) (n : nat) (ls0 : List_t T) (ls1 : List_t T) (i : u32) :
   result (T * T)
@@ -498,7 +498,7 @@ Fixpoint list_nth_shared_loop_pair_merge_loop
 .
 
 (** [loops::list_nth_shared_loop_pair_merge]:
-    Source: 'tests/src/loops.rs', lines 251:0-255:19 *)
+    Source: 'tests/src/loops.rs', lines 254:0-258:19 *)
 Definition list_nth_shared_loop_pair_merge
   (T : Type) (n : nat) (ls0 : List_t T) (ls1 : List_t T) (i : u32) :
   result (T * T)
@@ -507,7 +507,7 @@ Definition list_nth_shared_loop_pair_merge
 .
 
 (** [loops::list_nth_mut_shared_loop_pair]: loop 0:
-    Source: 'tests/src/loops.rs', lines 269:0-284:1 *)
+    Source: 'tests/src/loops.rs', lines 272:0-287:1 *)
 Fixpoint list_nth_mut_shared_loop_pair_loop
   (T : Type) (n : nat) (ls0 : List_t T) (ls1 : List_t T) (i : u32) :
   result ((T * T) * (T -> result (List_t T)))
@@ -538,7 +538,7 @@ Fixpoint list_nth_mut_shared_loop_pair_loop
 .
 
 (** [loops::list_nth_mut_shared_loop_pair]:
-    Source: 'tests/src/loops.rs', lines 269:0-273:23 *)
+    Source: 'tests/src/loops.rs', lines 272:0-276:23 *)
 Definition list_nth_mut_shared_loop_pair
   (T : Type) (n : nat) (ls0 : List_t T) (ls1 : List_t T) (i : u32) :
   result ((T * T) * (T -> result (List_t T)))
@@ -547,7 +547,7 @@ Definition list_nth_mut_shared_loop_pair
 .
 
 (** [loops::list_nth_mut_shared_loop_pair_merge]: loop 0:
-    Source: 'tests/src/loops.rs', lines 288:0-303:1 *)
+    Source: 'tests/src/loops.rs', lines 291:0-306:1 *)
 Fixpoint list_nth_mut_shared_loop_pair_merge_loop
   (T : Type) (n : nat) (ls0 : List_t T) (ls1 : List_t T) (i : u32) :
   result ((T * T) * (T -> result (List_t T)))
@@ -578,7 +578,7 @@ Fixpoint list_nth_mut_shared_loop_pair_merge_loop
 .
 
 (** [loops::list_nth_mut_shared_loop_pair_merge]:
-    Source: 'tests/src/loops.rs', lines 288:0-292:23 *)
+    Source: 'tests/src/loops.rs', lines 291:0-295:23 *)
 Definition list_nth_mut_shared_loop_pair_merge
   (T : Type) (n : nat) (ls0 : List_t T) (ls1 : List_t T) (i : u32) :
   result ((T * T) * (T -> result (List_t T)))
@@ -587,7 +587,7 @@ Definition list_nth_mut_shared_loop_pair_merge
 .
 
 (** [loops::list_nth_shared_mut_loop_pair]: loop 0:
-    Source: 'tests/src/loops.rs', lines 307:0-322:1 *)
+    Source: 'tests/src/loops.rs', lines 310:0-325:1 *)
 Fixpoint list_nth_shared_mut_loop_pair_loop
   (T : Type) (n : nat) (ls0 : List_t T) (ls1 : List_t T) (i : u32) :
   result ((T * T) * (T -> result (List_t T)))
@@ -618,7 +618,7 @@ Fixpoint list_nth_shared_mut_loop_pair_loop
 .
 
 (** [loops::list_nth_shared_mut_loop_pair]:
-    Source: 'tests/src/loops.rs', lines 307:0-311:23 *)
+    Source: 'tests/src/loops.rs', lines 310:0-314:23 *)
 Definition list_nth_shared_mut_loop_pair
   (T : Type) (n : nat) (ls0 : List_t T) (ls1 : List_t T) (i : u32) :
   result ((T * T) * (T -> result (List_t T)))
@@ -627,7 +627,7 @@ Definition list_nth_shared_mut_loop_pair
 .
 
 (** [loops::list_nth_shared_mut_loop_pair_merge]: loop 0:
-    Source: 'tests/src/loops.rs', lines 326:0-341:1 *)
+    Source: 'tests/src/loops.rs', lines 329:0-344:1 *)
 Fixpoint list_nth_shared_mut_loop_pair_merge_loop
   (T : Type) (n : nat) (ls0 : List_t T) (ls1 : List_t T) (i : u32) :
   result ((T * T) * (T -> result (List_t T)))
@@ -658,7 +658,7 @@ Fixpoint list_nth_shared_mut_loop_pair_merge_loop
 .
 
 (** [loops::list_nth_shared_mut_loop_pair_merge]:
-    Source: 'tests/src/loops.rs', lines 326:0-330:23 *)
+    Source: 'tests/src/loops.rs', lines 329:0-333:23 *)
 Definition list_nth_shared_mut_loop_pair_merge
   (T : Type) (n : nat) (ls0 : List_t T) (ls1 : List_t T) (i : u32) :
   result ((T * T) * (T -> result (List_t T)))
@@ -667,7 +667,7 @@ Definition list_nth_shared_mut_loop_pair_merge
 .
 
 (** [loops::ignore_input_mut_borrow]: loop 0:
-    Source: 'tests/src/loops.rs', lines 345:0-349:1 *)
+    Source: 'tests/src/loops.rs', lines 348:0-352:1 *)
 Fixpoint ignore_input_mut_borrow_loop (n : nat) (i : u32) : result unit :=
   match n with
   | O => Fail_ OutOfFuel
@@ -679,14 +679,14 @@ Fixpoint ignore_input_mut_borrow_loop (n : nat) (i : u32) : result unit :=
 .
 
 (** [loops::ignore_input_mut_borrow]:
-    Source: 'tests/src/loops.rs', lines 345:0-345:56 *)
+    Source: 'tests/src/loops.rs', lines 348:0-348:56 *)
 Definition ignore_input_mut_borrow
   (n : nat) (_a : u32) (i : u32) : result u32 :=
   _ <- ignore_input_mut_borrow_loop n i; Ok _a
 .
 
 (** [loops::incr_ignore_input_mut_borrow]: loop 0:
-    Source: 'tests/src/loops.rs', lines 353:0-358:1 *)
+    Source: 'tests/src/loops.rs', lines 356:0-361:1 *)
 Fixpoint incr_ignore_input_mut_borrow_loop (n : nat) (i : u32) : result unit :=
   match n with
   | O => Fail_ OutOfFuel
@@ -698,14 +698,14 @@ Fixpoint incr_ignore_input_mut_borrow_loop (n : nat) (i : u32) : result unit :=
 .
 
 (** [loops::incr_ignore_input_mut_borrow]:
-    Source: 'tests/src/loops.rs', lines 353:0-353:60 *)
+    Source: 'tests/src/loops.rs', lines 356:0-356:60 *)
 Definition incr_ignore_input_mut_borrow
   (n : nat) (a : u32) (i : u32) : result u32 :=
   a1 <- u32_add a 1%u32; _ <- incr_ignore_input_mut_borrow_loop n i; Ok a1
 .
 
 (** [loops::ignore_input_shared_borrow]: loop 0:
-    Source: 'tests/src/loops.rs', lines 362:0-366:1 *)
+    Source: 'tests/src/loops.rs', lines 365:0-369:1 *)
 Fixpoint ignore_input_shared_borrow_loop (n : nat) (i : u32) : result unit :=
   match n with
   | O => Fail_ OutOfFuel
@@ -717,7 +717,7 @@ Fixpoint ignore_input_shared_borrow_loop (n : nat) (i : u32) : result unit :=
 .
 
 (** [loops::ignore_input_shared_borrow]:
-    Source: 'tests/src/loops.rs', lines 362:0-362:59 *)
+    Source: 'tests/src/loops.rs', lines 365:0-365:59 *)
 Definition ignore_input_shared_borrow
   (n : nat) (_a : u32) (i : u32) : result u32 :=
   _ <- ignore_input_shared_borrow_loop n i; Ok _a

--- a/tests/coq/misc/NoNestedBorrows.v
+++ b/tests/coq/misc/NoNestedBorrows.v
@@ -9,7 +9,7 @@ Local Open Scope Primitives_scope.
 Module NoNestedBorrows.
 
 (** [no_nested_borrows::Pair]
-    Source: 'tests/src/no_nested_borrows.rs', lines 4:0-4:23 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 6:0-6:23 *)
 Record Pair_t (T1 T2 : Type) := mkPair_t { pair_x : T1; pair_y : T2; }.
 
 Arguments mkPair_t { _ _ }.
@@ -17,7 +17,7 @@ Arguments pair_x { _ _ }.
 Arguments pair_y { _ _ }.
 
 (** [no_nested_borrows::List]
-    Source: 'tests/src/no_nested_borrows.rs', lines 9:0-9:16 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 11:0-11:16 *)
 Inductive List_t (T : Type) :=
 | List_Cons : T -> List_t T -> List_t T
 | List_Nil : List_t T
@@ -27,25 +27,25 @@ Arguments List_Cons { _ }.
 Arguments List_Nil { _ }.
 
 (** [no_nested_borrows::One]
-    Source: 'tests/src/no_nested_borrows.rs', lines 20:0-20:16 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 22:0-22:16 *)
 Inductive One_t (T1 : Type) := | One_One : T1 -> One_t T1.
 
 Arguments One_One { _ }.
 
 (** [no_nested_borrows::EmptyEnum]
-    Source: 'tests/src/no_nested_borrows.rs', lines 26:0-26:18 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 28:0-28:18 *)
 Inductive EmptyEnum_t := | EmptyEnum_Empty : EmptyEnum_t.
 
 (** [no_nested_borrows::Enum]
-    Source: 'tests/src/no_nested_borrows.rs', lines 32:0-32:13 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 34:0-34:13 *)
 Inductive Enum_t := | Enum_Variant1 : Enum_t | Enum_Variant2 : Enum_t.
 
 (** [no_nested_borrows::EmptyStruct]
-    Source: 'tests/src/no_nested_borrows.rs', lines 39:0-39:22 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 41:0-41:22 *)
 Definition EmptyStruct_t : Type := unit.
 
 (** [no_nested_borrows::Sum]
-    Source: 'tests/src/no_nested_borrows.rs', lines 41:0-41:20 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 43:0-43:20 *)
 Inductive Sum_t (T1 T2 : Type) :=
 | Sum_Left : T1 -> Sum_t T1 T2
 | Sum_Right : T2 -> Sum_t T1 T2
@@ -55,22 +55,22 @@ Arguments Sum_Left { _ _ }.
 Arguments Sum_Right { _ _ }.
 
 (** [no_nested_borrows::cast_u32_to_i32]:
-    Source: 'tests/src/no_nested_borrows.rs', lines 46:0-46:37 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 48:0-48:37 *)
 Definition cast_u32_to_i32 (x : u32) : result i32 :=
   scalar_cast U32 I32 x.
 
 (** [no_nested_borrows::cast_bool_to_i32]:
-    Source: 'tests/src/no_nested_borrows.rs', lines 50:0-50:39 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 52:0-52:39 *)
 Definition cast_bool_to_i32 (x : bool) : result i32 :=
   scalar_cast_bool I32 x.
 
 (** [no_nested_borrows::cast_bool_to_bool]:
-    Source: 'tests/src/no_nested_borrows.rs', lines 55:0-55:41 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 57:0-57:41 *)
 Definition cast_bool_to_bool (x : bool) : result bool :=
   Ok x.
 
 (** [no_nested_borrows::test2]:
-    Source: 'tests/src/no_nested_borrows.rs', lines 60:0-60:14 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 62:0-62:14 *)
 Definition test2 : result unit :=
   _ <- u32_add 23%u32 44%u32; Ok tt.
 
@@ -78,13 +78,13 @@ Definition test2 : result unit :=
 Check (test2 )%return.
 
 (** [no_nested_borrows::get_max]:
-    Source: 'tests/src/no_nested_borrows.rs', lines 72:0-72:37 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 74:0-74:37 *)
 Definition get_max (x : u32) (y : u32) : result u32 :=
   if x s>= y then Ok x else Ok y
 .
 
 (** [no_nested_borrows::test3]:
-    Source: 'tests/src/no_nested_borrows.rs', lines 80:0-80:14 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 82:0-82:14 *)
 Definition test3 : result unit :=
   x <- get_max 4%u32 3%u32;
   y <- get_max 10%u32 11%u32;
@@ -96,7 +96,7 @@ Definition test3 : result unit :=
 Check (test3 )%return.
 
 (** [no_nested_borrows::test_neg1]:
-    Source: 'tests/src/no_nested_borrows.rs', lines 87:0-87:18 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 89:0-89:18 *)
 Definition test_neg1 : result unit :=
   y <- i32_neg 3%i32; if negb (y s= (-3)%i32) then Fail_ Failure else Ok tt
 .
@@ -105,7 +105,7 @@ Definition test_neg1 : result unit :=
 Check (test_neg1 )%return.
 
 (** [no_nested_borrows::refs_test1]:
-    Source: 'tests/src/no_nested_borrows.rs', lines 94:0-94:19 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 96:0-96:19 *)
 Definition refs_test1 : result unit :=
   if negb (1%i32 s= 1%i32) then Fail_ Failure else Ok tt
 .
@@ -114,7 +114,7 @@ Definition refs_test1 : result unit :=
 Check (refs_test1 )%return.
 
 (** [no_nested_borrows::refs_test2]:
-    Source: 'tests/src/no_nested_borrows.rs', lines 105:0-105:19 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 107:0-107:19 *)
 Definition refs_test2 : result unit :=
   if negb (2%i32 s= 2%i32)
   then Fail_ Failure
@@ -131,7 +131,7 @@ Definition refs_test2 : result unit :=
 Check (refs_test2 )%return.
 
 (** [no_nested_borrows::test_list1]:
-    Source: 'tests/src/no_nested_borrows.rs', lines 121:0-121:19 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 123:0-123:19 *)
 Definition test_list1 : result unit :=
   Ok tt.
 
@@ -139,7 +139,7 @@ Definition test_list1 : result unit :=
 Check (test_list1 )%return.
 
 (** [no_nested_borrows::test_box1]:
-    Source: 'tests/src/no_nested_borrows.rs', lines 126:0-126:18 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 128:0-128:18 *)
 Definition test_box1 : result unit :=
   p <- alloc_boxed_Box_deref_mut i32 0%i32;
   let (_, deref_mut_back) := p in
@@ -152,24 +152,24 @@ Definition test_box1 : result unit :=
 Check (test_box1 )%return.
 
 (** [no_nested_borrows::copy_int]:
-    Source: 'tests/src/no_nested_borrows.rs', lines 136:0-136:30 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 138:0-138:30 *)
 Definition copy_int (x : i32) : result i32 :=
   Ok x.
 
 (** [no_nested_borrows::test_unreachable]:
-    Source: 'tests/src/no_nested_borrows.rs', lines 142:0-142:32 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 144:0-144:32 *)
 Definition test_unreachable (b : bool) : result unit :=
   if b then Fail_ Failure else Ok tt
 .
 
 (** [no_nested_borrows::test_panic]:
-    Source: 'tests/src/no_nested_borrows.rs', lines 150:0-150:26 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 152:0-152:26 *)
 Definition test_panic (b : bool) : result unit :=
   if b then Fail_ Failure else Ok tt
 .
 
 (** [no_nested_borrows::test_copy_int]:
-    Source: 'tests/src/no_nested_borrows.rs', lines 157:0-157:22 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 159:0-159:22 *)
 Definition test_copy_int : result unit :=
   y <- copy_int 0%i32; if negb (0%i32 s= y) then Fail_ Failure else Ok tt
 .
@@ -178,13 +178,13 @@ Definition test_copy_int : result unit :=
 Check (test_copy_int )%return.
 
 (** [no_nested_borrows::is_cons]:
-    Source: 'tests/src/no_nested_borrows.rs', lines 164:0-164:38 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 166:0-166:38 *)
 Definition is_cons (T : Type) (l : List_t T) : result bool :=
   match l with | List_Cons _ _ => Ok true | List_Nil => Ok false end
 .
 
 (** [no_nested_borrows::test_is_cons]:
-    Source: 'tests/src/no_nested_borrows.rs', lines 171:0-171:21 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 173:0-173:21 *)
 Definition test_is_cons : result unit :=
   b <- is_cons i32 (List_Cons 0%i32 List_Nil);
   if negb b then Fail_ Failure else Ok tt
@@ -194,13 +194,13 @@ Definition test_is_cons : result unit :=
 Check (test_is_cons )%return.
 
 (** [no_nested_borrows::split_list]:
-    Source: 'tests/src/no_nested_borrows.rs', lines 177:0-177:48 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 179:0-179:48 *)
 Definition split_list (T : Type) (l : List_t T) : result (T * (List_t T)) :=
   match l with | List_Cons hd tl => Ok (hd, tl) | List_Nil => Fail_ Failure end
 .
 
 (** [no_nested_borrows::test_split_list]:
-    Source: 'tests/src/no_nested_borrows.rs', lines 185:0-185:24 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 187:0-187:24 *)
 Definition test_split_list : result unit :=
   p <- split_list i32 (List_Cons 0%i32 List_Nil);
   let (hd, _) := p in
@@ -211,7 +211,7 @@ Definition test_split_list : result unit :=
 Check (test_split_list )%return.
 
 (** [no_nested_borrows::choose]:
-    Source: 'tests/src/no_nested_borrows.rs', lines 192:0-192:70 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 194:0-194:70 *)
 Definition choose
   (T : Type) (b : bool) (x : T) (y : T) : result (T * (T -> result (T * T))) :=
   if b
@@ -220,7 +220,7 @@ Definition choose
 .
 
 (** [no_nested_borrows::choose_test]:
-    Source: 'tests/src/no_nested_borrows.rs', lines 200:0-200:20 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 202:0-202:20 *)
 Definition choose_test : result unit :=
   p <- choose i32 true 0%i32 0%i32;
   let (z, choose_back) := p in
@@ -239,18 +239,18 @@ Definition choose_test : result unit :=
 Check (choose_test )%return.
 
 (** [no_nested_borrows::test_char]:
-    Source: 'tests/src/no_nested_borrows.rs', lines 212:0-212:26 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 214:0-214:26 *)
 Definition test_char : result char :=
   Ok (char_of_byte Coq.Init.Byte.x61).
 
 (** [no_nested_borrows::Tree]
-    Source: 'tests/src/no_nested_borrows.rs', lines 217:0-217:16 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 219:0-219:16 *)
 Inductive Tree_t (T : Type) :=
 | Tree_Leaf : T -> Tree_t T
 | Tree_Node : T -> NodeElem_t T -> Tree_t T -> Tree_t T
 
 (** [no_nested_borrows::NodeElem]
-    Source: 'tests/src/no_nested_borrows.rs', lines 222:0-222:20 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 224:0-224:20 *)
 with NodeElem_t (T : Type) :=
 | NodeElem_Cons : Tree_t T -> NodeElem_t T -> NodeElem_t T
 | NodeElem_Nil : NodeElem_t T
@@ -263,7 +263,7 @@ Arguments NodeElem_Cons { _ }.
 Arguments NodeElem_Nil { _ }.
 
 (** [no_nested_borrows::list_length]:
-    Source: 'tests/src/no_nested_borrows.rs', lines 257:0-257:48 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 259:0-259:48 *)
 Fixpoint list_length (T : Type) (l : List_t T) : result u32 :=
   match l with
   | List_Cons _ l1 => i <- list_length T l1; u32_add 1%u32 i
@@ -272,7 +272,7 @@ Fixpoint list_length (T : Type) (l : List_t T) : result u32 :=
 .
 
 (** [no_nested_borrows::list_nth_shared]:
-    Source: 'tests/src/no_nested_borrows.rs', lines 265:0-265:62 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 267:0-267:62 *)
 Fixpoint list_nth_shared (T : Type) (l : List_t T) (i : u32) : result T :=
   match l with
   | List_Cons x tl =>
@@ -284,7 +284,7 @@ Fixpoint list_nth_shared (T : Type) (l : List_t T) (i : u32) : result T :=
 .
 
 (** [no_nested_borrows::list_nth_mut]:
-    Source: 'tests/src/no_nested_borrows.rs', lines 281:0-281:67 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 283:0-283:67 *)
 Fixpoint list_nth_mut
   (T : Type) (l : List_t T) (i : u32) :
   result (T * (T -> result (List_t T)))
@@ -305,7 +305,7 @@ Fixpoint list_nth_mut
 .
 
 (** [no_nested_borrows::list_rev_aux]:
-    Source: 'tests/src/no_nested_borrows.rs', lines 297:0-297:63 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 299:0-299:63 *)
 Fixpoint list_rev_aux
   (T : Type) (li : List_t T) (lo : List_t T) : result (List_t T) :=
   match li with
@@ -315,14 +315,14 @@ Fixpoint list_rev_aux
 .
 
 (** [no_nested_borrows::list_rev]:
-    Source: 'tests/src/no_nested_borrows.rs', lines 311:0-311:42 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 313:0-313:42 *)
 Definition list_rev (T : Type) (l : List_t T) : result (List_t T) :=
   let (li, _) := core_mem_replace (List_t T) l List_Nil in
   list_rev_aux T li List_Nil
 .
 
 (** [no_nested_borrows::test_list_functions]:
-    Source: 'tests/src/no_nested_borrows.rs', lines 316:0-316:28 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 318:0-318:28 *)
 Definition test_list_functions : result unit :=
   let l := List_Cons 2%i32 List_Nil in
   let l1 := List_Cons 1%i32 l in
@@ -361,7 +361,7 @@ Definition test_list_functions : result unit :=
 Check (test_list_functions )%return.
 
 (** [no_nested_borrows::id_mut_pair1]:
-    Source: 'tests/src/no_nested_borrows.rs', lines 332:0-332:89 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 334:0-334:89 *)
 Definition id_mut_pair1
   (T1 T2 : Type) (x : T1) (y : T2) :
   result ((T1 * T2) * ((T1 * T2) -> result (T1 * T2)))
@@ -370,7 +370,7 @@ Definition id_mut_pair1
 .
 
 (** [no_nested_borrows::id_mut_pair2]:
-    Source: 'tests/src/no_nested_borrows.rs', lines 336:0-336:88 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 338:0-338:88 *)
 Definition id_mut_pair2
   (T1 T2 : Type) (p : (T1 * T2)) :
   result ((T1 * T2) * ((T1 * T2) -> result (T1 * T2)))
@@ -379,7 +379,7 @@ Definition id_mut_pair2
 .
 
 (** [no_nested_borrows::id_mut_pair3]:
-    Source: 'tests/src/no_nested_borrows.rs', lines 340:0-340:93 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 342:0-342:93 *)
 Definition id_mut_pair3
   (T1 T2 : Type) (x : T1) (y : T2) :
   result ((T1 * T2) * (T1 -> result T1) * (T2 -> result T2))
@@ -388,7 +388,7 @@ Definition id_mut_pair3
 .
 
 (** [no_nested_borrows::id_mut_pair4]:
-    Source: 'tests/src/no_nested_borrows.rs', lines 344:0-344:92 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 346:0-346:92 *)
 Definition id_mut_pair4
   (T1 T2 : Type) (p : (T1 * T2)) :
   result ((T1 * T2) * (T1 -> result T1) * (T2 -> result T2))
@@ -397,7 +397,7 @@ Definition id_mut_pair4
 .
 
 (** [no_nested_borrows::StructWithTuple]
-    Source: 'tests/src/no_nested_borrows.rs', lines 351:0-351:34 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 353:0-353:34 *)
 Record StructWithTuple_t (T1 T2 : Type) :=
 mkStructWithTuple_t {
   structWithTuple_p : (T1 * T2);
@@ -408,25 +408,25 @@ Arguments mkStructWithTuple_t { _ _ }.
 Arguments structWithTuple_p { _ _ }.
 
 (** [no_nested_borrows::new_tuple1]:
-    Source: 'tests/src/no_nested_borrows.rs', lines 355:0-355:48 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 357:0-357:48 *)
 Definition new_tuple1 : result (StructWithTuple_t u32 u32) :=
   Ok {| structWithTuple_p := (1%u32, 2%u32) |}
 .
 
 (** [no_nested_borrows::new_tuple2]:
-    Source: 'tests/src/no_nested_borrows.rs', lines 359:0-359:48 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 361:0-361:48 *)
 Definition new_tuple2 : result (StructWithTuple_t i16 i16) :=
   Ok {| structWithTuple_p := (1%i16, 2%i16) |}
 .
 
 (** [no_nested_borrows::new_tuple3]:
-    Source: 'tests/src/no_nested_borrows.rs', lines 363:0-363:48 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 365:0-365:48 *)
 Definition new_tuple3 : result (StructWithTuple_t u64 i64) :=
   Ok {| structWithTuple_p := (1%u64, 2%i64) |}
 .
 
 (** [no_nested_borrows::StructWithPair]
-    Source: 'tests/src/no_nested_borrows.rs', lines 368:0-368:33 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 370:0-370:33 *)
 Record StructWithPair_t (T1 T2 : Type) :=
 mkStructWithPair_t {
   structWithPair_p : Pair_t T1 T2;
@@ -437,13 +437,13 @@ Arguments mkStructWithPair_t { _ _ }.
 Arguments structWithPair_p { _ _ }.
 
 (** [no_nested_borrows::new_pair1]:
-    Source: 'tests/src/no_nested_borrows.rs', lines 372:0-372:46 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 374:0-374:46 *)
 Definition new_pair1 : result (StructWithPair_t u32 u32) :=
   Ok {| structWithPair_p := {| pair_x := 1%u32; pair_y := 2%u32 |} |}
 .
 
 (** [no_nested_borrows::test_constants]:
-    Source: 'tests/src/no_nested_borrows.rs', lines 380:0-380:23 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 382:0-382:23 *)
 Definition test_constants : result unit :=
   swt <- new_tuple1;
   let (i, _) := swt.(structWithTuple_p) in
@@ -470,7 +470,7 @@ Definition test_constants : result unit :=
 Check (test_constants )%return.
 
 (** [no_nested_borrows::test_weird_borrows1]:
-    Source: 'tests/src/no_nested_borrows.rs', lines 389:0-389:28 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 391:0-391:28 *)
 Definition test_weird_borrows1 : result unit :=
   Ok tt.
 
@@ -478,78 +478,78 @@ Definition test_weird_borrows1 : result unit :=
 Check (test_weird_borrows1 )%return.
 
 (** [no_nested_borrows::test_mem_replace]:
-    Source: 'tests/src/no_nested_borrows.rs', lines 399:0-399:37 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 401:0-401:37 *)
 Definition test_mem_replace (px : u32) : result u32 :=
   let (y, _) := core_mem_replace u32 px 1%u32 in
   if negb (y s= 0%u32) then Fail_ Failure else Ok 2%u32
 .
 
 (** [no_nested_borrows::test_shared_borrow_bool1]:
-    Source: 'tests/src/no_nested_borrows.rs', lines 406:0-406:47 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 408:0-408:47 *)
 Definition test_shared_borrow_bool1 (b : bool) : result u32 :=
   if b then Ok 0%u32 else Ok 1%u32
 .
 
 (** [no_nested_borrows::test_shared_borrow_bool2]:
-    Source: 'tests/src/no_nested_borrows.rs', lines 419:0-419:40 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 421:0-421:40 *)
 Definition test_shared_borrow_bool2 : result u32 :=
   Ok 0%u32.
 
 (** [no_nested_borrows::test_shared_borrow_enum1]:
-    Source: 'tests/src/no_nested_borrows.rs', lines 434:0-434:52 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 436:0-436:52 *)
 Definition test_shared_borrow_enum1 (l : List_t u32) : result u32 :=
   match l with | List_Cons _ _ => Ok 1%u32 | List_Nil => Ok 0%u32 end
 .
 
 (** [no_nested_borrows::test_shared_borrow_enum2]:
-    Source: 'tests/src/no_nested_borrows.rs', lines 446:0-446:40 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 448:0-448:40 *)
 Definition test_shared_borrow_enum2 : result u32 :=
   Ok 0%u32.
 
 (** [no_nested_borrows::incr]:
-    Source: 'tests/src/no_nested_borrows.rs', lines 457:0-457:24 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 459:0-459:24 *)
 Definition incr (x : u32) : result u32 :=
   u32_add x 1%u32.
 
 (** [no_nested_borrows::call_incr]:
-    Source: 'tests/src/no_nested_borrows.rs', lines 461:0-461:35 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 463:0-463:35 *)
 Definition call_incr (x : u32) : result u32 :=
   incr x.
 
 (** [no_nested_borrows::read_then_incr]:
-    Source: 'tests/src/no_nested_borrows.rs', lines 466:0-466:41 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 468:0-468:41 *)
 Definition read_then_incr (x : u32) : result (u32 * u32) :=
   x1 <- u32_add x 1%u32; Ok (x, x1)
 .
 
 (** [no_nested_borrows::Tuple]
-    Source: 'tests/src/no_nested_borrows.rs', lines 472:0-472:24 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 474:0-474:24 *)
 Definition Tuple_t (T1 T2 : Type) : Type := T1 * T2.
 
 (** [no_nested_borrows::use_tuple_struct]:
-    Source: 'tests/src/no_nested_borrows.rs', lines 474:0-474:48 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 476:0-476:48 *)
 Definition use_tuple_struct (x : Tuple_t u32 u32) : result (Tuple_t u32 u32) :=
   let (_, i) := x in Ok (1%u32, i)
 .
 
 (** [no_nested_borrows::create_tuple_struct]:
-    Source: 'tests/src/no_nested_borrows.rs', lines 478:0-478:61 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 480:0-480:61 *)
 Definition create_tuple_struct
   (x : u32) (y : u64) : result (Tuple_t u32 u64) :=
   Ok (x, y)
 .
 
 (** [no_nested_borrows::IdType]
-    Source: 'tests/src/no_nested_borrows.rs', lines 483:0-483:20 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 485:0-485:20 *)
 Definition IdType_t (T : Type) : Type := T.
 
 (** [no_nested_borrows::use_id_type]:
-    Source: 'tests/src/no_nested_borrows.rs', lines 485:0-485:40 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 487:0-487:40 *)
 Definition use_id_type (T : Type) (x : IdType_t T) : result T :=
   Ok x.
 
 (** [no_nested_borrows::create_id_type]:
-    Source: 'tests/src/no_nested_borrows.rs', lines 489:0-489:43 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 491:0-491:43 *)
 Definition create_id_type (T : Type) (x : T) : result (IdType_t T) :=
   Ok x.
 

--- a/tests/coq/misc/Paper.v
+++ b/tests/coq/misc/Paper.v
@@ -9,12 +9,12 @@ Local Open Scope Primitives_scope.
 Module Paper.
 
 (** [paper::ref_incr]:
-    Source: 'tests/src/paper.rs', lines 4:0-4:28 *)
+    Source: 'tests/src/paper.rs', lines 6:0-6:28 *)
 Definition ref_incr (x : i32) : result i32 :=
   i32_add x 1%i32.
 
 (** [paper::test_incr]:
-    Source: 'tests/src/paper.rs', lines 8:0-8:18 *)
+    Source: 'tests/src/paper.rs', lines 10:0-10:18 *)
 Definition test_incr : result unit :=
   x <- ref_incr 0%i32; if negb (x s= 1%i32) then Fail_ Failure else Ok tt
 .
@@ -23,7 +23,7 @@ Definition test_incr : result unit :=
 Check (test_incr )%return.
 
 (** [paper::choose]:
-    Source: 'tests/src/paper.rs', lines 15:0-15:70 *)
+    Source: 'tests/src/paper.rs', lines 17:0-17:70 *)
 Definition choose
   (T : Type) (b : bool) (x : T) (y : T) : result (T * (T -> result (T * T))) :=
   if b
@@ -32,7 +32,7 @@ Definition choose
 .
 
 (** [paper::test_choose]:
-    Source: 'tests/src/paper.rs', lines 23:0-23:20 *)
+    Source: 'tests/src/paper.rs', lines 25:0-25:20 *)
 Definition test_choose : result unit :=
   p <- choose i32 true 0%i32 0%i32;
   let (z, choose_back) := p in
@@ -51,7 +51,7 @@ Definition test_choose : result unit :=
 Check (test_choose )%return.
 
 (** [paper::List]
-    Source: 'tests/src/paper.rs', lines 35:0-35:16 *)
+    Source: 'tests/src/paper.rs', lines 37:0-37:16 *)
 Inductive List_t (T : Type) :=
 | List_Cons : T -> List_t T -> List_t T
 | List_Nil : List_t T
@@ -61,7 +61,7 @@ Arguments List_Cons { _ }.
 Arguments List_Nil { _ }.
 
 (** [paper::list_nth_mut]:
-    Source: 'tests/src/paper.rs', lines 42:0-42:67 *)
+    Source: 'tests/src/paper.rs', lines 44:0-44:67 *)
 Fixpoint list_nth_mut
   (T : Type) (l : List_t T) (i : u32) :
   result (T * (T -> result (List_t T)))
@@ -82,7 +82,7 @@ Fixpoint list_nth_mut
 .
 
 (** [paper::sum]:
-    Source: 'tests/src/paper.rs', lines 57:0-57:32 *)
+    Source: 'tests/src/paper.rs', lines 59:0-59:32 *)
 Fixpoint sum (l : List_t i32) : result i32 :=
   match l with
   | List_Cons x tl => i <- sum tl; i32_add x i
@@ -91,7 +91,7 @@ Fixpoint sum (l : List_t i32) : result i32 :=
 .
 
 (** [paper::test_nth]:
-    Source: 'tests/src/paper.rs', lines 68:0-68:17 *)
+    Source: 'tests/src/paper.rs', lines 70:0-70:17 *)
 Definition test_nth : result unit :=
   let l := List_Cons 3%i32 List_Nil in
   let l1 := List_Cons 2%i32 l in
@@ -107,7 +107,7 @@ Definition test_nth : result unit :=
 Check (test_nth )%return.
 
 (** [paper::call_choose]:
-    Source: 'tests/src/paper.rs', lines 76:0-76:44 *)
+    Source: 'tests/src/paper.rs', lines 78:0-78:44 *)
 Definition call_choose (p : (u32 * u32)) : result u32 :=
   let (px, py) := p in
   p1 <- choose u32 true px py;

--- a/tests/coq/misc/PoloniusList.v
+++ b/tests/coq/misc/PoloniusList.v
@@ -9,7 +9,7 @@ Local Open Scope Primitives_scope.
 Module PoloniusList.
 
 (** [polonius_list::List]
-    Source: 'tests/src/polonius_list.rs', lines 3:0-3:16 *)
+    Source: 'tests/src/polonius_list.rs', lines 5:0-5:16 *)
 Inductive List_t (T : Type) :=
 | List_Cons : T -> List_t T -> List_t T
 | List_Nil : List_t T
@@ -19,7 +19,7 @@ Arguments List_Cons { _ }.
 Arguments List_Nil { _ }.
 
 (** [polonius_list::get_list_at_x]:
-    Source: 'tests/src/polonius_list.rs', lines 13:0-13:76 *)
+    Source: 'tests/src/polonius_list.rs', lines 15:0-15:76 *)
 Fixpoint get_list_at_x
   (ls : List_t u32) (x : u32) :
   result ((List_t u32) * (List_t u32 -> result (List_t u32)))

--- a/tests/coq/traits/Traits.v
+++ b/tests/coq/traits/Traits.v
@@ -9,7 +9,7 @@ Local Open Scope Primitives_scope.
 Module Traits.
 
 (** Trait declaration: [traits::BoolTrait]
-    Source: 'tests/src/traits.rs', lines 1:0-1:19 *)
+    Source: 'tests/src/traits.rs', lines 2:0-2:19 *)
 Record BoolTrait_t (Self : Type) := mkBoolTrait_t {
   BoolTrait_t_get_bool : Self -> result bool;
 }.
@@ -18,59 +18,59 @@ Arguments mkBoolTrait_t { _ }.
 Arguments BoolTrait_t_get_bool { _ }.
 
 (** [traits::{(traits::BoolTrait for bool)}::get_bool]:
-    Source: 'tests/src/traits.rs', lines 12:4-12:30 *)
+    Source: 'tests/src/traits.rs', lines 13:4-13:30 *)
 Definition boolTraitBool_get_bool (self : bool) : result bool :=
   Ok self.
 
 (** Trait implementation: [traits::{(traits::BoolTrait for bool)}]
-    Source: 'tests/src/traits.rs', lines 11:0-11:23 *)
+    Source: 'tests/src/traits.rs', lines 12:0-12:23 *)
 Definition BoolTraitBool : BoolTrait_t bool := {|
   BoolTrait_t_get_bool := boolTraitBool_get_bool;
 |}.
 
 (** [traits::BoolTrait::ret_true]:
-    Source: 'tests/src/traits.rs', lines 6:4-6:30 *)
+    Source: 'tests/src/traits.rs', lines 7:4-7:30 *)
 Definition boolTrait_ret_true
   {Self : Type} (self_clause : BoolTrait_t Self) (self : Self) : result bool :=
   Ok true
 .
 
 (** [traits::test_bool_trait_bool]:
-    Source: 'tests/src/traits.rs', lines 17:0-17:44 *)
+    Source: 'tests/src/traits.rs', lines 18:0-18:44 *)
 Definition test_bool_trait_bool (x : bool) : result bool :=
   b <- boolTraitBool_get_bool x;
   if b then boolTrait_ret_true BoolTraitBool x else Ok false
 .
 
 (** [traits::{(traits::BoolTrait for core::option::Option<T>)#1}::get_bool]:
-    Source: 'tests/src/traits.rs', lines 23:4-23:30 *)
+    Source: 'tests/src/traits.rs', lines 24:4-24:30 *)
 Definition boolTraitOption_get_bool
   (T : Type) (self : option T) : result bool :=
   match self with | None => Ok false | Some _ => Ok true end
 .
 
 (** Trait implementation: [traits::{(traits::BoolTrait for core::option::Option<T>)#1}]
-    Source: 'tests/src/traits.rs', lines 22:0-22:31 *)
+    Source: 'tests/src/traits.rs', lines 23:0-23:31 *)
 Definition BoolTraitOption (T : Type) : BoolTrait_t (option T) := {|
   BoolTrait_t_get_bool := boolTraitOption_get_bool T;
 |}.
 
 (** [traits::test_bool_trait_option]:
-    Source: 'tests/src/traits.rs', lines 31:0-31:54 *)
+    Source: 'tests/src/traits.rs', lines 32:0-32:54 *)
 Definition test_bool_trait_option (T : Type) (x : option T) : result bool :=
   b <- boolTraitOption_get_bool T x;
   if b then boolTrait_ret_true (BoolTraitOption T) x else Ok false
 .
 
 (** [traits::test_bool_trait]:
-    Source: 'tests/src/traits.rs', lines 35:0-35:50 *)
+    Source: 'tests/src/traits.rs', lines 36:0-36:50 *)
 Definition test_bool_trait
   (T : Type) (boolTraitInst : BoolTrait_t T) (x : T) : result bool :=
   boolTraitInst.(BoolTrait_t_get_bool) x
 .
 
 (** Trait declaration: [traits::ToU64]
-    Source: 'tests/src/traits.rs', lines 39:0-39:15 *)
+    Source: 'tests/src/traits.rs', lines 40:0-40:15 *)
 Record ToU64_t (Self : Type) := mkToU64_t {
   ToU64_t_to_u64 : Self -> result u64;
 }.
@@ -79,16 +79,16 @@ Arguments mkToU64_t { _ }.
 Arguments ToU64_t_to_u64 { _ }.
 
 (** [traits::{(traits::ToU64 for u64)#2}::to_u64]:
-    Source: 'tests/src/traits.rs', lines 44:4-44:26 *)
+    Source: 'tests/src/traits.rs', lines 45:4-45:26 *)
 Definition toU64U64_to_u64 (self : u64) : result u64 :=
   Ok self.
 
 (** Trait implementation: [traits::{(traits::ToU64 for u64)#2}]
-    Source: 'tests/src/traits.rs', lines 43:0-43:18 *)
+    Source: 'tests/src/traits.rs', lines 44:0-44:18 *)
 Definition ToU64U64 : ToU64_t u64 := {| ToU64_t_to_u64 := toU64U64_to_u64; |}.
 
 (** [traits::{(traits::ToU64 for (A, A))#3}::to_u64]:
-    Source: 'tests/src/traits.rs', lines 50:4-50:26 *)
+    Source: 'tests/src/traits.rs', lines 51:4-51:26 *)
 Definition toU64Pair_to_u64
   (A : Type) (toU64Inst : ToU64_t A) (self : (A * A)) : result u64 :=
   let (t, t1) := self in
@@ -98,65 +98,65 @@ Definition toU64Pair_to_u64
 .
 
 (** Trait implementation: [traits::{(traits::ToU64 for (A, A))#3}]
-    Source: 'tests/src/traits.rs', lines 49:0-49:31 *)
+    Source: 'tests/src/traits.rs', lines 50:0-50:31 *)
 Definition ToU64Pair (A : Type) (toU64Inst : ToU64_t A) : ToU64_t (A * A) := {|
   ToU64_t_to_u64 := toU64Pair_to_u64 A toU64Inst;
 |}.
 
 (** [traits::f]:
-    Source: 'tests/src/traits.rs', lines 55:0-55:36 *)
+    Source: 'tests/src/traits.rs', lines 56:0-56:36 *)
 Definition f (T : Type) (toU64Inst : ToU64_t T) (x : (T * T)) : result u64 :=
   toU64Pair_to_u64 T toU64Inst x
 .
 
 (** [traits::g]:
-    Source: 'tests/src/traits.rs', lines 59:0-61:18 *)
+    Source: 'tests/src/traits.rs', lines 60:0-62:18 *)
 Definition g
   (T : Type) (toU64PairInst : ToU64_t (T * T)) (x : (T * T)) : result u64 :=
   toU64PairInst.(ToU64_t_to_u64) x
 .
 
 (** [traits::h0]:
-    Source: 'tests/src/traits.rs', lines 66:0-66:24 *)
+    Source: 'tests/src/traits.rs', lines 67:0-67:24 *)
 Definition h0 (x : u64) : result u64 :=
   toU64U64_to_u64 x.
 
 (** [traits::Wrapper]
-    Source: 'tests/src/traits.rs', lines 70:0-70:21 *)
+    Source: 'tests/src/traits.rs', lines 71:0-71:21 *)
 Record Wrapper_t (T : Type) := mkWrapper_t { wrapper_x : T; }.
 
 Arguments mkWrapper_t { _ }.
 Arguments wrapper_x { _ }.
 
 (** [traits::{(traits::ToU64 for traits::Wrapper<T>)#4}::to_u64]:
-    Source: 'tests/src/traits.rs', lines 75:4-75:26 *)
+    Source: 'tests/src/traits.rs', lines 76:4-76:26 *)
 Definition toU64traitsWrapper_to_u64
   (T : Type) (toU64Inst : ToU64_t T) (self : Wrapper_t T) : result u64 :=
   toU64Inst.(ToU64_t_to_u64) self.(wrapper_x)
 .
 
 (** Trait implementation: [traits::{(traits::ToU64 for traits::Wrapper<T>)#4}]
-    Source: 'tests/src/traits.rs', lines 74:0-74:35 *)
+    Source: 'tests/src/traits.rs', lines 75:0-75:35 *)
 Definition ToU64traitsWrapper (T : Type) (toU64Inst : ToU64_t T) : ToU64_t
   (Wrapper_t T) := {|
   ToU64_t_to_u64 := toU64traitsWrapper_to_u64 T toU64Inst;
 |}.
 
 (** [traits::h1]:
-    Source: 'tests/src/traits.rs', lines 80:0-80:33 *)
+    Source: 'tests/src/traits.rs', lines 81:0-81:33 *)
 Definition h1 (x : Wrapper_t u64) : result u64 :=
   toU64traitsWrapper_to_u64 u64 ToU64U64 x
 .
 
 (** [traits::h2]:
-    Source: 'tests/src/traits.rs', lines 84:0-84:41 *)
+    Source: 'tests/src/traits.rs', lines 85:0-85:41 *)
 Definition h2
   (T : Type) (toU64Inst : ToU64_t T) (x : Wrapper_t T) : result u64 :=
   toU64traitsWrapper_to_u64 T toU64Inst x
 .
 
 (** Trait declaration: [traits::ToType]
-    Source: 'tests/src/traits.rs', lines 88:0-88:19 *)
+    Source: 'tests/src/traits.rs', lines 89:0-89:19 *)
 Record ToType_t (Self T : Type) := mkToType_t {
   ToType_t_to_type : Self -> result T;
 }.
@@ -165,19 +165,19 @@ Arguments mkToType_t { _ _ }.
 Arguments ToType_t_to_type { _ _ }.
 
 (** [traits::{(traits::ToType<bool> for u64)#5}::to_type]:
-    Source: 'tests/src/traits.rs', lines 93:4-93:28 *)
+    Source: 'tests/src/traits.rs', lines 94:4-94:28 *)
 Definition toTypeU64Bool_to_type (self : u64) : result bool :=
   Ok (self s> 0%u64)
 .
 
 (** Trait implementation: [traits::{(traits::ToType<bool> for u64)#5}]
-    Source: 'tests/src/traits.rs', lines 92:0-92:25 *)
+    Source: 'tests/src/traits.rs', lines 93:0-93:25 *)
 Definition ToTypeU64Bool : ToType_t u64 bool := {|
   ToType_t_to_type := toTypeU64Bool_to_type;
 |}.
 
 (** Trait declaration: [traits::OfType]
-    Source: 'tests/src/traits.rs', lines 98:0-98:16 *)
+    Source: 'tests/src/traits.rs', lines 99:0-99:16 *)
 Record OfType_t (Self : Type) := mkOfType_t {
   OfType_t_of_type : forall (T : Type) (toTypeInst : ToType_t T Self), T ->
     result Self;
@@ -187,7 +187,7 @@ Arguments mkOfType_t { _ }.
 Arguments OfType_t_of_type { _ }.
 
 (** [traits::h3]:
-    Source: 'tests/src/traits.rs', lines 104:0-104:50 *)
+    Source: 'tests/src/traits.rs', lines 105:0-105:50 *)
 Definition h3
   (T1 T2 : Type) (ofTypeInst : OfType_t T1) (toTypeInst : ToType_t T2 T1)
   (y : T2) :
@@ -197,7 +197,7 @@ Definition h3
 .
 
 (** Trait declaration: [traits::OfTypeBis]
-    Source: 'tests/src/traits.rs', lines 109:0-109:36 *)
+    Source: 'tests/src/traits.rs', lines 110:0-110:36 *)
 Record OfTypeBis_t (Self T : Type) := mkOfTypeBis_t {
   OfTypeBis_tOfTypeBis_t_ToTypeInst : ToType_t T Self;
   OfTypeBis_t_of_type : T -> result Self;
@@ -208,7 +208,7 @@ Arguments OfTypeBis_tOfTypeBis_t_ToTypeInst { _ _ }.
 Arguments OfTypeBis_t_of_type { _ _ }.
 
 (** [traits::h4]:
-    Source: 'tests/src/traits.rs', lines 118:0-118:57 *)
+    Source: 'tests/src/traits.rs', lines 119:0-119:57 *)
 Definition h4
   (T1 T2 : Type) (ofTypeBisInst : OfTypeBis_t T1 T2) (toTypeInst : ToType_t T2
   T1) (y : T2) :
@@ -218,15 +218,15 @@ Definition h4
 .
 
 (** [traits::TestType]
-    Source: 'tests/src/traits.rs', lines 122:0-122:22 *)
+    Source: 'tests/src/traits.rs', lines 123:0-123:22 *)
 Definition TestType_t (T : Type) : Type := T.
 
 (** [traits::{traits::TestType<T>#6}::test::TestType1]
-    Source: 'tests/src/traits.rs', lines 127:8-127:24 *)
+    Source: 'tests/src/traits.rs', lines 128:8-128:24 *)
 Definition TestType_test_TestType1_t : Type := u64.
 
 (** Trait declaration: [traits::{traits::TestType<T>#6}::test::TestTrait]
-    Source: 'tests/src/traits.rs', lines 128:8-128:23 *)
+    Source: 'tests/src/traits.rs', lines 129:8-129:23 *)
 Record TestType_test_TestTrait_t (Self : Type) := mkTestType_test_TestTrait_t {
   TestType_test_TestTrait_t_test : Self -> result bool;
 }.
@@ -235,14 +235,14 @@ Arguments mkTestType_test_TestTrait_t { _ }.
 Arguments TestType_test_TestTrait_t_test { _ }.
 
 (** [traits::{traits::TestType<T>#6}::test::{(traits::{traits::TestType<T>#6}::test::TestTrait for traits::{traits::TestType<T>#6}::test::TestType1)}::test]:
-    Source: 'tests/src/traits.rs', lines 139:12-139:34 *)
+    Source: 'tests/src/traits.rs', lines 140:12-140:34 *)
 Definition testType_test_TestTraittraitsTestTypetestTestType1_test
   (self : TestType_test_TestType1_t) : result bool :=
   Ok (self s> 1%u64)
 .
 
 (** Trait implementation: [traits::{traits::TestType<T>#6}::test::{(traits::{traits::TestType<T>#6}::test::TestTrait for traits::{traits::TestType<T>#6}::test::TestType1)}]
-    Source: 'tests/src/traits.rs', lines 138:8-138:36 *)
+    Source: 'tests/src/traits.rs', lines 139:8-139:36 *)
 Definition TestType_test_TestTraittraitsTestTypetestTestType1 :
   TestType_test_TestTrait_t TestType_test_TestType1_t := {|
   TestType_test_TestTrait_t_test :=
@@ -250,7 +250,7 @@ Definition TestType_test_TestTraittraitsTestTypetestTestType1 :
 |}.
 
 (** [traits::{traits::TestType<T>#6}::test]:
-    Source: 'tests/src/traits.rs', lines 126:4-126:36 *)
+    Source: 'tests/src/traits.rs', lines 127:4-127:36 *)
 Definition testType_test
   (T : Type) (toU64Inst : ToU64_t T) (self : TestType_t T) (x : T) :
   result bool
@@ -262,11 +262,11 @@ Definition testType_test
 .
 
 (** [traits::BoolWrapper]
-    Source: 'tests/src/traits.rs', lines 150:0-150:22 *)
+    Source: 'tests/src/traits.rs', lines 151:0-151:22 *)
 Definition BoolWrapper_t : Type := bool.
 
 (** [traits::{(traits::ToType<T> for traits::BoolWrapper)#7}::to_type]:
-    Source: 'tests/src/traits.rs', lines 156:4-156:25 *)
+    Source: 'tests/src/traits.rs', lines 157:4-157:25 *)
 Definition toTypetraitsBoolWrapperT_to_type
   (T : Type) (toTypeBoolTInst : ToType_t bool T) (self : BoolWrapper_t) :
   result T
@@ -275,14 +275,14 @@ Definition toTypetraitsBoolWrapperT_to_type
 .
 
 (** Trait implementation: [traits::{(traits::ToType<T> for traits::BoolWrapper)#7}]
-    Source: 'tests/src/traits.rs', lines 152:0-152:33 *)
+    Source: 'tests/src/traits.rs', lines 153:0-153:33 *)
 Definition ToTypetraitsBoolWrapperT (T : Type) (toTypeBoolTInst : ToType_t bool
   T) : ToType_t BoolWrapper_t T := {|
   ToType_t_to_type := toTypetraitsBoolWrapperT_to_type T toTypeBoolTInst;
 |}.
 
 (** [traits::WithConstTy::LEN2]
-    Source: 'tests/src/traits.rs', lines 164:4-164:21 *)
+    Source: 'tests/src/traits.rs', lines 165:4-165:21 *)
 Definition with_const_ty_len2_default_body (Self : Type) (LEN : usize)
   : result usize :=
   Ok 32%usize
@@ -292,7 +292,7 @@ Definition with_const_ty_len2_default (Self : Type) (LEN : usize) : usize :=
 .
 
 (** Trait declaration: [traits::WithConstTy]
-    Source: 'tests/src/traits.rs', lines 161:0-161:39 *)
+    Source: 'tests/src/traits.rs', lines 162:0-162:39 *)
 Record WithConstTy_t (Self : Type) (LEN : usize) := mkWithConstTy_t {
   WithConstTy_tWithConstTy_t_LEN1 : usize;
   WithConstTy_tWithConstTy_t_LEN2 : usize;
@@ -312,21 +312,21 @@ Arguments WithConstTy_tWithConstTy_t_W_clause_0 { _ _ }.
 Arguments WithConstTy_t_f { _ _ }.
 
 (** [traits::{(traits::WithConstTy<32: usize> for bool)#8}::LEN1]
-    Source: 'tests/src/traits.rs', lines 175:4-175:21 *)
+    Source: 'tests/src/traits.rs', lines 176:4-176:21 *)
 Definition with_const_ty_bool32_len1_body : result usize := Ok 12%usize.
 Definition with_const_ty_bool32_len1 : usize :=
   with_const_ty_bool32_len1_body%global
 .
 
 (** [traits::{(traits::WithConstTy<32: usize> for bool)#8}::f]:
-    Source: 'tests/src/traits.rs', lines 180:4-180:39 *)
+    Source: 'tests/src/traits.rs', lines 181:4-181:39 *)
 Definition withConstTyBool32_f
   (i : u64) (a : array u8 32%usize) : result u64 :=
   Ok i
 .
 
 (** Trait implementation: [traits::{(traits::WithConstTy<32: usize> for bool)#8}]
-    Source: 'tests/src/traits.rs', lines 174:0-174:29 *)
+    Source: 'tests/src/traits.rs', lines 175:0-175:29 *)
 Definition WithConstTyBool32 : WithConstTy_t bool 32%usize := {|
   WithConstTy_tWithConstTy_t_LEN1 := with_const_ty_bool32_len1;
   WithConstTy_tWithConstTy_t_LEN2 := with_const_ty_len2_default bool 32%usize;
@@ -337,7 +337,7 @@ Definition WithConstTyBool32 : WithConstTy_t bool 32%usize := {|
 |}.
 
 (** [traits::use_with_const_ty1]:
-    Source: 'tests/src/traits.rs', lines 183:0-183:75 *)
+    Source: 'tests/src/traits.rs', lines 184:0-184:75 *)
 Definition use_with_const_ty1
   (H : Type) (LEN : usize) (withConstTyInst : WithConstTy_t H LEN) :
   result usize
@@ -346,7 +346,7 @@ Definition use_with_const_ty1
 .
 
 (** [traits::use_with_const_ty2]:
-    Source: 'tests/src/traits.rs', lines 187:0-187:73 *)
+    Source: 'tests/src/traits.rs', lines 188:0-188:73 *)
 Definition use_with_const_ty2
   (H : Type) (LEN : usize) (withConstTyInst : WithConstTy_t H LEN)
   (w : withConstTyInst.(WithConstTy_tWithConstTy_t_W)) :
@@ -356,7 +356,7 @@ Definition use_with_const_ty2
 .
 
 (** [traits::use_with_const_ty3]:
-    Source: 'tests/src/traits.rs', lines 189:0-189:80 *)
+    Source: 'tests/src/traits.rs', lines 190:0-190:80 *)
 Definition use_with_const_ty3
   (H : Type) (LEN : usize) (withConstTyInst : WithConstTy_t H LEN)
   (x : withConstTyInst.(WithConstTy_tWithConstTy_t_W)) :
@@ -366,12 +366,12 @@ Definition use_with_const_ty3
 .
 
 (** [traits::test_where1]:
-    Source: 'tests/src/traits.rs', lines 193:0-193:40 *)
+    Source: 'tests/src/traits.rs', lines 194:0-194:40 *)
 Definition test_where1 (T : Type) (_x : T) : result unit :=
   Ok tt.
 
 (** [traits::test_where2]:
-    Source: 'tests/src/traits.rs', lines 194:0-194:57 *)
+    Source: 'tests/src/traits.rs', lines 195:0-195:57 *)
 Definition test_where2
   (T : Type) (withConstTyT32Inst : WithConstTy_t T 32%usize) (_x : u32) :
   result unit
@@ -380,7 +380,7 @@ Definition test_where2
 .
 
 (** Trait declaration: [traits::ParentTrait0]
-    Source: 'tests/src/traits.rs', lines 200:0-200:22 *)
+    Source: 'tests/src/traits.rs', lines 201:0-201:22 *)
 Record ParentTrait0_t (Self : Type) := mkParentTrait0_t {
   ParentTrait0_tParentTrait0_t_W : Type;
   ParentTrait0_t_get_name : Self -> result string;
@@ -393,13 +393,13 @@ Arguments ParentTrait0_t_get_name { _ }.
 Arguments ParentTrait0_t_get_w { _ }.
 
 (** Trait declaration: [traits::ParentTrait1]
-    Source: 'tests/src/traits.rs', lines 205:0-205:22 *)
+    Source: 'tests/src/traits.rs', lines 206:0-206:22 *)
 Record ParentTrait1_t (Self : Type) := mkParentTrait1_t{}.
 
 Arguments mkParentTrait1_t { _ }.
 
 (** Trait declaration: [traits::ChildTrait]
-    Source: 'tests/src/traits.rs', lines 206:0-206:49 *)
+    Source: 'tests/src/traits.rs', lines 207:0-207:49 *)
 Record ChildTrait_t (Self : Type) := mkChildTrait_t {
   ChildTrait_tChildTrait_t_ParentTrait0Inst : ParentTrait0_t Self;
   ChildTrait_tChildTrait_t_ParentTrait1Inst : ParentTrait1_t Self;
@@ -410,7 +410,7 @@ Arguments ChildTrait_tChildTrait_t_ParentTrait0Inst { _ }.
 Arguments ChildTrait_tChildTrait_t_ParentTrait1Inst { _ }.
 
 (** [traits::test_child_trait1]:
-    Source: 'tests/src/traits.rs', lines 209:0-209:56 *)
+    Source: 'tests/src/traits.rs', lines 210:0-210:56 *)
 Definition test_child_trait1
   (T : Type) (childTraitInst : ChildTrait_t T) (x : T) : result string :=
   childTraitInst.(ChildTrait_tChildTrait_t_ParentTrait0Inst).(ParentTrait0_t_get_name)
@@ -418,7 +418,7 @@ Definition test_child_trait1
 .
 
 (** [traits::test_child_trait2]:
-    Source: 'tests/src/traits.rs', lines 213:0-213:54 *)
+    Source: 'tests/src/traits.rs', lines 214:0-214:54 *)
 Definition test_child_trait2
   (T : Type) (childTraitInst : ChildTrait_t T) (x : T) :
   result
@@ -429,7 +429,7 @@ Definition test_child_trait2
 .
 
 (** [traits::order1]:
-    Source: 'tests/src/traits.rs', lines 219:0-219:59 *)
+    Source: 'tests/src/traits.rs', lines 220:0-220:59 *)
 Definition order1
   (T U : Type) (parentTrait0Inst : ParentTrait0_t T) (parentTrait0Inst1 :
   ParentTrait0_t U) :
@@ -439,7 +439,7 @@ Definition order1
 .
 
 (** Trait declaration: [traits::ChildTrait1]
-    Source: 'tests/src/traits.rs', lines 222:0-222:35 *)
+    Source: 'tests/src/traits.rs', lines 223:0-223:35 *)
 Record ChildTrait1_t (Self : Type) := mkChildTrait1_t {
   ChildTrait1_tChildTrait1_t_ParentTrait1Inst : ParentTrait1_t Self;
 }.
@@ -448,17 +448,17 @@ Arguments mkChildTrait1_t { _ }.
 Arguments ChildTrait1_tChildTrait1_t_ParentTrait1Inst { _ }.
 
 (** Trait implementation: [traits::{(traits::ParentTrait1 for usize)#9}]
-    Source: 'tests/src/traits.rs', lines 224:0-224:27 *)
+    Source: 'tests/src/traits.rs', lines 225:0-225:27 *)
 Definition ParentTrait1Usize : ParentTrait1_t usize := mkParentTrait1_t.
 
 (** Trait implementation: [traits::{(traits::ChildTrait1 for usize)#10}]
-    Source: 'tests/src/traits.rs', lines 225:0-225:26 *)
+    Source: 'tests/src/traits.rs', lines 226:0-226:26 *)
 Definition ChildTrait1Usize : ChildTrait1_t usize := {|
   ChildTrait1_tChildTrait1_t_ParentTrait1Inst := ParentTrait1Usize;
 |}.
 
 (** Trait declaration: [traits::Iterator]
-    Source: 'tests/src/traits.rs', lines 229:0-229:18 *)
+    Source: 'tests/src/traits.rs', lines 230:0-230:18 *)
 Record Iterator_t (Self : Type) := mkIterator_t {
   Iterator_tIterator_t_Item : Type;
 }.
@@ -467,7 +467,7 @@ Arguments mkIterator_t { _ }.
 Arguments Iterator_tIterator_t_Item { _ }.
 
 (** Trait declaration: [traits::IntoIterator]
-    Source: 'tests/src/traits.rs', lines 233:0-233:22 *)
+    Source: 'tests/src/traits.rs', lines 234:0-234:22 *)
 Record IntoIterator_t (Self : Type) := mkIntoIterator_t {
   IntoIterator_tIntoIterator_t_Item : Type;
   IntoIterator_tIntoIterator_t_IntoIter : Type;
@@ -484,13 +484,13 @@ Arguments IntoIterator_tIntoIterator_t_IntoIter_clause_0 { _ }.
 Arguments IntoIterator_t_into_iter { _ }.
 
 (** Trait declaration: [traits::FromResidual]
-    Source: 'tests/src/traits.rs', lines 250:0-250:21 *)
+    Source: 'tests/src/traits.rs', lines 251:0-251:21 *)
 Record FromResidual_t (Self T : Type) := mkFromResidual_t{}.
 
 Arguments mkFromResidual_t { _ _ }.
 
 (** Trait declaration: [traits::Try]
-    Source: 'tests/src/traits.rs', lines 246:0-246:48 *)
+    Source: 'tests/src/traits.rs', lines 247:0-247:48 *)
 Record Try_t (Self : Type) := mkTry_t {
   Try_tTry_t_Residual : Type;
   Try_tTry_t_FromResidualSelftraitsTryResidualInst : FromResidual_t Self
@@ -502,7 +502,7 @@ Arguments Try_tTry_t_Residual { _ }.
 Arguments Try_tTry_t_FromResidualSelftraitsTryResidualInst { _ }.
 
 (** Trait declaration: [traits::WithTarget]
-    Source: 'tests/src/traits.rs', lines 252:0-252:20 *)
+    Source: 'tests/src/traits.rs', lines 253:0-253:20 *)
 Record WithTarget_t (Self : Type) := mkWithTarget_t {
   WithTarget_tWithTarget_t_Target : Type;
 }.
@@ -511,7 +511,7 @@ Arguments mkWithTarget_t { _ }.
 Arguments WithTarget_tWithTarget_t_Target { _ }.
 
 (** Trait declaration: [traits::ParentTrait2]
-    Source: 'tests/src/traits.rs', lines 256:0-256:22 *)
+    Source: 'tests/src/traits.rs', lines 257:0-257:22 *)
 Record ParentTrait2_t (Self : Type) := mkParentTrait2_t {
   ParentTrait2_tParentTrait2_t_U : Type;
   ParentTrait2_tParentTrait2_t_U_clause_0 : WithTarget_t
@@ -523,7 +523,7 @@ Arguments ParentTrait2_tParentTrait2_t_U { _ }.
 Arguments ParentTrait2_tParentTrait2_t_U_clause_0 { _ }.
 
 (** Trait declaration: [traits::ChildTrait2]
-    Source: 'tests/src/traits.rs', lines 260:0-260:35 *)
+    Source: 'tests/src/traits.rs', lines 261:0-261:35 *)
 Record ChildTrait2_t (Self : Type) := mkChildTrait2_t {
   ChildTrait2_tChildTrait2_t_ParentTrait2Inst : ParentTrait2_t Self;
   ChildTrait2_t_convert :
@@ -537,32 +537,32 @@ Arguments ChildTrait2_tChildTrait2_t_ParentTrait2Inst { _ }.
 Arguments ChildTrait2_t_convert { _ }.
 
 (** Trait implementation: [traits::{(traits::WithTarget for u32)#11}]
-    Source: 'tests/src/traits.rs', lines 264:0-264:23 *)
+    Source: 'tests/src/traits.rs', lines 265:0-265:23 *)
 Definition WithTargetU32 : WithTarget_t u32 := {|
   WithTarget_tWithTarget_t_Target := u32;
 |}.
 
 (** Trait implementation: [traits::{(traits::ParentTrait2 for u32)#12}]
-    Source: 'tests/src/traits.rs', lines 268:0-268:25 *)
+    Source: 'tests/src/traits.rs', lines 269:0-269:25 *)
 Definition ParentTrait2U32 : ParentTrait2_t u32 := {|
   ParentTrait2_tParentTrait2_t_U := u32;
   ParentTrait2_tParentTrait2_t_U_clause_0 := WithTargetU32;
 |}.
 
 (** [traits::{(traits::ChildTrait2 for u32)#13}::convert]:
-    Source: 'tests/src/traits.rs', lines 273:4-273:29 *)
+    Source: 'tests/src/traits.rs', lines 274:4-274:29 *)
 Definition childTrait2U32_convert (x : u32) : result u32 :=
   Ok x.
 
 (** Trait implementation: [traits::{(traits::ChildTrait2 for u32)#13}]
-    Source: 'tests/src/traits.rs', lines 272:0-272:24 *)
+    Source: 'tests/src/traits.rs', lines 273:0-273:24 *)
 Definition ChildTrait2U32 : ChildTrait2_t u32 := {|
   ChildTrait2_tChildTrait2_t_ParentTrait2Inst := ParentTrait2U32;
   ChildTrait2_t_convert := childTrait2U32_convert;
 |}.
 
 (** Trait declaration: [traits::CFnOnce]
-    Source: 'tests/src/traits.rs', lines 286:0-286:23 *)
+    Source: 'tests/src/traits.rs', lines 287:0-287:23 *)
 Record CFnOnce_t (Self Args : Type) := mkCFnOnce_t {
   CFnOnce_tCFnOnce_t_Output : Type;
   CFnOnce_t_call_once : Self -> Args -> result CFnOnce_tCFnOnce_t_Output;
@@ -573,7 +573,7 @@ Arguments CFnOnce_tCFnOnce_t_Output { _ _ }.
 Arguments CFnOnce_t_call_once { _ _ }.
 
 (** Trait declaration: [traits::CFnMut]
-    Source: 'tests/src/traits.rs', lines 292:0-292:37 *)
+    Source: 'tests/src/traits.rs', lines 293:0-293:37 *)
 Record CFnMut_t (Self Args : Type) := mkCFnMut_t {
   CFnMut_tCFnMut_t_CFnOnceInst : CFnOnce_t Self Args;
   CFnMut_t_call_mut : Self -> Args -> result
@@ -585,7 +585,7 @@ Arguments CFnMut_tCFnMut_t_CFnOnceInst { _ _ }.
 Arguments CFnMut_t_call_mut { _ _ }.
 
 (** Trait declaration: [traits::CFn]
-    Source: 'tests/src/traits.rs', lines 296:0-296:33 *)
+    Source: 'tests/src/traits.rs', lines 297:0-297:33 *)
 Record CFn_t (Self Args : Type) := mkCFn_t {
   CFn_tCFn_t_CFnMutInst : CFnMut_t Self Args;
   CFn_t_call : Self -> Args -> result
@@ -597,7 +597,7 @@ Arguments CFn_tCFn_t_CFnMutInst { _ _ }.
 Arguments CFn_t_call { _ _ }.
 
 (** Trait declaration: [traits::GetTrait]
-    Source: 'tests/src/traits.rs', lines 300:0-300:18 *)
+    Source: 'tests/src/traits.rs', lines 301:0-301:18 *)
 Record GetTrait_t (Self : Type) := mkGetTrait_t {
   GetTrait_tGetTrait_t_W : Type;
   GetTrait_t_get_w : Self -> result GetTrait_tGetTrait_t_W;
@@ -608,7 +608,7 @@ Arguments GetTrait_tGetTrait_t_W { _ }.
 Arguments GetTrait_t_get_w { _ }.
 
 (** [traits::test_get_trait]:
-    Source: 'tests/src/traits.rs', lines 305:0-305:49 *)
+    Source: 'tests/src/traits.rs', lines 306:0-306:49 *)
 Definition test_get_trait
   (T : Type) (getTraitInst : GetTrait_t T) (x : T) :
   result getTraitInst.(GetTrait_tGetTrait_t_W)
@@ -617,27 +617,27 @@ Definition test_get_trait
 .
 
 (** Trait declaration: [traits::Trait]
-    Source: 'tests/src/traits.rs', lines 310:0-310:15 *)
+    Source: 'tests/src/traits.rs', lines 311:0-311:15 *)
 Record Trait_t (Self : Type) := mkTrait_t { Trait_tTrait_t_LEN : usize; }.
 
 Arguments mkTrait_t { _ }.
 Arguments Trait_tTrait_t_LEN { _ }.
 
 (** [traits::{(traits::Trait for @Array<T, N>)#14}::LEN]
-    Source: 'tests/src/traits.rs', lines 315:4-315:20 *)
+    Source: 'tests/src/traits.rs', lines 316:4-316:20 *)
 Definition trait_array_len_body (T : Type) (N : usize) : result usize := Ok N.
 Definition trait_array_len (T : Type) (N : usize) : usize :=
   (trait_array_len_body T N)%global
 .
 
 (** Trait implementation: [traits::{(traits::Trait for @Array<T, N>)#14}]
-    Source: 'tests/src/traits.rs', lines 314:0-314:40 *)
+    Source: 'tests/src/traits.rs', lines 315:0-315:40 *)
 Definition TraitArray (T : Type) (N : usize) : Trait_t (array T N) := {|
   Trait_tTrait_t_LEN := trait_array_len T N;
 |}.
 
 (** [traits::{(traits::Trait for traits::Wrapper<T>)#15}::LEN]
-    Source: 'tests/src/traits.rs', lines 319:4-319:20 *)
+    Source: 'tests/src/traits.rs', lines 320:4-320:20 *)
 Definition traittraits_wrapper_len_body (T : Type) (traitInst : Trait_t T)
   : result usize :=
   Ok 0%usize
@@ -648,20 +648,20 @@ Definition traittraits_wrapper_len (T : Type) (traitInst : Trait_t T)
 .
 
 (** Trait implementation: [traits::{(traits::Trait for traits::Wrapper<T>)#15}]
-    Source: 'tests/src/traits.rs', lines 318:0-318:35 *)
+    Source: 'tests/src/traits.rs', lines 319:0-319:35 *)
 Definition TraittraitsWrapper (T : Type) (traitInst : Trait_t T) : Trait_t
   (Wrapper_t T) := {|
   Trait_tTrait_t_LEN := traittraits_wrapper_len T traitInst;
 |}.
 
 (** [traits::use_wrapper_len]:
-    Source: 'tests/src/traits.rs', lines 322:0-322:43 *)
+    Source: 'tests/src/traits.rs', lines 323:0-323:43 *)
 Definition use_wrapper_len (T : Type) (traitInst : Trait_t T) : result usize :=
   Ok (TraittraitsWrapper T traitInst).(Trait_tTrait_t_LEN)
 .
 
 (** [traits::Foo]
-    Source: 'tests/src/traits.rs', lines 326:0-326:20 *)
+    Source: 'tests/src/traits.rs', lines 327:0-327:20 *)
 Record Foo_t (T U : Type) := mkFoo_t { foo_x : T; foo_y : U; }.
 
 Arguments mkFoo_t { _ _ }.
@@ -680,7 +680,7 @@ Arguments Core_result_Result_Ok { _ _ }.
 Arguments Core_result_Result_Err { _ _ }.
 
 (** [traits::{traits::Foo<T, U>#16}::FOO]
-    Source: 'tests/src/traits.rs', lines 332:4-332:33 *)
+    Source: 'tests/src/traits.rs', lines 333:4-333:33 *)
 Definition foo_foo_body (T U : Type) (traitInst : Trait_t T)
   : result (core_result_Result_t T i32) :=
   Ok (Core_result_Result_Err 0%i32)
@@ -691,14 +691,14 @@ Definition foo_foo (T U : Type) (traitInst : Trait_t T)
 .
 
 (** [traits::use_foo1]:
-    Source: 'tests/src/traits.rs', lines 335:0-335:48 *)
+    Source: 'tests/src/traits.rs', lines 336:0-336:48 *)
 Definition use_foo1
   (T U : Type) (traitInst : Trait_t T) : result (core_result_Result_t T i32) :=
   Ok (foo_foo T U traitInst)
 .
 
 (** [traits::use_foo2]:
-    Source: 'tests/src/traits.rs', lines 339:0-339:48 *)
+    Source: 'tests/src/traits.rs', lines 340:0-340:48 *)
 Definition use_foo2
   (T U : Type) (traitInst : Trait_t U) : result (core_result_Result_t U i32) :=
   Ok (foo_foo U T traitInst)

--- a/tests/fstar/arrays/Arrays.Clauses.Template.fst
+++ b/tests/fstar/arrays/Arrays.Clauses.Template.fst
@@ -7,31 +7,31 @@ open Arrays.Types
 #set-options "--z3rlimit 50 --fuel 1 --ifuel 1"
 
 (** [arrays::sum]: decreases clause
-    Source: 'tests/src/arrays.rs', lines 242:0-250:1 *)
+    Source: 'tests/src/arrays.rs', lines 245:0-253:1 *)
 unfold
 let sum_loop_decreases (s : slice u32) (sum1 : u32) (i : usize) : nat =
   admit ()
 
 (** [arrays::sum2]: decreases clause
-    Source: 'tests/src/arrays.rs', lines 252:0-261:1 *)
+    Source: 'tests/src/arrays.rs', lines 255:0-264:1 *)
 unfold
 let sum2_loop_decreases (s : slice u32) (s2 : slice u32) (sum1 : u32)
   (i : usize) : nat =
   admit ()
 
 (** [arrays::zero_slice]: decreases clause
-    Source: 'tests/src/arrays.rs', lines 303:0-310:1 *)
+    Source: 'tests/src/arrays.rs', lines 306:0-313:1 *)
 unfold
 let zero_slice_loop_decreases (a : slice u8) (i : usize) (len : usize) : nat =
   admit ()
 
 (** [arrays::iter_mut_slice]: decreases clause
-    Source: 'tests/src/arrays.rs', lines 312:0-318:1 *)
+    Source: 'tests/src/arrays.rs', lines 315:0-321:1 *)
 unfold
 let iter_mut_slice_loop_decreases (len : usize) (i : usize) : nat = admit ()
 
 (** [arrays::sum_mut_slice]: decreases clause
-    Source: 'tests/src/arrays.rs', lines 320:0-328:1 *)
+    Source: 'tests/src/arrays.rs', lines 323:0-331:1 *)
 unfold
 let sum_mut_slice_loop_decreases (a : slice u32) (i : usize) (s : u32) : nat =
   admit ()

--- a/tests/fstar/arrays/Arrays.Funs.fst
+++ b/tests/fstar/arrays/Arrays.Funs.fst
@@ -8,17 +8,17 @@ include Arrays.Clauses
 #set-options "--z3rlimit 50 --fuel 1 --ifuel 1"
 
 (** [arrays::incr]:
-    Source: 'tests/src/arrays.rs', lines 8:0-8:24 *)
+    Source: 'tests/src/arrays.rs', lines 11:0-11:24 *)
 let incr (x : u32) : result u32 =
   u32_add x 1
 
 (** [arrays::array_to_shared_slice_]:
-    Source: 'tests/src/arrays.rs', lines 16:0-16:53 *)
+    Source: 'tests/src/arrays.rs', lines 19:0-19:53 *)
 let array_to_shared_slice_ (t : Type0) (s : array t 32) : result (slice t) =
   array_to_slice t 32 s
 
 (** [arrays::array_to_mut_slice_]:
-    Source: 'tests/src/arrays.rs', lines 21:0-21:58 *)
+    Source: 'tests/src/arrays.rs', lines 24:0-24:58 *)
 let array_to_mut_slice_
   (t : Type0) (s : array t 32) :
   result ((slice t) & (slice t -> result (array t 32)))
@@ -26,37 +26,37 @@ let array_to_mut_slice_
   array_to_slice_mut t 32 s
 
 (** [arrays::array_len]:
-    Source: 'tests/src/arrays.rs', lines 25:0-25:40 *)
+    Source: 'tests/src/arrays.rs', lines 28:0-28:40 *)
 let array_len (t : Type0) (s : array t 32) : result usize =
   let* s1 = array_to_slice t 32 s in Ok (slice_len t s1)
 
 (** [arrays::shared_array_len]:
-    Source: 'tests/src/arrays.rs', lines 29:0-29:48 *)
+    Source: 'tests/src/arrays.rs', lines 32:0-32:48 *)
 let shared_array_len (t : Type0) (s : array t 32) : result usize =
   let* s1 = array_to_slice t 32 s in Ok (slice_len t s1)
 
 (** [arrays::shared_slice_len]:
-    Source: 'tests/src/arrays.rs', lines 33:0-33:44 *)
+    Source: 'tests/src/arrays.rs', lines 36:0-36:44 *)
 let shared_slice_len (t : Type0) (s : slice t) : result usize =
   Ok (slice_len t s)
 
 (** [arrays::index_array_shared]:
-    Source: 'tests/src/arrays.rs', lines 37:0-37:57 *)
+    Source: 'tests/src/arrays.rs', lines 40:0-40:57 *)
 let index_array_shared (t : Type0) (s : array t 32) (i : usize) : result t =
   array_index_usize t 32 s i
 
 (** [arrays::index_array_u32]:
-    Source: 'tests/src/arrays.rs', lines 44:0-44:53 *)
+    Source: 'tests/src/arrays.rs', lines 47:0-47:53 *)
 let index_array_u32 (s : array u32 32) (i : usize) : result u32 =
   array_index_usize u32 32 s i
 
 (** [arrays::index_array_copy]:
-    Source: 'tests/src/arrays.rs', lines 48:0-48:45 *)
+    Source: 'tests/src/arrays.rs', lines 51:0-51:45 *)
 let index_array_copy (x : array u32 32) : result u32 =
   array_index_usize u32 32 x 0
 
 (** [arrays::index_mut_array]:
-    Source: 'tests/src/arrays.rs', lines 52:0-52:62 *)
+    Source: 'tests/src/arrays.rs', lines 55:0-55:62 *)
 let index_mut_array
   (t : Type0) (s : array t 32) (i : usize) :
   result (t & (t -> result (array t 32)))
@@ -64,12 +64,12 @@ let index_mut_array
   array_index_mut_usize t 32 s i
 
 (** [arrays::index_slice]:
-    Source: 'tests/src/arrays.rs', lines 56:0-56:46 *)
+    Source: 'tests/src/arrays.rs', lines 59:0-59:46 *)
 let index_slice (t : Type0) (s : slice t) (i : usize) : result t =
   slice_index_usize t s i
 
 (** [arrays::index_mut_slice]:
-    Source: 'tests/src/arrays.rs', lines 60:0-60:58 *)
+    Source: 'tests/src/arrays.rs', lines 63:0-63:58 *)
 let index_mut_slice
   (t : Type0) (s : slice t) (i : usize) :
   result (t & (t -> result (slice t)))
@@ -77,7 +77,7 @@ let index_mut_slice
   slice_index_mut_usize t s i
 
 (** [arrays::slice_subslice_shared_]:
-    Source: 'tests/src/arrays.rs', lines 64:0-64:70 *)
+    Source: 'tests/src/arrays.rs', lines 67:0-67:70 *)
 let slice_subslice_shared_
   (x : slice u32) (y : usize) (z : usize) : result (slice u32) =
   core_slice_index_Slice_index u32 (core_ops_range_Range usize)
@@ -85,7 +85,7 @@ let slice_subslice_shared_
     { start = y; end_ = z }
 
 (** [arrays::slice_subslice_mut_]:
-    Source: 'tests/src/arrays.rs', lines 68:0-68:75 *)
+    Source: 'tests/src/arrays.rs', lines 71:0-71:75 *)
 let slice_subslice_mut_
   (x : slice u32) (y : usize) (z : usize) :
   result ((slice u32) & (slice u32 -> result (slice u32)))
@@ -97,12 +97,12 @@ let slice_subslice_mut_
   Ok (s, index_mut_back)
 
 (** [arrays::array_to_slice_shared_]:
-    Source: 'tests/src/arrays.rs', lines 72:0-72:54 *)
+    Source: 'tests/src/arrays.rs', lines 75:0-75:54 *)
 let array_to_slice_shared_ (x : array u32 32) : result (slice u32) =
   array_to_slice u32 32 x
 
 (** [arrays::array_to_slice_mut_]:
-    Source: 'tests/src/arrays.rs', lines 76:0-76:59 *)
+    Source: 'tests/src/arrays.rs', lines 79:0-79:59 *)
 let array_to_slice_mut_
   (x : array u32 32) :
   result ((slice u32) & (slice u32 -> result (array u32 32)))
@@ -110,7 +110,7 @@ let array_to_slice_mut_
   array_to_slice_mut u32 32 x
 
 (** [arrays::array_subslice_shared_]:
-    Source: 'tests/src/arrays.rs', lines 80:0-80:74 *)
+    Source: 'tests/src/arrays.rs', lines 83:0-83:74 *)
 let array_subslice_shared_
   (x : array u32 32) (y : usize) (z : usize) : result (slice u32) =
   core_array_Array_index u32 (core_ops_range_Range usize) 32
@@ -119,7 +119,7 @@ let array_subslice_shared_
     { start = y; end_ = z }
 
 (** [arrays::array_subslice_mut_]:
-    Source: 'tests/src/arrays.rs', lines 84:0-84:79 *)
+    Source: 'tests/src/arrays.rs', lines 87:0-87:79 *)
 let array_subslice_mut_
   (x : array u32 32) (y : usize) (z : usize) :
   result ((slice u32) & (slice u32 -> result (array u32 32)))
@@ -132,24 +132,24 @@ let array_subslice_mut_
   Ok (s, index_mut_back)
 
 (** [arrays::index_slice_0]:
-    Source: 'tests/src/arrays.rs', lines 88:0-88:38 *)
+    Source: 'tests/src/arrays.rs', lines 91:0-91:38 *)
 let index_slice_0 (t : Type0) (s : slice t) : result t =
   slice_index_usize t s 0
 
 (** [arrays::index_array_0]:
-    Source: 'tests/src/arrays.rs', lines 92:0-92:42 *)
+    Source: 'tests/src/arrays.rs', lines 95:0-95:42 *)
 let index_array_0 (t : Type0) (s : array t 32) : result t =
   array_index_usize t 32 s 0
 
 (** [arrays::index_index_array]:
-    Source: 'tests/src/arrays.rs', lines 103:0-103:71 *)
+    Source: 'tests/src/arrays.rs', lines 106:0-106:71 *)
 let index_index_array
   (s : array (array u32 32) 32) (i : usize) (j : usize) : result u32 =
   let* a = array_index_usize (array u32 32) 32 s i in
   array_index_usize u32 32 a j
 
 (** [arrays::update_update_array]:
-    Source: 'tests/src/arrays.rs', lines 114:0-114:70 *)
+    Source: 'tests/src/arrays.rs', lines 117:0-117:70 *)
 let update_update_array
   (s : array (array u32 32) 32) (i : usize) (j : usize) : result unit =
   let* (a, index_mut_back) = array_index_mut_usize (array u32 32) 32 s i in
@@ -159,42 +159,42 @@ let update_update_array
   Ok ()
 
 (** [arrays::array_local_deep_copy]:
-    Source: 'tests/src/arrays.rs', lines 118:0-118:43 *)
+    Source: 'tests/src/arrays.rs', lines 121:0-121:43 *)
 let array_local_deep_copy (x : array u32 32) : result unit =
   Ok ()
 
 (** [arrays::take_array]:
-    Source: 'tests/src/arrays.rs', lines 122:0-122:30 *)
+    Source: 'tests/src/arrays.rs', lines 125:0-125:30 *)
 let take_array (a : array u32 2) : result unit =
   Ok ()
 
 (** [arrays::take_array_borrow]:
-    Source: 'tests/src/arrays.rs', lines 123:0-123:38 *)
+    Source: 'tests/src/arrays.rs', lines 126:0-126:38 *)
 let take_array_borrow (a : array u32 2) : result unit =
   Ok ()
 
 (** [arrays::take_slice]:
-    Source: 'tests/src/arrays.rs', lines 124:0-124:28 *)
+    Source: 'tests/src/arrays.rs', lines 127:0-127:28 *)
 let take_slice (s : slice u32) : result unit =
   Ok ()
 
 (** [arrays::take_mut_slice]:
-    Source: 'tests/src/arrays.rs', lines 125:0-125:36 *)
+    Source: 'tests/src/arrays.rs', lines 128:0-128:36 *)
 let take_mut_slice (s : slice u32) : result (slice u32) =
   Ok s
 
 (** [arrays::const_array]:
-    Source: 'tests/src/arrays.rs', lines 127:0-127:32 *)
+    Source: 'tests/src/arrays.rs', lines 130:0-130:32 *)
 let const_array : result (array u32 2) =
   Ok (mk_array u32 2 [ 0; 0 ])
 
 (** [arrays::const_slice]:
-    Source: 'tests/src/arrays.rs', lines 131:0-131:20 *)
+    Source: 'tests/src/arrays.rs', lines 134:0-134:20 *)
 let const_slice : result unit =
   let* _ = array_to_slice u32 2 (mk_array u32 2 [ 0; 0 ]) in Ok ()
 
 (** [arrays::take_all]:
-    Source: 'tests/src/arrays.rs', lines 141:0-141:17 *)
+    Source: 'tests/src/arrays.rs', lines 144:0-144:17 *)
 let take_all : result unit =
   let* _ = take_array (mk_array u32 2 [ 0; 0 ]) in
   let* _ = take_array (mk_array u32 2 [ 0; 0 ]) in
@@ -208,27 +208,27 @@ let take_all : result unit =
   Ok ()
 
 (** [arrays::index_array]:
-    Source: 'tests/src/arrays.rs', lines 155:0-155:38 *)
+    Source: 'tests/src/arrays.rs', lines 158:0-158:38 *)
 let index_array (x : array u32 2) : result u32 =
   array_index_usize u32 2 x 0
 
 (** [arrays::index_array_borrow]:
-    Source: 'tests/src/arrays.rs', lines 158:0-158:46 *)
+    Source: 'tests/src/arrays.rs', lines 161:0-161:46 *)
 let index_array_borrow (x : array u32 2) : result u32 =
   array_index_usize u32 2 x 0
 
 (** [arrays::index_slice_u32_0]:
-    Source: 'tests/src/arrays.rs', lines 162:0-162:42 *)
+    Source: 'tests/src/arrays.rs', lines 165:0-165:42 *)
 let index_slice_u32_0 (x : slice u32) : result u32 =
   slice_index_usize u32 x 0
 
 (** [arrays::index_mut_slice_u32_0]:
-    Source: 'tests/src/arrays.rs', lines 166:0-166:50 *)
+    Source: 'tests/src/arrays.rs', lines 169:0-169:50 *)
 let index_mut_slice_u32_0 (x : slice u32) : result (u32 & (slice u32)) =
   let* i = slice_index_usize u32 x 0 in Ok (i, x)
 
 (** [arrays::index_all]:
-    Source: 'tests/src/arrays.rs', lines 170:0-170:25 *)
+    Source: 'tests/src/arrays.rs', lines 173:0-173:25 *)
 let index_all : result u32 =
   let* i = index_array (mk_array u32 2 [ 0; 0 ]) in
   let* i1 = index_array (mk_array u32 2 [ 0; 0 ]) in
@@ -246,25 +246,25 @@ let index_all : result u32 =
   Ok i8
 
 (** [arrays::update_array]:
-    Source: 'tests/src/arrays.rs', lines 184:0-184:36 *)
+    Source: 'tests/src/arrays.rs', lines 187:0-187:36 *)
 let update_array (x : array u32 2) : result unit =
   let* (_, index_mut_back) = array_index_mut_usize u32 2 x 0 in
   let* _ = index_mut_back 1 in
   Ok ()
 
 (** [arrays::update_array_mut_borrow]:
-    Source: 'tests/src/arrays.rs', lines 187:0-187:48 *)
+    Source: 'tests/src/arrays.rs', lines 190:0-190:48 *)
 let update_array_mut_borrow (x : array u32 2) : result (array u32 2) =
   let* (_, index_mut_back) = array_index_mut_usize u32 2 x 0 in
   index_mut_back 1
 
 (** [arrays::update_mut_slice]:
-    Source: 'tests/src/arrays.rs', lines 190:0-190:38 *)
+    Source: 'tests/src/arrays.rs', lines 193:0-193:38 *)
 let update_mut_slice (x : slice u32) : result (slice u32) =
   let* (_, index_mut_back) = slice_index_mut_usize u32 x 0 in index_mut_back 1
 
 (** [arrays::update_all]:
-    Source: 'tests/src/arrays.rs', lines 194:0-194:19 *)
+    Source: 'tests/src/arrays.rs', lines 197:0-197:19 *)
 let update_all : result unit =
   let* _ = update_array (mk_array u32 2 [ 0; 0 ]) in
   let* _ = update_array (mk_array u32 2 [ 0; 0 ]) in
@@ -275,7 +275,7 @@ let update_all : result unit =
   Ok ()
 
 (** [arrays::range_all]:
-    Source: 'tests/src/arrays.rs', lines 205:0-205:18 *)
+    Source: 'tests/src/arrays.rs', lines 208:0-208:18 *)
 let range_all : result unit =
   let* (s, index_mut_back) =
     core_array_Array_index_mut u32 (core_ops_range_Range usize) 4
@@ -287,27 +287,27 @@ let range_all : result unit =
   Ok ()
 
 (** [arrays::deref_array_borrow]:
-    Source: 'tests/src/arrays.rs', lines 214:0-214:46 *)
+    Source: 'tests/src/arrays.rs', lines 217:0-217:46 *)
 let deref_array_borrow (x : array u32 2) : result u32 =
   array_index_usize u32 2 x 0
 
 (** [arrays::deref_array_mut_borrow]:
-    Source: 'tests/src/arrays.rs', lines 219:0-219:54 *)
+    Source: 'tests/src/arrays.rs', lines 222:0-222:54 *)
 let deref_array_mut_borrow (x : array u32 2) : result (u32 & (array u32 2)) =
   let* i = array_index_usize u32 2 x 0 in Ok (i, x)
 
 (** [arrays::take_array_t]:
-    Source: 'tests/src/arrays.rs', lines 227:0-227:31 *)
+    Source: 'tests/src/arrays.rs', lines 230:0-230:31 *)
 let take_array_t (a : array aB_t 2) : result unit =
   Ok ()
 
 (** [arrays::non_copyable_array]:
-    Source: 'tests/src/arrays.rs', lines 229:0-229:27 *)
+    Source: 'tests/src/arrays.rs', lines 232:0-232:27 *)
 let non_copyable_array : result unit =
   take_array_t (mk_array aB_t 2 [ AB_A; AB_B ])
 
 (** [arrays::sum]: loop 0:
-    Source: 'tests/src/arrays.rs', lines 242:0-250:1 *)
+    Source: 'tests/src/arrays.rs', lines 245:0-253:1 *)
 let rec sum_loop
   (s : slice u32) (sum1 : u32) (i : usize) :
   Tot (result u32) (decreases (sum_loop_decreases s sum1 i))
@@ -322,12 +322,12 @@ let rec sum_loop
   else Ok sum1
 
 (** [arrays::sum]:
-    Source: 'tests/src/arrays.rs', lines 242:0-242:28 *)
+    Source: 'tests/src/arrays.rs', lines 245:0-245:28 *)
 let sum (s : slice u32) : result u32 =
   sum_loop s 0 0
 
 (** [arrays::sum2]: loop 0:
-    Source: 'tests/src/arrays.rs', lines 252:0-261:1 *)
+    Source: 'tests/src/arrays.rs', lines 255:0-264:1 *)
 let rec sum2_loop
   (s : slice u32) (s2 : slice u32) (sum1 : u32) (i : usize) :
   Tot (result u32) (decreases (sum2_loop_decreases s s2 sum1 i))
@@ -344,14 +344,14 @@ let rec sum2_loop
   else Ok sum1
 
 (** [arrays::sum2]:
-    Source: 'tests/src/arrays.rs', lines 252:0-252:41 *)
+    Source: 'tests/src/arrays.rs', lines 255:0-255:41 *)
 let sum2 (s : slice u32) (s2 : slice u32) : result u32 =
   let i = slice_len u32 s in
   let i1 = slice_len u32 s2 in
   if not (i = i1) then Fail Failure else sum2_loop s s2 0 0
 
 (** [arrays::f0]:
-    Source: 'tests/src/arrays.rs', lines 263:0-263:11 *)
+    Source: 'tests/src/arrays.rs', lines 266:0-266:11 *)
 let f0 : result unit =
   let* (s, to_slice_mut_back) =
     array_to_slice_mut u32 2 (mk_array u32 2 [ 1; 2 ]) in
@@ -361,7 +361,7 @@ let f0 : result unit =
   Ok ()
 
 (** [arrays::f1]:
-    Source: 'tests/src/arrays.rs', lines 268:0-268:11 *)
+    Source: 'tests/src/arrays.rs', lines 271:0-271:11 *)
 let f1 : result unit =
   let* (_, index_mut_back) =
     array_index_mut_usize u32 2 (mk_array u32 2 [ 1; 2 ]) 0 in
@@ -369,12 +369,12 @@ let f1 : result unit =
   Ok ()
 
 (** [arrays::f2]:
-    Source: 'tests/src/arrays.rs', lines 273:0-273:17 *)
+    Source: 'tests/src/arrays.rs', lines 276:0-276:17 *)
 let f2 (i : u32) : result unit =
   Ok ()
 
 (** [arrays::f4]:
-    Source: 'tests/src/arrays.rs', lines 282:0-282:54 *)
+    Source: 'tests/src/arrays.rs', lines 285:0-285:54 *)
 let f4 (x : array u32 32) (y : usize) (z : usize) : result (slice u32) =
   core_array_Array_index u32 (core_ops_range_Range usize) 32
     (core_ops_index_IndexSliceTIInst u32 (core_ops_range_Range usize)
@@ -382,7 +382,7 @@ let f4 (x : array u32 32) (y : usize) (z : usize) : result (slice u32) =
     { start = y; end_ = z }
 
 (** [arrays::f3]:
-    Source: 'tests/src/arrays.rs', lines 275:0-275:18 *)
+    Source: 'tests/src/arrays.rs', lines 278:0-278:18 *)
 let f3 : result u32 =
   let* i = array_index_usize u32 2 (mk_array u32 2 [ 1; 2 ]) 0 in
   let* _ = f2 i in
@@ -392,17 +392,17 @@ let f3 : result u32 =
   sum2 s s1
 
 (** [arrays::SZ]
-    Source: 'tests/src/arrays.rs', lines 286:0-286:19 *)
+    Source: 'tests/src/arrays.rs', lines 289:0-289:19 *)
 let sz_body : result usize = Ok 32
 let sz : usize = eval_global sz_body
 
 (** [arrays::f5]:
-    Source: 'tests/src/arrays.rs', lines 289:0-289:31 *)
+    Source: 'tests/src/arrays.rs', lines 292:0-292:31 *)
 let f5 (x : array u32 32) : result u32 =
   array_index_usize u32 32 x 0
 
 (** [arrays::ite]:
-    Source: 'tests/src/arrays.rs', lines 294:0-294:12 *)
+    Source: 'tests/src/arrays.rs', lines 297:0-297:12 *)
 let ite : result unit =
   let* (s, to_slice_mut_back) =
     array_to_slice_mut u32 2 (mk_array u32 2 [ 0; 0 ]) in
@@ -415,7 +415,7 @@ let ite : result unit =
   Ok ()
 
 (** [arrays::zero_slice]: loop 0:
-    Source: 'tests/src/arrays.rs', lines 303:0-310:1 *)
+    Source: 'tests/src/arrays.rs', lines 306:0-313:1 *)
 let rec zero_slice_loop
   (a : slice u8) (i : usize) (len : usize) :
   Tot (result (slice u8)) (decreases (zero_slice_loop_decreases a i len))
@@ -429,12 +429,12 @@ let rec zero_slice_loop
   else Ok a
 
 (** [arrays::zero_slice]:
-    Source: 'tests/src/arrays.rs', lines 303:0-303:31 *)
+    Source: 'tests/src/arrays.rs', lines 306:0-306:31 *)
 let zero_slice (a : slice u8) : result (slice u8) =
   let len = slice_len u8 a in zero_slice_loop a 0 len
 
 (** [arrays::iter_mut_slice]: loop 0:
-    Source: 'tests/src/arrays.rs', lines 312:0-318:1 *)
+    Source: 'tests/src/arrays.rs', lines 315:0-321:1 *)
 let rec iter_mut_slice_loop
   (len : usize) (i : usize) :
   Tot (result unit) (decreases (iter_mut_slice_loop_decreases len i))
@@ -444,12 +444,12 @@ let rec iter_mut_slice_loop
   else Ok ()
 
 (** [arrays::iter_mut_slice]:
-    Source: 'tests/src/arrays.rs', lines 312:0-312:35 *)
+    Source: 'tests/src/arrays.rs', lines 315:0-315:35 *)
 let iter_mut_slice (a : slice u8) : result (slice u8) =
   let len = slice_len u8 a in let* _ = iter_mut_slice_loop len 0 in Ok a
 
 (** [arrays::sum_mut_slice]: loop 0:
-    Source: 'tests/src/arrays.rs', lines 320:0-328:1 *)
+    Source: 'tests/src/arrays.rs', lines 323:0-331:1 *)
 let rec sum_mut_slice_loop
   (a : slice u32) (i : usize) (s : u32) :
   Tot (result u32) (decreases (sum_mut_slice_loop_decreases a i s))
@@ -464,7 +464,7 @@ let rec sum_mut_slice_loop
   else Ok s
 
 (** [arrays::sum_mut_slice]:
-    Source: 'tests/src/arrays.rs', lines 320:0-320:42 *)
+    Source: 'tests/src/arrays.rs', lines 323:0-323:42 *)
 let sum_mut_slice (a : slice u32) : result (u32 & (slice u32)) =
   let* i = sum_mut_slice_loop a 0 0 in Ok (i, a)
 

--- a/tests/fstar/arrays/Arrays.Types.fst
+++ b/tests/fstar/arrays/Arrays.Types.fst
@@ -6,6 +6,6 @@ open Primitives
 #set-options "--z3rlimit 50 --fuel 1 --ifuel 1"
 
 (** [arrays::AB]
-    Source: 'tests/src/arrays.rs', lines 3:0-3:11 *)
+    Source: 'tests/src/arrays.rs', lines 6:0-6:11 *)
 type aB_t = | AB_A : aB_t | AB_B : aB_t
 

--- a/tests/fstar/demo/Demo.fst
+++ b/tests/fstar/demo/Demo.fst
@@ -6,7 +6,7 @@ open Primitives
 #set-options "--z3rlimit 50 --fuel 1 --ifuel 1"
 
 (** [demo::choose]:
-    Source: 'tests/src/demo.rs', lines 5:0-5:70 *)
+    Source: 'tests/src/demo.rs', lines 6:0-6:70 *)
 let choose
   (t : Type0) (b : bool) (x : t) (y : t) : result (t & (t -> result (t & t))) =
   if b
@@ -14,33 +14,33 @@ let choose
   else let back = fun ret -> Ok (x, ret) in Ok (y, back)
 
 (** [demo::mul2_add1]:
-    Source: 'tests/src/demo.rs', lines 13:0-13:31 *)
+    Source: 'tests/src/demo.rs', lines 14:0-14:31 *)
 let mul2_add1 (x : u32) : result u32 =
   let* i = u32_add x x in u32_add i 1
 
 (** [demo::use_mul2_add1]:
-    Source: 'tests/src/demo.rs', lines 17:0-17:43 *)
+    Source: 'tests/src/demo.rs', lines 18:0-18:43 *)
 let use_mul2_add1 (x : u32) (y : u32) : result u32 =
   let* i = mul2_add1 x in u32_add i y
 
 (** [demo::incr]:
-    Source: 'tests/src/demo.rs', lines 21:0-21:31 *)
+    Source: 'tests/src/demo.rs', lines 22:0-22:31 *)
 let incr (x : u32) : result u32 =
   u32_add x 1
 
 (** [demo::use_incr]:
-    Source: 'tests/src/demo.rs', lines 25:0-25:17 *)
+    Source: 'tests/src/demo.rs', lines 26:0-26:17 *)
 let use_incr : result unit =
   let* x = incr 0 in let* x1 = incr x in let* _ = incr x1 in Ok ()
 
 (** [demo::CList]
-    Source: 'tests/src/demo.rs', lines 34:0-34:17 *)
+    Source: 'tests/src/demo.rs', lines 35:0-35:17 *)
 type cList_t (t : Type0) =
 | CList_CCons : t -> cList_t t -> cList_t t
 | CList_CNil : cList_t t
 
 (** [demo::list_nth]:
-    Source: 'tests/src/demo.rs', lines 39:0-39:56 *)
+    Source: 'tests/src/demo.rs', lines 40:0-40:56 *)
 let rec list_nth (t : Type0) (n : nat) (l : cList_t t) (i : u32) : result t =
   if is_zero n
   then Fail OutOfFuel
@@ -53,7 +53,7 @@ let rec list_nth (t : Type0) (n : nat) (l : cList_t t) (i : u32) : result t =
     end
 
 (** [demo::list_nth_mut]:
-    Source: 'tests/src/demo.rs', lines 54:0-54:68 *)
+    Source: 'tests/src/demo.rs', lines 55:0-55:68 *)
 let rec list_nth_mut
   (t : Type0) (n : nat) (l : cList_t t) (i : u32) :
   result (t & (t -> result (cList_t t)))
@@ -77,7 +77,7 @@ let rec list_nth_mut
     end
 
 (** [demo::list_nth_mut1]: loop 0:
-    Source: 'tests/src/demo.rs', lines 69:0-78:1 *)
+    Source: 'tests/src/demo.rs', lines 70:0-79:1 *)
 let rec list_nth_mut1_loop
   (t : Type0) (n : nat) (l : cList_t t) (i : u32) :
   result (t & (t -> result (cList_t t)))
@@ -99,7 +99,7 @@ let rec list_nth_mut1_loop
     end
 
 (** [demo::list_nth_mut1]:
-    Source: 'tests/src/demo.rs', lines 69:0-69:77 *)
+    Source: 'tests/src/demo.rs', lines 70:0-70:77 *)
 let list_nth_mut1
   (t : Type0) (n : nat) (l : cList_t t) (i : u32) :
   result (t & (t -> result (cList_t t)))
@@ -107,7 +107,7 @@ let list_nth_mut1
   list_nth_mut1_loop t n l i
 
 (** [demo::i32_id]:
-    Source: 'tests/src/demo.rs', lines 80:0-80:28 *)
+    Source: 'tests/src/demo.rs', lines 81:0-81:28 *)
 let rec i32_id (n : nat) (i : i32) : result i32 =
   if is_zero n
   then Fail OutOfFuel
@@ -118,7 +118,7 @@ let rec i32_id (n : nat) (i : i32) : result i32 =
     else let* i1 = i32_sub i 1 in let* i2 = i32_id n1 i1 in i32_add i2 1
 
 (** [demo::list_tail]:
-    Source: 'tests/src/demo.rs', lines 88:0-88:64 *)
+    Source: 'tests/src/demo.rs', lines 89:0-89:64 *)
 let rec list_tail
   (t : Type0) (n : nat) (l : cList_t t) :
   result ((cList_t t) & (cList_t t -> result (cList_t t)))
@@ -137,20 +137,20 @@ let rec list_tail
     end
 
 (** Trait declaration: [demo::Counter]
-    Source: 'tests/src/demo.rs', lines 97:0-97:17 *)
+    Source: 'tests/src/demo.rs', lines 98:0-98:17 *)
 noeq type counter_t (self : Type0) = { incr : self -> result (usize & self); }
 
 (** [demo::{(demo::Counter for usize)}::incr]:
-    Source: 'tests/src/demo.rs', lines 102:4-102:31 *)
+    Source: 'tests/src/demo.rs', lines 103:4-103:31 *)
 let counterUsize_incr (self : usize) : result (usize & usize) =
   let* self1 = usize_add self 1 in Ok (self, self1)
 
 (** Trait implementation: [demo::{(demo::Counter for usize)}]
-    Source: 'tests/src/demo.rs', lines 101:0-101:22 *)
+    Source: 'tests/src/demo.rs', lines 102:0-102:22 *)
 let counterUsize : counter_t usize = { incr = counterUsize_incr; }
 
 (** [demo::use_counter]:
-    Source: 'tests/src/demo.rs', lines 109:0-109:59 *)
+    Source: 'tests/src/demo.rs', lines 110:0-110:59 *)
 let use_counter
   (t : Type0) (counterInst : counter_t t) (cnt : t) : result (usize & t) =
   counterInst.incr cnt

--- a/tests/fstar/hashmap/Hashmap.Clauses.Template.fst
+++ b/tests/fstar/hashmap/Hashmap.Clauses.Template.fst
@@ -7,63 +7,63 @@ open Hashmap.Types
 #set-options "--z3rlimit 50 --fuel 1 --ifuel 1"
 
 (** [hashmap::{hashmap::HashMap<T>}::allocate_slots]: decreases clause
-    Source: 'tests/src/hashmap.rs', lines 50:4-56:5 *)
+    Source: 'tests/src/hashmap.rs', lines 58:4-64:5 *)
 unfold
 let hashMap_allocate_slots_loop_decreases (t : Type0)
   (slots : alloc_vec_Vec (list_t t)) (n : usize) : nat =
   admit ()
 
 (** [hashmap::{hashmap::HashMap<T>}::clear]: decreases clause
-    Source: 'tests/src/hashmap.rs', lines 80:4-88:5 *)
+    Source: 'tests/src/hashmap.rs', lines 88:4-96:5 *)
 unfold
 let hashMap_clear_loop_decreases (t : Type0) (slots : alloc_vec_Vec (list_t t))
   (i : usize) : nat =
   admit ()
 
 (** [hashmap::{hashmap::HashMap<T>}::insert_in_list]: decreases clause
-    Source: 'tests/src/hashmap.rs', lines 97:4-114:5 *)
+    Source: 'tests/src/hashmap.rs', lines 105:4-122:5 *)
 unfold
 let hashMap_insert_in_list_loop_decreases (t : Type0) (key : usize) (value : t)
   (ls : list_t t) : nat =
   admit ()
 
 (** [hashmap::{hashmap::HashMap<T>}::move_elements_from_list]: decreases clause
-    Source: 'tests/src/hashmap.rs', lines 183:4-196:5 *)
+    Source: 'tests/src/hashmap.rs', lines 191:4-204:5 *)
 unfold
 let hashMap_move_elements_from_list_loop_decreases (t : Type0)
   (ntable : hashMap_t t) (ls : list_t t) : nat =
   admit ()
 
 (** [hashmap::{hashmap::HashMap<T>}::move_elements]: decreases clause
-    Source: 'tests/src/hashmap.rs', lines 171:4-180:5 *)
+    Source: 'tests/src/hashmap.rs', lines 179:4-188:5 *)
 unfold
 let hashMap_move_elements_loop_decreases (t : Type0) (ntable : hashMap_t t)
   (slots : alloc_vec_Vec (list_t t)) (i : usize) : nat =
   admit ()
 
 (** [hashmap::{hashmap::HashMap<T>}::contains_key_in_list]: decreases clause
-    Source: 'tests/src/hashmap.rs', lines 206:4-219:5 *)
+    Source: 'tests/src/hashmap.rs', lines 214:4-227:5 *)
 unfold
 let hashMap_contains_key_in_list_loop_decreases (t : Type0) (key : usize)
   (ls : list_t t) : nat =
   admit ()
 
 (** [hashmap::{hashmap::HashMap<T>}::get_in_list]: decreases clause
-    Source: 'tests/src/hashmap.rs', lines 224:4-237:5 *)
+    Source: 'tests/src/hashmap.rs', lines 232:4-245:5 *)
 unfold
 let hashMap_get_in_list_loop_decreases (t : Type0) (key : usize)
   (ls : list_t t) : nat =
   admit ()
 
 (** [hashmap::{hashmap::HashMap<T>}::get_mut_in_list]: decreases clause
-    Source: 'tests/src/hashmap.rs', lines 245:4-254:5 *)
+    Source: 'tests/src/hashmap.rs', lines 253:4-262:5 *)
 unfold
 let hashMap_get_mut_in_list_loop_decreases (t : Type0) (ls : list_t t)
   (key : usize) : nat =
   admit ()
 
 (** [hashmap::{hashmap::HashMap<T>}::remove_from_list]: decreases clause
-    Source: 'tests/src/hashmap.rs', lines 265:4-291:5 *)
+    Source: 'tests/src/hashmap.rs', lines 273:4-299:5 *)
 unfold
 let hashMap_remove_from_list_loop_decreases (t : Type0) (key : usize)
   (ls : list_t t) : nat =

--- a/tests/fstar/hashmap/Hashmap.Funs.fst
+++ b/tests/fstar/hashmap/Hashmap.Funs.fst
@@ -8,12 +8,12 @@ include Hashmap.Clauses
 #set-options "--z3rlimit 50 --fuel 1 --ifuel 1"
 
 (** [hashmap::hash_key]:
-    Source: 'tests/src/hashmap.rs', lines 27:0-27:32 *)
+    Source: 'tests/src/hashmap.rs', lines 35:0-35:32 *)
 let hash_key (k : usize) : result usize =
   Ok k
 
 (** [hashmap::{hashmap::HashMap<T>}::allocate_slots]: loop 0:
-    Source: 'tests/src/hashmap.rs', lines 50:4-56:5 *)
+    Source: 'tests/src/hashmap.rs', lines 58:4-64:5 *)
 let rec hashMap_allocate_slots_loop
   (t : Type0) (slots : alloc_vec_Vec (list_t t)) (n : usize) :
   Tot (result (alloc_vec_Vec (list_t t)))
@@ -27,7 +27,7 @@ let rec hashMap_allocate_slots_loop
   else Ok slots
 
 (** [hashmap::{hashmap::HashMap<T>}::allocate_slots]:
-    Source: 'tests/src/hashmap.rs', lines 50:4-50:76 *)
+    Source: 'tests/src/hashmap.rs', lines 58:4-58:76 *)
 let hashMap_allocate_slots
   (t : Type0) (slots : alloc_vec_Vec (list_t t)) (n : usize) :
   result (alloc_vec_Vec (list_t t))
@@ -35,7 +35,7 @@ let hashMap_allocate_slots
   hashMap_allocate_slots_loop t slots n
 
 (** [hashmap::{hashmap::HashMap<T>}::new_with_capacity]:
-    Source: 'tests/src/hashmap.rs', lines 59:4-63:13 *)
+    Source: 'tests/src/hashmap.rs', lines 67:4-71:13 *)
 let hashMap_new_with_capacity
   (t : Type0) (capacity : usize) (max_load_dividend : usize)
   (max_load_divisor : usize) :
@@ -54,12 +54,12 @@ let hashMap_new_with_capacity
     }
 
 (** [hashmap::{hashmap::HashMap<T>}::new]:
-    Source: 'tests/src/hashmap.rs', lines 75:4-75:24 *)
+    Source: 'tests/src/hashmap.rs', lines 83:4-83:24 *)
 let hashMap_new (t : Type0) : result (hashMap_t t) =
   hashMap_new_with_capacity t 32 4 5
 
 (** [hashmap::{hashmap::HashMap<T>}::clear]: loop 0:
-    Source: 'tests/src/hashmap.rs', lines 80:4-88:5 *)
+    Source: 'tests/src/hashmap.rs', lines 88:4-96:5 *)
 let rec hashMap_clear_loop
   (t : Type0) (slots : alloc_vec_Vec (list_t t)) (i : usize) :
   Tot (result (alloc_vec_Vec (list_t t)))
@@ -77,18 +77,18 @@ let rec hashMap_clear_loop
   else Ok slots
 
 (** [hashmap::{hashmap::HashMap<T>}::clear]:
-    Source: 'tests/src/hashmap.rs', lines 80:4-80:27 *)
+    Source: 'tests/src/hashmap.rs', lines 88:4-88:27 *)
 let hashMap_clear (t : Type0) (self : hashMap_t t) : result (hashMap_t t) =
   let* hm = hashMap_clear_loop t self.slots 0 in
   Ok { self with num_entries = 0; slots = hm }
 
 (** [hashmap::{hashmap::HashMap<T>}::len]:
-    Source: 'tests/src/hashmap.rs', lines 90:4-90:30 *)
+    Source: 'tests/src/hashmap.rs', lines 98:4-98:30 *)
 let hashMap_len (t : Type0) (self : hashMap_t t) : result usize =
   Ok self.num_entries
 
 (** [hashmap::{hashmap::HashMap<T>}::insert_in_list]: loop 0:
-    Source: 'tests/src/hashmap.rs', lines 97:4-114:5 *)
+    Source: 'tests/src/hashmap.rs', lines 105:4-122:5 *)
 let rec hashMap_insert_in_list_loop
   (t : Type0) (key : usize) (value : t) (ls : list_t t) :
   Tot (result (bool & (list_t t)))
@@ -105,7 +105,7 @@ let rec hashMap_insert_in_list_loop
   end
 
 (** [hashmap::{hashmap::HashMap<T>}::insert_in_list]:
-    Source: 'tests/src/hashmap.rs', lines 97:4-97:71 *)
+    Source: 'tests/src/hashmap.rs', lines 105:4-105:71 *)
 let hashMap_insert_in_list
   (t : Type0) (key : usize) (value : t) (ls : list_t t) :
   result (bool & (list_t t))
@@ -113,7 +113,7 @@ let hashMap_insert_in_list
   hashMap_insert_in_list_loop t key value ls
 
 (** [hashmap::{hashmap::HashMap<T>}::insert_no_resize]:
-    Source: 'tests/src/hashmap.rs', lines 117:4-117:54 *)
+    Source: 'tests/src/hashmap.rs', lines 125:4-125:54 *)
 let hashMap_insert_no_resize
   (t : Type0) (self : hashMap_t t) (key : usize) (value : t) :
   result (hashMap_t t)
@@ -134,7 +134,7 @@ let hashMap_insert_no_resize
   else let* v = index_mut_back l1 in Ok { self with slots = v }
 
 (** [hashmap::{hashmap::HashMap<T>}::move_elements_from_list]: loop 0:
-    Source: 'tests/src/hashmap.rs', lines 183:4-196:5 *)
+    Source: 'tests/src/hashmap.rs', lines 191:4-204:5 *)
 let rec hashMap_move_elements_from_list_loop
   (t : Type0) (ntable : hashMap_t t) (ls : list_t t) :
   Tot (result (hashMap_t t))
@@ -148,13 +148,13 @@ let rec hashMap_move_elements_from_list_loop
   end
 
 (** [hashmap::{hashmap::HashMap<T>}::move_elements_from_list]:
-    Source: 'tests/src/hashmap.rs', lines 183:4-183:72 *)
+    Source: 'tests/src/hashmap.rs', lines 191:4-191:72 *)
 let hashMap_move_elements_from_list
   (t : Type0) (ntable : hashMap_t t) (ls : list_t t) : result (hashMap_t t) =
   hashMap_move_elements_from_list_loop t ntable ls
 
 (** [hashmap::{hashmap::HashMap<T>}::move_elements]: loop 0:
-    Source: 'tests/src/hashmap.rs', lines 171:4-180:5 *)
+    Source: 'tests/src/hashmap.rs', lines 179:4-188:5 *)
 let rec hashMap_move_elements_loop
   (t : Type0) (ntable : hashMap_t t) (slots : alloc_vec_Vec (list_t t))
   (i : usize) :
@@ -175,7 +175,7 @@ let rec hashMap_move_elements_loop
   else Ok (ntable, slots)
 
 (** [hashmap::{hashmap::HashMap<T>}::move_elements]:
-    Source: 'tests/src/hashmap.rs', lines 171:4-171:95 *)
+    Source: 'tests/src/hashmap.rs', lines 179:4-179:95 *)
 let hashMap_move_elements
   (t : Type0) (ntable : hashMap_t t) (slots : alloc_vec_Vec (list_t t))
   (i : usize) :
@@ -184,7 +184,7 @@ let hashMap_move_elements
   hashMap_move_elements_loop t ntable slots i
 
 (** [hashmap::{hashmap::HashMap<T>}::try_resize]:
-    Source: 'tests/src/hashmap.rs', lines 140:4-140:28 *)
+    Source: 'tests/src/hashmap.rs', lines 148:4-148:28 *)
 let hashMap_try_resize
   (t : Type0) (self : hashMap_t t) : result (hashMap_t t) =
   let* max_usize = scalar_cast U32 Usize core_u32_max in
@@ -204,7 +204,7 @@ let hashMap_try_resize
   else Ok { self with max_load_factor = (i, i1) }
 
 (** [hashmap::{hashmap::HashMap<T>}::insert]:
-    Source: 'tests/src/hashmap.rs', lines 129:4-129:48 *)
+    Source: 'tests/src/hashmap.rs', lines 137:4-137:48 *)
 let hashMap_insert
   (t : Type0) (self : hashMap_t t) (key : usize) (value : t) :
   result (hashMap_t t)
@@ -214,7 +214,7 @@ let hashMap_insert
   if i > self1.max_load then hashMap_try_resize t self1 else Ok self1
 
 (** [hashmap::{hashmap::HashMap<T>}::contains_key_in_list]: loop 0:
-    Source: 'tests/src/hashmap.rs', lines 206:4-219:5 *)
+    Source: 'tests/src/hashmap.rs', lines 214:4-227:5 *)
 let rec hashMap_contains_key_in_list_loop
   (t : Type0) (key : usize) (ls : list_t t) :
   Tot (result bool)
@@ -227,13 +227,13 @@ let rec hashMap_contains_key_in_list_loop
   end
 
 (** [hashmap::{hashmap::HashMap<T>}::contains_key_in_list]:
-    Source: 'tests/src/hashmap.rs', lines 206:4-206:68 *)
+    Source: 'tests/src/hashmap.rs', lines 214:4-214:68 *)
 let hashMap_contains_key_in_list
   (t : Type0) (key : usize) (ls : list_t t) : result bool =
   hashMap_contains_key_in_list_loop t key ls
 
 (** [hashmap::{hashmap::HashMap<T>}::contains_key]:
-    Source: 'tests/src/hashmap.rs', lines 199:4-199:49 *)
+    Source: 'tests/src/hashmap.rs', lines 207:4-207:49 *)
 let hashMap_contains_key
   (t : Type0) (self : hashMap_t t) (key : usize) : result bool =
   let* hash = hash_key key in
@@ -246,7 +246,7 @@ let hashMap_contains_key
   hashMap_contains_key_in_list t key l
 
 (** [hashmap::{hashmap::HashMap<T>}::get_in_list]: loop 0:
-    Source: 'tests/src/hashmap.rs', lines 224:4-237:5 *)
+    Source: 'tests/src/hashmap.rs', lines 232:4-245:5 *)
 let rec hashMap_get_in_list_loop
   (t : Type0) (key : usize) (ls : list_t t) :
   Tot (result t) (decreases (hashMap_get_in_list_loop_decreases t key ls))
@@ -258,12 +258,12 @@ let rec hashMap_get_in_list_loop
   end
 
 (** [hashmap::{hashmap::HashMap<T>}::get_in_list]:
-    Source: 'tests/src/hashmap.rs', lines 224:4-224:70 *)
+    Source: 'tests/src/hashmap.rs', lines 232:4-232:70 *)
 let hashMap_get_in_list (t : Type0) (key : usize) (ls : list_t t) : result t =
   hashMap_get_in_list_loop t key ls
 
 (** [hashmap::{hashmap::HashMap<T>}::get]:
-    Source: 'tests/src/hashmap.rs', lines 239:4-239:55 *)
+    Source: 'tests/src/hashmap.rs', lines 247:4-247:55 *)
 let hashMap_get (t : Type0) (self : hashMap_t t) (key : usize) : result t =
   let* hash = hash_key key in
   let i = alloc_vec_Vec_len (list_t t) self.slots in
@@ -275,7 +275,7 @@ let hashMap_get (t : Type0) (self : hashMap_t t) (key : usize) : result t =
   hashMap_get_in_list t key l
 
 (** [hashmap::{hashmap::HashMap<T>}::get_mut_in_list]: loop 0:
-    Source: 'tests/src/hashmap.rs', lines 245:4-254:5 *)
+    Source: 'tests/src/hashmap.rs', lines 253:4-262:5 *)
 let rec hashMap_get_mut_in_list_loop
   (t : Type0) (ls : list_t t) (key : usize) :
   Tot (result (t & (t -> result (list_t t))))
@@ -294,7 +294,7 @@ let rec hashMap_get_mut_in_list_loop
   end
 
 (** [hashmap::{hashmap::HashMap<T>}::get_mut_in_list]:
-    Source: 'tests/src/hashmap.rs', lines 245:4-245:86 *)
+    Source: 'tests/src/hashmap.rs', lines 253:4-253:86 *)
 let hashMap_get_mut_in_list
   (t : Type0) (ls : list_t t) (key : usize) :
   result (t & (t -> result (list_t t)))
@@ -302,7 +302,7 @@ let hashMap_get_mut_in_list
   hashMap_get_mut_in_list_loop t ls key
 
 (** [hashmap::{hashmap::HashMap<T>}::get_mut]:
-    Source: 'tests/src/hashmap.rs', lines 257:4-257:67 *)
+    Source: 'tests/src/hashmap.rs', lines 265:4-265:67 *)
 let hashMap_get_mut
   (t : Type0) (self : hashMap_t t) (key : usize) :
   result (t & (t -> result (hashMap_t t)))
@@ -323,7 +323,7 @@ let hashMap_get_mut
   Ok (x, back)
 
 (** [hashmap::{hashmap::HashMap<T>}::remove_from_list]: loop 0:
-    Source: 'tests/src/hashmap.rs', lines 265:4-291:5 *)
+    Source: 'tests/src/hashmap.rs', lines 273:4-299:5 *)
 let rec hashMap_remove_from_list_loop
   (t : Type0) (key : usize) (ls : list_t t) :
   Tot (result ((option t) & (list_t t)))
@@ -346,7 +346,7 @@ let rec hashMap_remove_from_list_loop
   end
 
 (** [hashmap::{hashmap::HashMap<T>}::remove_from_list]:
-    Source: 'tests/src/hashmap.rs', lines 265:4-265:69 *)
+    Source: 'tests/src/hashmap.rs', lines 273:4-273:69 *)
 let hashMap_remove_from_list
   (t : Type0) (key : usize) (ls : list_t t) :
   result ((option t) & (list_t t))
@@ -354,7 +354,7 @@ let hashMap_remove_from_list
   hashMap_remove_from_list_loop t key ls
 
 (** [hashmap::{hashmap::HashMap<T>}::remove]:
-    Source: 'tests/src/hashmap.rs', lines 294:4-294:52 *)
+    Source: 'tests/src/hashmap.rs', lines 302:4-302:52 *)
 let hashMap_remove
   (t : Type0) (self : hashMap_t t) (key : usize) :
   result ((option t) & (hashMap_t t))
@@ -376,7 +376,7 @@ let hashMap_remove
   end
 
 (** [hashmap::test1]:
-    Source: 'tests/src/hashmap.rs', lines 315:0-315:10 *)
+    Source: 'tests/src/hashmap.rs', lines 323:0-323:10 *)
 let test1 : result unit =
   let* hm = hashMap_new u64 in
   let* hm1 = hashMap_insert u64 hm 0 42 in

--- a/tests/fstar/hashmap/Hashmap.Types.fst
+++ b/tests/fstar/hashmap/Hashmap.Types.fst
@@ -6,13 +6,13 @@ open Primitives
 #set-options "--z3rlimit 50 --fuel 1 --ifuel 1"
 
 (** [hashmap::List]
-    Source: 'tests/src/hashmap.rs', lines 19:0-19:16 *)
+    Source: 'tests/src/hashmap.rs', lines 27:0-27:16 *)
 type list_t (t : Type0) =
 | List_Cons : usize -> t -> list_t t -> list_t t
 | List_Nil : list_t t
 
 (** [hashmap::HashMap]
-    Source: 'tests/src/hashmap.rs', lines 35:0-35:21 *)
+    Source: 'tests/src/hashmap.rs', lines 43:0-43:21 *)
 type hashMap_t (t : Type0) =
 {
   num_entries : usize;

--- a/tests/fstar/hashmap_on_disk/HashmapMain.Clauses.Template.fst
+++ b/tests/fstar/hashmap_on_disk/HashmapMain.Clauses.Template.fst
@@ -7,35 +7,35 @@ open HashmapMain.Types
 #set-options "--z3rlimit 50 --fuel 1 --ifuel 1"
 
 (** [hashmap_main::hashmap::{hashmap_main::hashmap::HashMap<T>}::allocate_slots]: decreases clause
-    Source: 'tests/src/hashmap.rs', lines 50:4-56:5 *)
+    Source: 'tests/src/hashmap.rs', lines 58:4-64:5 *)
 unfold
 let hashmap_HashMap_allocate_slots_loop_decreases (t : Type0)
   (slots : alloc_vec_Vec (hashmap_List_t t)) (n : usize) : nat =
   admit ()
 
 (** [hashmap_main::hashmap::{hashmap_main::hashmap::HashMap<T>}::clear]: decreases clause
-    Source: 'tests/src/hashmap.rs', lines 80:4-88:5 *)
+    Source: 'tests/src/hashmap.rs', lines 88:4-96:5 *)
 unfold
 let hashmap_HashMap_clear_loop_decreases (t : Type0)
   (slots : alloc_vec_Vec (hashmap_List_t t)) (i : usize) : nat =
   admit ()
 
 (** [hashmap_main::hashmap::{hashmap_main::hashmap::HashMap<T>}::insert_in_list]: decreases clause
-    Source: 'tests/src/hashmap.rs', lines 97:4-114:5 *)
+    Source: 'tests/src/hashmap.rs', lines 105:4-122:5 *)
 unfold
 let hashmap_HashMap_insert_in_list_loop_decreases (t : Type0) (key : usize)
   (value : t) (ls : hashmap_List_t t) : nat =
   admit ()
 
 (** [hashmap_main::hashmap::{hashmap_main::hashmap::HashMap<T>}::move_elements_from_list]: decreases clause
-    Source: 'tests/src/hashmap.rs', lines 183:4-196:5 *)
+    Source: 'tests/src/hashmap.rs', lines 191:4-204:5 *)
 unfold
 let hashmap_HashMap_move_elements_from_list_loop_decreases (t : Type0)
   (ntable : hashmap_HashMap_t t) (ls : hashmap_List_t t) : nat =
   admit ()
 
 (** [hashmap_main::hashmap::{hashmap_main::hashmap::HashMap<T>}::move_elements]: decreases clause
-    Source: 'tests/src/hashmap.rs', lines 171:4-180:5 *)
+    Source: 'tests/src/hashmap.rs', lines 179:4-188:5 *)
 unfold
 let hashmap_HashMap_move_elements_loop_decreases (t : Type0)
   (ntable : hashmap_HashMap_t t) (slots : alloc_vec_Vec (hashmap_List_t t))
@@ -43,28 +43,28 @@ let hashmap_HashMap_move_elements_loop_decreases (t : Type0)
   admit ()
 
 (** [hashmap_main::hashmap::{hashmap_main::hashmap::HashMap<T>}::contains_key_in_list]: decreases clause
-    Source: 'tests/src/hashmap.rs', lines 206:4-219:5 *)
+    Source: 'tests/src/hashmap.rs', lines 214:4-227:5 *)
 unfold
 let hashmap_HashMap_contains_key_in_list_loop_decreases (t : Type0)
   (key : usize) (ls : hashmap_List_t t) : nat =
   admit ()
 
 (** [hashmap_main::hashmap::{hashmap_main::hashmap::HashMap<T>}::get_in_list]: decreases clause
-    Source: 'tests/src/hashmap.rs', lines 224:4-237:5 *)
+    Source: 'tests/src/hashmap.rs', lines 232:4-245:5 *)
 unfold
 let hashmap_HashMap_get_in_list_loop_decreases (t : Type0) (key : usize)
   (ls : hashmap_List_t t) : nat =
   admit ()
 
 (** [hashmap_main::hashmap::{hashmap_main::hashmap::HashMap<T>}::get_mut_in_list]: decreases clause
-    Source: 'tests/src/hashmap.rs', lines 245:4-254:5 *)
+    Source: 'tests/src/hashmap.rs', lines 253:4-262:5 *)
 unfold
 let hashmap_HashMap_get_mut_in_list_loop_decreases (t : Type0)
   (ls : hashmap_List_t t) (key : usize) : nat =
   admit ()
 
 (** [hashmap_main::hashmap::{hashmap_main::hashmap::HashMap<T>}::remove_from_list]: decreases clause
-    Source: 'tests/src/hashmap.rs', lines 265:4-291:5 *)
+    Source: 'tests/src/hashmap.rs', lines 273:4-299:5 *)
 unfold
 let hashmap_HashMap_remove_from_list_loop_decreases (t : Type0) (key : usize)
   (ls : hashmap_List_t t) : nat =

--- a/tests/fstar/hashmap_on_disk/HashmapMain.Funs.fst
+++ b/tests/fstar/hashmap_on_disk/HashmapMain.Funs.fst
@@ -9,12 +9,12 @@ include HashmapMain.Clauses
 #set-options "--z3rlimit 50 --fuel 1 --ifuel 1"
 
 (** [hashmap_main::hashmap::hash_key]:
-    Source: 'tests/src/hashmap.rs', lines 27:0-27:32 *)
+    Source: 'tests/src/hashmap.rs', lines 35:0-35:32 *)
 let hashmap_hash_key (k : usize) : result usize =
   Ok k
 
 (** [hashmap_main::hashmap::{hashmap_main::hashmap::HashMap<T>}::allocate_slots]: loop 0:
-    Source: 'tests/src/hashmap.rs', lines 50:4-56:5 *)
+    Source: 'tests/src/hashmap.rs', lines 58:4-64:5 *)
 let rec hashmap_HashMap_allocate_slots_loop
   (t : Type0) (slots : alloc_vec_Vec (hashmap_List_t t)) (n : usize) :
   Tot (result (alloc_vec_Vec (hashmap_List_t t)))
@@ -29,7 +29,7 @@ let rec hashmap_HashMap_allocate_slots_loop
   else Ok slots
 
 (** [hashmap_main::hashmap::{hashmap_main::hashmap::HashMap<T>}::allocate_slots]:
-    Source: 'tests/src/hashmap.rs', lines 50:4-50:76 *)
+    Source: 'tests/src/hashmap.rs', lines 58:4-58:76 *)
 let hashmap_HashMap_allocate_slots
   (t : Type0) (slots : alloc_vec_Vec (hashmap_List_t t)) (n : usize) :
   result (alloc_vec_Vec (hashmap_List_t t))
@@ -37,7 +37,7 @@ let hashmap_HashMap_allocate_slots
   hashmap_HashMap_allocate_slots_loop t slots n
 
 (** [hashmap_main::hashmap::{hashmap_main::hashmap::HashMap<T>}::new_with_capacity]:
-    Source: 'tests/src/hashmap.rs', lines 59:4-63:13 *)
+    Source: 'tests/src/hashmap.rs', lines 67:4-71:13 *)
 let hashmap_HashMap_new_with_capacity
   (t : Type0) (capacity : usize) (max_load_dividend : usize)
   (max_load_divisor : usize) :
@@ -57,12 +57,12 @@ let hashmap_HashMap_new_with_capacity
     }
 
 (** [hashmap_main::hashmap::{hashmap_main::hashmap::HashMap<T>}::new]:
-    Source: 'tests/src/hashmap.rs', lines 75:4-75:24 *)
+    Source: 'tests/src/hashmap.rs', lines 83:4-83:24 *)
 let hashmap_HashMap_new (t : Type0) : result (hashmap_HashMap_t t) =
   hashmap_HashMap_new_with_capacity t 32 4 5
 
 (** [hashmap_main::hashmap::{hashmap_main::hashmap::HashMap<T>}::clear]: loop 0:
-    Source: 'tests/src/hashmap.rs', lines 80:4-88:5 *)
+    Source: 'tests/src/hashmap.rs', lines 88:4-96:5 *)
 let rec hashmap_HashMap_clear_loop
   (t : Type0) (slots : alloc_vec_Vec (hashmap_List_t t)) (i : usize) :
   Tot (result (alloc_vec_Vec (hashmap_List_t t)))
@@ -81,20 +81,20 @@ let rec hashmap_HashMap_clear_loop
   else Ok slots
 
 (** [hashmap_main::hashmap::{hashmap_main::hashmap::HashMap<T>}::clear]:
-    Source: 'tests/src/hashmap.rs', lines 80:4-80:27 *)
+    Source: 'tests/src/hashmap.rs', lines 88:4-88:27 *)
 let hashmap_HashMap_clear
   (t : Type0) (self : hashmap_HashMap_t t) : result (hashmap_HashMap_t t) =
   let* hm = hashmap_HashMap_clear_loop t self.slots 0 in
   Ok { self with num_entries = 0; slots = hm }
 
 (** [hashmap_main::hashmap::{hashmap_main::hashmap::HashMap<T>}::len]:
-    Source: 'tests/src/hashmap.rs', lines 90:4-90:30 *)
+    Source: 'tests/src/hashmap.rs', lines 98:4-98:30 *)
 let hashmap_HashMap_len
   (t : Type0) (self : hashmap_HashMap_t t) : result usize =
   Ok self.num_entries
 
 (** [hashmap_main::hashmap::{hashmap_main::hashmap::HashMap<T>}::insert_in_list]: loop 0:
-    Source: 'tests/src/hashmap.rs', lines 97:4-114:5 *)
+    Source: 'tests/src/hashmap.rs', lines 105:4-122:5 *)
 let rec hashmap_HashMap_insert_in_list_loop
   (t : Type0) (key : usize) (value : t) (ls : hashmap_List_t t) :
   Tot (result (bool & (hashmap_List_t t)))
@@ -111,7 +111,7 @@ let rec hashmap_HashMap_insert_in_list_loop
   end
 
 (** [hashmap_main::hashmap::{hashmap_main::hashmap::HashMap<T>}::insert_in_list]:
-    Source: 'tests/src/hashmap.rs', lines 97:4-97:71 *)
+    Source: 'tests/src/hashmap.rs', lines 105:4-105:71 *)
 let hashmap_HashMap_insert_in_list
   (t : Type0) (key : usize) (value : t) (ls : hashmap_List_t t) :
   result (bool & (hashmap_List_t t))
@@ -119,7 +119,7 @@ let hashmap_HashMap_insert_in_list
   hashmap_HashMap_insert_in_list_loop t key value ls
 
 (** [hashmap_main::hashmap::{hashmap_main::hashmap::HashMap<T>}::insert_no_resize]:
-    Source: 'tests/src/hashmap.rs', lines 117:4-117:54 *)
+    Source: 'tests/src/hashmap.rs', lines 125:4-125:54 *)
 let hashmap_HashMap_insert_no_resize
   (t : Type0) (self : hashmap_HashMap_t t) (key : usize) (value : t) :
   result (hashmap_HashMap_t t)
@@ -140,7 +140,7 @@ let hashmap_HashMap_insert_no_resize
   else let* v = index_mut_back l1 in Ok { self with slots = v }
 
 (** [hashmap_main::hashmap::{hashmap_main::hashmap::HashMap<T>}::move_elements_from_list]: loop 0:
-    Source: 'tests/src/hashmap.rs', lines 183:4-196:5 *)
+    Source: 'tests/src/hashmap.rs', lines 191:4-204:5 *)
 let rec hashmap_HashMap_move_elements_from_list_loop
   (t : Type0) (ntable : hashmap_HashMap_t t) (ls : hashmap_List_t t) :
   Tot (result (hashmap_HashMap_t t))
@@ -155,7 +155,7 @@ let rec hashmap_HashMap_move_elements_from_list_loop
   end
 
 (** [hashmap_main::hashmap::{hashmap_main::hashmap::HashMap<T>}::move_elements_from_list]:
-    Source: 'tests/src/hashmap.rs', lines 183:4-183:72 *)
+    Source: 'tests/src/hashmap.rs', lines 191:4-191:72 *)
 let hashmap_HashMap_move_elements_from_list
   (t : Type0) (ntable : hashmap_HashMap_t t) (ls : hashmap_List_t t) :
   result (hashmap_HashMap_t t)
@@ -163,7 +163,7 @@ let hashmap_HashMap_move_elements_from_list
   hashmap_HashMap_move_elements_from_list_loop t ntable ls
 
 (** [hashmap_main::hashmap::{hashmap_main::hashmap::HashMap<T>}::move_elements]: loop 0:
-    Source: 'tests/src/hashmap.rs', lines 171:4-180:5 *)
+    Source: 'tests/src/hashmap.rs', lines 179:4-188:5 *)
 let rec hashmap_HashMap_move_elements_loop
   (t : Type0) (ntable : hashmap_HashMap_t t)
   (slots : alloc_vec_Vec (hashmap_List_t t)) (i : usize) :
@@ -185,7 +185,7 @@ let rec hashmap_HashMap_move_elements_loop
   else Ok (ntable, slots)
 
 (** [hashmap_main::hashmap::{hashmap_main::hashmap::HashMap<T>}::move_elements]:
-    Source: 'tests/src/hashmap.rs', lines 171:4-171:95 *)
+    Source: 'tests/src/hashmap.rs', lines 179:4-179:95 *)
 let hashmap_HashMap_move_elements
   (t : Type0) (ntable : hashmap_HashMap_t t)
   (slots : alloc_vec_Vec (hashmap_List_t t)) (i : usize) :
@@ -194,7 +194,7 @@ let hashmap_HashMap_move_elements
   hashmap_HashMap_move_elements_loop t ntable slots i
 
 (** [hashmap_main::hashmap::{hashmap_main::hashmap::HashMap<T>}::try_resize]:
-    Source: 'tests/src/hashmap.rs', lines 140:4-140:28 *)
+    Source: 'tests/src/hashmap.rs', lines 148:4-148:28 *)
 let hashmap_HashMap_try_resize
   (t : Type0) (self : hashmap_HashMap_t t) : result (hashmap_HashMap_t t) =
   let* max_usize = scalar_cast U32 Usize core_u32_max in
@@ -214,7 +214,7 @@ let hashmap_HashMap_try_resize
   else Ok { self with max_load_factor = (i, i1) }
 
 (** [hashmap_main::hashmap::{hashmap_main::hashmap::HashMap<T>}::insert]:
-    Source: 'tests/src/hashmap.rs', lines 129:4-129:48 *)
+    Source: 'tests/src/hashmap.rs', lines 137:4-137:48 *)
 let hashmap_HashMap_insert
   (t : Type0) (self : hashmap_HashMap_t t) (key : usize) (value : t) :
   result (hashmap_HashMap_t t)
@@ -224,7 +224,7 @@ let hashmap_HashMap_insert
   if i > self1.max_load then hashmap_HashMap_try_resize t self1 else Ok self1
 
 (** [hashmap_main::hashmap::{hashmap_main::hashmap::HashMap<T>}::contains_key_in_list]: loop 0:
-    Source: 'tests/src/hashmap.rs', lines 206:4-219:5 *)
+    Source: 'tests/src/hashmap.rs', lines 214:4-227:5 *)
 let rec hashmap_HashMap_contains_key_in_list_loop
   (t : Type0) (key : usize) (ls : hashmap_List_t t) :
   Tot (result bool)
@@ -239,13 +239,13 @@ let rec hashmap_HashMap_contains_key_in_list_loop
   end
 
 (** [hashmap_main::hashmap::{hashmap_main::hashmap::HashMap<T>}::contains_key_in_list]:
-    Source: 'tests/src/hashmap.rs', lines 206:4-206:68 *)
+    Source: 'tests/src/hashmap.rs', lines 214:4-214:68 *)
 let hashmap_HashMap_contains_key_in_list
   (t : Type0) (key : usize) (ls : hashmap_List_t t) : result bool =
   hashmap_HashMap_contains_key_in_list_loop t key ls
 
 (** [hashmap_main::hashmap::{hashmap_main::hashmap::HashMap<T>}::contains_key]:
-    Source: 'tests/src/hashmap.rs', lines 199:4-199:49 *)
+    Source: 'tests/src/hashmap.rs', lines 207:4-207:49 *)
 let hashmap_HashMap_contains_key
   (t : Type0) (self : hashmap_HashMap_t t) (key : usize) : result bool =
   let* hash = hashmap_hash_key key in
@@ -258,7 +258,7 @@ let hashmap_HashMap_contains_key
   hashmap_HashMap_contains_key_in_list t key l
 
 (** [hashmap_main::hashmap::{hashmap_main::hashmap::HashMap<T>}::get_in_list]: loop 0:
-    Source: 'tests/src/hashmap.rs', lines 224:4-237:5 *)
+    Source: 'tests/src/hashmap.rs', lines 232:4-245:5 *)
 let rec hashmap_HashMap_get_in_list_loop
   (t : Type0) (key : usize) (ls : hashmap_List_t t) :
   Tot (result t)
@@ -271,13 +271,13 @@ let rec hashmap_HashMap_get_in_list_loop
   end
 
 (** [hashmap_main::hashmap::{hashmap_main::hashmap::HashMap<T>}::get_in_list]:
-    Source: 'tests/src/hashmap.rs', lines 224:4-224:70 *)
+    Source: 'tests/src/hashmap.rs', lines 232:4-232:70 *)
 let hashmap_HashMap_get_in_list
   (t : Type0) (key : usize) (ls : hashmap_List_t t) : result t =
   hashmap_HashMap_get_in_list_loop t key ls
 
 (** [hashmap_main::hashmap::{hashmap_main::hashmap::HashMap<T>}::get]:
-    Source: 'tests/src/hashmap.rs', lines 239:4-239:55 *)
+    Source: 'tests/src/hashmap.rs', lines 247:4-247:55 *)
 let hashmap_HashMap_get
   (t : Type0) (self : hashmap_HashMap_t t) (key : usize) : result t =
   let* hash = hashmap_hash_key key in
@@ -290,7 +290,7 @@ let hashmap_HashMap_get
   hashmap_HashMap_get_in_list t key l
 
 (** [hashmap_main::hashmap::{hashmap_main::hashmap::HashMap<T>}::get_mut_in_list]: loop 0:
-    Source: 'tests/src/hashmap.rs', lines 245:4-254:5 *)
+    Source: 'tests/src/hashmap.rs', lines 253:4-262:5 *)
 let rec hashmap_HashMap_get_mut_in_list_loop
   (t : Type0) (ls : hashmap_List_t t) (key : usize) :
   Tot (result (t & (t -> result (hashmap_List_t t))))
@@ -312,7 +312,7 @@ let rec hashmap_HashMap_get_mut_in_list_loop
   end
 
 (** [hashmap_main::hashmap::{hashmap_main::hashmap::HashMap<T>}::get_mut_in_list]:
-    Source: 'tests/src/hashmap.rs', lines 245:4-245:86 *)
+    Source: 'tests/src/hashmap.rs', lines 253:4-253:86 *)
 let hashmap_HashMap_get_mut_in_list
   (t : Type0) (ls : hashmap_List_t t) (key : usize) :
   result (t & (t -> result (hashmap_List_t t)))
@@ -320,7 +320,7 @@ let hashmap_HashMap_get_mut_in_list
   hashmap_HashMap_get_mut_in_list_loop t ls key
 
 (** [hashmap_main::hashmap::{hashmap_main::hashmap::HashMap<T>}::get_mut]:
-    Source: 'tests/src/hashmap.rs', lines 257:4-257:67 *)
+    Source: 'tests/src/hashmap.rs', lines 265:4-265:67 *)
 let hashmap_HashMap_get_mut
   (t : Type0) (self : hashmap_HashMap_t t) (key : usize) :
   result (t & (t -> result (hashmap_HashMap_t t)))
@@ -341,7 +341,7 @@ let hashmap_HashMap_get_mut
   Ok (x, back)
 
 (** [hashmap_main::hashmap::{hashmap_main::hashmap::HashMap<T>}::remove_from_list]: loop 0:
-    Source: 'tests/src/hashmap.rs', lines 265:4-291:5 *)
+    Source: 'tests/src/hashmap.rs', lines 273:4-299:5 *)
 let rec hashmap_HashMap_remove_from_list_loop
   (t : Type0) (key : usize) (ls : hashmap_List_t t) :
   Tot (result ((option t) & (hashmap_List_t t)))
@@ -365,7 +365,7 @@ let rec hashmap_HashMap_remove_from_list_loop
   end
 
 (** [hashmap_main::hashmap::{hashmap_main::hashmap::HashMap<T>}::remove_from_list]:
-    Source: 'tests/src/hashmap.rs', lines 265:4-265:69 *)
+    Source: 'tests/src/hashmap.rs', lines 273:4-273:69 *)
 let hashmap_HashMap_remove_from_list
   (t : Type0) (key : usize) (ls : hashmap_List_t t) :
   result ((option t) & (hashmap_List_t t))
@@ -373,7 +373,7 @@ let hashmap_HashMap_remove_from_list
   hashmap_HashMap_remove_from_list_loop t key ls
 
 (** [hashmap_main::hashmap::{hashmap_main::hashmap::HashMap<T>}::remove]:
-    Source: 'tests/src/hashmap.rs', lines 294:4-294:52 *)
+    Source: 'tests/src/hashmap.rs', lines 302:4-302:52 *)
 let hashmap_HashMap_remove
   (t : Type0) (self : hashmap_HashMap_t t) (key : usize) :
   result ((option t) & (hashmap_HashMap_t t))
@@ -395,7 +395,7 @@ let hashmap_HashMap_remove
   end
 
 (** [hashmap_main::hashmap::test1]:
-    Source: 'tests/src/hashmap.rs', lines 315:0-315:10 *)
+    Source: 'tests/src/hashmap.rs', lines 323:0-323:10 *)
 let hashmap_test1 : result unit =
   let* hm = hashmap_HashMap_new u64 in
   let* hm1 = hashmap_HashMap_insert u64 hm 0 42 in
@@ -432,7 +432,7 @@ let hashmap_test1 : result unit =
       end
 
 (** [hashmap_main::insert_on_disk]:
-    Source: 'tests/src/hashmap_main.rs', lines 7:0-7:43 *)
+    Source: 'tests/src/hashmap_main.rs', lines 13:0-13:43 *)
 let insert_on_disk
   (key : usize) (value : u64) (st : state) : result (state & unit) =
   let* (st1, hm) = hashmap_utils_deserialize st in
@@ -440,7 +440,7 @@ let insert_on_disk
   hashmap_utils_serialize hm1 st1
 
 (** [hashmap_main::main]:
-    Source: 'tests/src/hashmap_main.rs', lines 16:0-16:13 *)
+    Source: 'tests/src/hashmap_main.rs', lines 22:0-22:13 *)
 let main : result unit =
   Ok ()
 

--- a/tests/fstar/hashmap_on_disk/HashmapMain.FunsExternal.fsti
+++ b/tests/fstar/hashmap_on_disk/HashmapMain.FunsExternal.fsti
@@ -7,12 +7,12 @@ include HashmapMain.Types
 #set-options "--z3rlimit 50 --fuel 1 --ifuel 1"
 
 (** [hashmap_main::hashmap_utils::deserialize]:
-    Source: 'tests/src/hashmap_utils.rs', lines 10:0-10:43 *)
+    Source: 'tests/src/hashmap_utils.rs', lines 11:0-11:43 *)
 val hashmap_utils_deserialize
   : state -> result (state & (hashmap_HashMap_t u64))
 
 (** [hashmap_main::hashmap_utils::serialize]:
-    Source: 'tests/src/hashmap_utils.rs', lines 5:0-5:42 *)
+    Source: 'tests/src/hashmap_utils.rs', lines 6:0-6:42 *)
 val hashmap_utils_serialize
   : hashmap_HashMap_t u64 -> state -> result (state & unit)
 

--- a/tests/fstar/hashmap_on_disk/HashmapMain.Types.fst
+++ b/tests/fstar/hashmap_on_disk/HashmapMain.Types.fst
@@ -7,13 +7,13 @@ include HashmapMain.TypesExternal
 #set-options "--z3rlimit 50 --fuel 1 --ifuel 1"
 
 (** [hashmap_main::hashmap::List]
-    Source: 'tests/src/hashmap.rs', lines 19:0-19:16 *)
+    Source: 'tests/src/hashmap.rs', lines 27:0-27:16 *)
 type hashmap_List_t (t : Type0) =
 | Hashmap_List_Cons : usize -> t -> hashmap_List_t t -> hashmap_List_t t
 | Hashmap_List_Nil : hashmap_List_t t
 
 (** [hashmap_main::hashmap::HashMap]
-    Source: 'tests/src/hashmap.rs', lines 35:0-35:21 *)
+    Source: 'tests/src/hashmap.rs', lines 43:0-43:21 *)
 type hashmap_HashMap_t (t : Type0) =
 {
   num_entries : usize;

--- a/tests/fstar/misc/Bitwise.fst
+++ b/tests/fstar/misc/Bitwise.fst
@@ -6,27 +6,27 @@ open Primitives
 #set-options "--z3rlimit 50 --fuel 1 --ifuel 1"
 
 (** [bitwise::shift_u32]:
-    Source: 'tests/src/bitwise.rs', lines 3:0-3:31 *)
+    Source: 'tests/src/bitwise.rs', lines 4:0-4:31 *)
 let shift_u32 (a : u32) : result u32 =
   let* t = u32_shr #Usize a 16 in u32_shl #Usize t 16
 
 (** [bitwise::shift_i32]:
-    Source: 'tests/src/bitwise.rs', lines 10:0-10:31 *)
+    Source: 'tests/src/bitwise.rs', lines 11:0-11:31 *)
 let shift_i32 (a : i32) : result i32 =
   let* t = i32_shr #Isize a 16 in i32_shl #Isize t 16
 
 (** [bitwise::xor_u32]:
-    Source: 'tests/src/bitwise.rs', lines 17:0-17:37 *)
+    Source: 'tests/src/bitwise.rs', lines 18:0-18:37 *)
 let xor_u32 (a : u32) (b : u32) : result u32 =
   Ok (u32_xor a b)
 
 (** [bitwise::or_u32]:
-    Source: 'tests/src/bitwise.rs', lines 21:0-21:36 *)
+    Source: 'tests/src/bitwise.rs', lines 22:0-22:36 *)
 let or_u32 (a : u32) (b : u32) : result u32 =
   Ok (u32_or a b)
 
 (** [bitwise::and_u32]:
-    Source: 'tests/src/bitwise.rs', lines 25:0-25:37 *)
+    Source: 'tests/src/bitwise.rs', lines 26:0-26:37 *)
 let and_u32 (a : u32) (b : u32) : result u32 =
   Ok (u32_and a b)
 

--- a/tests/fstar/misc/Constants.fst
+++ b/tests/fstar/misc/Constants.fst
@@ -6,154 +6,154 @@ open Primitives
 #set-options "--z3rlimit 50 --fuel 1 --ifuel 1"
 
 (** [constants::X0]
-    Source: 'tests/src/constants.rs', lines 5:0-5:17 *)
+    Source: 'tests/src/constants.rs', lines 7:0-7:17 *)
 let x0_body : result u32 = Ok 0
 let x0 : u32 = eval_global x0_body
 
 (** [constants::X1]
-    Source: 'tests/src/constants.rs', lines 7:0-7:17 *)
+    Source: 'tests/src/constants.rs', lines 9:0-9:17 *)
 let x1_body : result u32 = Ok core_u32_max
 let x1 : u32 = eval_global x1_body
 
 (** [constants::X2]
-    Source: 'tests/src/constants.rs', lines 10:0-10:17 *)
+    Source: 'tests/src/constants.rs', lines 12:0-12:17 *)
 let x2_body : result u32 = Ok 3
 let x2 : u32 = eval_global x2_body
 
 (** [constants::incr]:
-    Source: 'tests/src/constants.rs', lines 17:0-17:32 *)
+    Source: 'tests/src/constants.rs', lines 19:0-19:32 *)
 let incr (n : u32) : result u32 =
   u32_add n 1
 
 (** [constants::X3]
-    Source: 'tests/src/constants.rs', lines 15:0-15:17 *)
+    Source: 'tests/src/constants.rs', lines 17:0-17:17 *)
 let x3_body : result u32 = incr 32
 let x3 : u32 = eval_global x3_body
 
 (** [constants::mk_pair0]:
-    Source: 'tests/src/constants.rs', lines 23:0-23:51 *)
+    Source: 'tests/src/constants.rs', lines 25:0-25:51 *)
 let mk_pair0 (x : u32) (y1 : u32) : result (u32 & u32) =
   Ok (x, y1)
 
 (** [constants::Pair]
-    Source: 'tests/src/constants.rs', lines 36:0-36:23 *)
+    Source: 'tests/src/constants.rs', lines 38:0-38:23 *)
 type pair_t (t1 t2 : Type0) = { x : t1; y : t2; }
 
 (** [constants::mk_pair1]:
-    Source: 'tests/src/constants.rs', lines 27:0-27:55 *)
+    Source: 'tests/src/constants.rs', lines 29:0-29:55 *)
 let mk_pair1 (x : u32) (y1 : u32) : result (pair_t u32 u32) =
   Ok { x = x; y = y1 }
 
 (** [constants::P0]
-    Source: 'tests/src/constants.rs', lines 31:0-31:24 *)
+    Source: 'tests/src/constants.rs', lines 33:0-33:24 *)
 let p0_body : result (u32 & u32) = mk_pair0 0 1
 let p0 : (u32 & u32) = eval_global p0_body
 
 (** [constants::P1]
-    Source: 'tests/src/constants.rs', lines 32:0-32:28 *)
+    Source: 'tests/src/constants.rs', lines 34:0-34:28 *)
 let p1_body : result (pair_t u32 u32) = mk_pair1 0 1
 let p1 : pair_t u32 u32 = eval_global p1_body
 
 (** [constants::P2]
-    Source: 'tests/src/constants.rs', lines 33:0-33:24 *)
+    Source: 'tests/src/constants.rs', lines 35:0-35:24 *)
 let p2_body : result (u32 & u32) = Ok (0, 1)
 let p2 : (u32 & u32) = eval_global p2_body
 
 (** [constants::P3]
-    Source: 'tests/src/constants.rs', lines 34:0-34:28 *)
+    Source: 'tests/src/constants.rs', lines 36:0-36:28 *)
 let p3_body : result (pair_t u32 u32) = Ok { x = 0; y = 1 }
 let p3 : pair_t u32 u32 = eval_global p3_body
 
 (** [constants::Wrap]
-    Source: 'tests/src/constants.rs', lines 49:0-49:18 *)
+    Source: 'tests/src/constants.rs', lines 51:0-51:18 *)
 type wrap_t (t : Type0) = { value : t; }
 
 (** [constants::{constants::Wrap<T>}::new]:
-    Source: 'tests/src/constants.rs', lines 54:4-54:41 *)
+    Source: 'tests/src/constants.rs', lines 56:4-56:41 *)
 let wrap_new (t : Type0) (value : t) : result (wrap_t t) =
   Ok { value = value }
 
 (** [constants::Y]
-    Source: 'tests/src/constants.rs', lines 41:0-41:22 *)
+    Source: 'tests/src/constants.rs', lines 43:0-43:22 *)
 let y_body : result (wrap_t i32) = wrap_new i32 2
 let y : wrap_t i32 = eval_global y_body
 
 (** [constants::unwrap_y]:
-    Source: 'tests/src/constants.rs', lines 43:0-43:30 *)
+    Source: 'tests/src/constants.rs', lines 45:0-45:30 *)
 let unwrap_y : result i32 =
   Ok y.value
 
 (** [constants::YVAL]
-    Source: 'tests/src/constants.rs', lines 47:0-47:19 *)
+    Source: 'tests/src/constants.rs', lines 49:0-49:19 *)
 let yval_body : result i32 = unwrap_y
 let yval : i32 = eval_global yval_body
 
 (** [constants::get_z1::Z1]
-    Source: 'tests/src/constants.rs', lines 62:4-62:17 *)
+    Source: 'tests/src/constants.rs', lines 64:4-64:17 *)
 let get_z1_z1_body : result i32 = Ok 3
 let get_z1_z1 : i32 = eval_global get_z1_z1_body
 
 (** [constants::get_z1]:
-    Source: 'tests/src/constants.rs', lines 61:0-61:28 *)
+    Source: 'tests/src/constants.rs', lines 63:0-63:28 *)
 let get_z1 : result i32 =
   Ok get_z1_z1
 
 (** [constants::add]:
-    Source: 'tests/src/constants.rs', lines 66:0-66:39 *)
+    Source: 'tests/src/constants.rs', lines 68:0-68:39 *)
 let add (a : i32) (b : i32) : result i32 =
   i32_add a b
 
 (** [constants::Q1]
-    Source: 'tests/src/constants.rs', lines 74:0-74:17 *)
+    Source: 'tests/src/constants.rs', lines 76:0-76:17 *)
 let q1_body : result i32 = Ok 5
 let q1 : i32 = eval_global q1_body
 
 (** [constants::Q2]
-    Source: 'tests/src/constants.rs', lines 75:0-75:17 *)
+    Source: 'tests/src/constants.rs', lines 77:0-77:17 *)
 let q2_body : result i32 = Ok q1
 let q2 : i32 = eval_global q2_body
 
 (** [constants::Q3]
-    Source: 'tests/src/constants.rs', lines 76:0-76:17 *)
+    Source: 'tests/src/constants.rs', lines 78:0-78:17 *)
 let q3_body : result i32 = add q2 3
 let q3 : i32 = eval_global q3_body
 
 (** [constants::get_z2]:
-    Source: 'tests/src/constants.rs', lines 70:0-70:28 *)
+    Source: 'tests/src/constants.rs', lines 72:0-72:28 *)
 let get_z2 : result i32 =
   let* i = get_z1 in let* i1 = add i q3 in add q1 i1
 
 (** [constants::S1]
-    Source: 'tests/src/constants.rs', lines 80:0-80:18 *)
+    Source: 'tests/src/constants.rs', lines 82:0-82:18 *)
 let s1_body : result u32 = Ok 6
 let s1 : u32 = eval_global s1_body
 
 (** [constants::S2]
-    Source: 'tests/src/constants.rs', lines 81:0-81:18 *)
+    Source: 'tests/src/constants.rs', lines 83:0-83:18 *)
 let s2_body : result u32 = incr s1
 let s2 : u32 = eval_global s2_body
 
 (** [constants::S3]
-    Source: 'tests/src/constants.rs', lines 82:0-82:29 *)
+    Source: 'tests/src/constants.rs', lines 84:0-84:29 *)
 let s3_body : result (pair_t u32 u32) = Ok p3
 let s3 : pair_t u32 u32 = eval_global s3_body
 
 (** [constants::S4]
-    Source: 'tests/src/constants.rs', lines 83:0-83:29 *)
+    Source: 'tests/src/constants.rs', lines 85:0-85:29 *)
 let s4_body : result (pair_t u32 u32) = mk_pair1 7 8
 let s4 : pair_t u32 u32 = eval_global s4_body
 
 (** [constants::V]
-    Source: 'tests/src/constants.rs', lines 86:0-86:31 *)
+    Source: 'tests/src/constants.rs', lines 88:0-88:31 *)
 type v_t (t : Type0) (n : usize) = { x : array t n; }
 
 (** [constants::{constants::V<T, N>#1}::LEN]
-    Source: 'tests/src/constants.rs', lines 91:4-91:24 *)
+    Source: 'tests/src/constants.rs', lines 93:4-93:24 *)
 let v_len_body (t : Type0) (n : usize) : result usize = Ok n
 let v_len (t : Type0) (n : usize) : usize = eval_global (v_len_body t n)
 
 (** [constants::use_v]:
-    Source: 'tests/src/constants.rs', lines 94:0-94:42 *)
+    Source: 'tests/src/constants.rs', lines 96:0-96:42 *)
 let use_v (t : Type0) (n : usize) : result usize =
   Ok (v_len t n)
 

--- a/tests/fstar/misc/External.Funs.fst
+++ b/tests/fstar/misc/External.Funs.fst
@@ -15,12 +15,12 @@ let core_marker_CopyU32 : core_marker_Copy_t u32 = {
 }
 
 (** [external::use_get]:
-    Source: 'tests/src/external.rs', lines 5:0-5:37 *)
+    Source: 'tests/src/external.rs', lines 8:0-8:37 *)
 let use_get (rc : core_cell_Cell_t u32) (st : state) : result (state & u32) =
   core_cell_Cell_get u32 core_marker_CopyU32 rc st
 
 (** [external::incr]:
-    Source: 'tests/src/external.rs', lines 9:0-9:31 *)
+    Source: 'tests/src/external.rs', lines 12:0-12:31 *)
 let incr
   (rc : core_cell_Cell_t u32) (st : state) :
   result (state & (core_cell_Cell_t u32))

--- a/tests/fstar/misc/Loops.Clauses.Template.fst
+++ b/tests/fstar/misc/Loops.Clauses.Template.fst
@@ -7,144 +7,144 @@ open Loops.Types
 #set-options "--z3rlimit 50 --fuel 1 --ifuel 1"
 
 (** [loops::sum]: decreases clause
-    Source: 'tests/src/loops.rs', lines 4:0-14:1 *)
+    Source: 'tests/src/loops.rs', lines 7:0-17:1 *)
 unfold let sum_loop_decreases (max : u32) (i : u32) (s : u32) : nat = admit ()
 
 (** [loops::sum_with_mut_borrows]: decreases clause
-    Source: 'tests/src/loops.rs', lines 19:0-31:1 *)
+    Source: 'tests/src/loops.rs', lines 22:0-34:1 *)
 unfold
 let sum_with_mut_borrows_loop_decreases (max : u32) (i : u32) (s : u32) : nat =
   admit ()
 
 (** [loops::sum_with_shared_borrows]: decreases clause
-    Source: 'tests/src/loops.rs', lines 34:0-48:1 *)
+    Source: 'tests/src/loops.rs', lines 37:0-51:1 *)
 unfold
 let sum_with_shared_borrows_loop_decreases (max : u32) (i : u32) (s : u32) :
   nat =
   admit ()
 
 (** [loops::sum_array]: decreases clause
-    Source: 'tests/src/loops.rs', lines 50:0-58:1 *)
+    Source: 'tests/src/loops.rs', lines 53:0-61:1 *)
 unfold
 let sum_array_loop_decreases (n : usize) (a : array u32 n) (i : usize)
   (s : u32) : nat =
   admit ()
 
 (** [loops::clear]: decreases clause
-    Source: 'tests/src/loops.rs', lines 62:0-68:1 *)
+    Source: 'tests/src/loops.rs', lines 65:0-71:1 *)
 unfold
 let clear_loop_decreases (v : alloc_vec_Vec u32) (i : usize) : nat = admit ()
 
 (** [loops::list_mem]: decreases clause
-    Source: 'tests/src/loops.rs', lines 76:0-85:1 *)
+    Source: 'tests/src/loops.rs', lines 79:0-88:1 *)
 unfold let list_mem_loop_decreases (x : u32) (ls : list_t u32) : nat = admit ()
 
 (** [loops::list_nth_mut_loop]: decreases clause
-    Source: 'tests/src/loops.rs', lines 88:0-98:1 *)
+    Source: 'tests/src/loops.rs', lines 91:0-101:1 *)
 unfold
 let list_nth_mut_loop_loop_decreases (t : Type0) (ls : list_t t) (i : u32) :
   nat =
   admit ()
 
 (** [loops::list_nth_shared_loop]: decreases clause
-    Source: 'tests/src/loops.rs', lines 101:0-111:1 *)
+    Source: 'tests/src/loops.rs', lines 104:0-114:1 *)
 unfold
 let list_nth_shared_loop_loop_decreases (t : Type0) (ls : list_t t) (i : u32) :
   nat =
   admit ()
 
 (** [loops::get_elem_mut]: decreases clause
-    Source: 'tests/src/loops.rs', lines 113:0-127:1 *)
+    Source: 'tests/src/loops.rs', lines 116:0-130:1 *)
 unfold
 let get_elem_mut_loop_decreases (x : usize) (ls : list_t usize) : nat =
   admit ()
 
 (** [loops::get_elem_shared]: decreases clause
-    Source: 'tests/src/loops.rs', lines 129:0-143:1 *)
+    Source: 'tests/src/loops.rs', lines 132:0-146:1 *)
 unfold
 let get_elem_shared_loop_decreases (x : usize) (ls : list_t usize) : nat =
   admit ()
 
 (** [loops::list_nth_mut_loop_with_id]: decreases clause
-    Source: 'tests/src/loops.rs', lines 154:0-165:1 *)
+    Source: 'tests/src/loops.rs', lines 157:0-168:1 *)
 unfold
 let list_nth_mut_loop_with_id_loop_decreases (t : Type0) (i : u32)
   (ls : list_t t) : nat =
   admit ()
 
 (** [loops::list_nth_shared_loop_with_id]: decreases clause
-    Source: 'tests/src/loops.rs', lines 168:0-179:1 *)
+    Source: 'tests/src/loops.rs', lines 171:0-182:1 *)
 unfold
 let list_nth_shared_loop_with_id_loop_decreases (t : Type0) (i : u32)
   (ls : list_t t) : nat =
   admit ()
 
 (** [loops::list_nth_mut_loop_pair]: decreases clause
-    Source: 'tests/src/loops.rs', lines 184:0-205:1 *)
+    Source: 'tests/src/loops.rs', lines 187:0-208:1 *)
 unfold
 let list_nth_mut_loop_pair_loop_decreases (t : Type0) (ls0 : list_t t)
   (ls1 : list_t t) (i : u32) : nat =
   admit ()
 
 (** [loops::list_nth_shared_loop_pair]: decreases clause
-    Source: 'tests/src/loops.rs', lines 208:0-229:1 *)
+    Source: 'tests/src/loops.rs', lines 211:0-232:1 *)
 unfold
 let list_nth_shared_loop_pair_loop_decreases (t : Type0) (ls0 : list_t t)
   (ls1 : list_t t) (i : u32) : nat =
   admit ()
 
 (** [loops::list_nth_mut_loop_pair_merge]: decreases clause
-    Source: 'tests/src/loops.rs', lines 233:0-248:1 *)
+    Source: 'tests/src/loops.rs', lines 236:0-251:1 *)
 unfold
 let list_nth_mut_loop_pair_merge_loop_decreases (t : Type0) (ls0 : list_t t)
   (ls1 : list_t t) (i : u32) : nat =
   admit ()
 
 (** [loops::list_nth_shared_loop_pair_merge]: decreases clause
-    Source: 'tests/src/loops.rs', lines 251:0-266:1 *)
+    Source: 'tests/src/loops.rs', lines 254:0-269:1 *)
 unfold
 let list_nth_shared_loop_pair_merge_loop_decreases (t : Type0) (ls0 : list_t t)
   (ls1 : list_t t) (i : u32) : nat =
   admit ()
 
 (** [loops::list_nth_mut_shared_loop_pair]: decreases clause
-    Source: 'tests/src/loops.rs', lines 269:0-284:1 *)
+    Source: 'tests/src/loops.rs', lines 272:0-287:1 *)
 unfold
 let list_nth_mut_shared_loop_pair_loop_decreases (t : Type0) (ls0 : list_t t)
   (ls1 : list_t t) (i : u32) : nat =
   admit ()
 
 (** [loops::list_nth_mut_shared_loop_pair_merge]: decreases clause
-    Source: 'tests/src/loops.rs', lines 288:0-303:1 *)
+    Source: 'tests/src/loops.rs', lines 291:0-306:1 *)
 unfold
 let list_nth_mut_shared_loop_pair_merge_loop_decreases (t : Type0)
   (ls0 : list_t t) (ls1 : list_t t) (i : u32) : nat =
   admit ()
 
 (** [loops::list_nth_shared_mut_loop_pair]: decreases clause
-    Source: 'tests/src/loops.rs', lines 307:0-322:1 *)
+    Source: 'tests/src/loops.rs', lines 310:0-325:1 *)
 unfold
 let list_nth_shared_mut_loop_pair_loop_decreases (t : Type0) (ls0 : list_t t)
   (ls1 : list_t t) (i : u32) : nat =
   admit ()
 
 (** [loops::list_nth_shared_mut_loop_pair_merge]: decreases clause
-    Source: 'tests/src/loops.rs', lines 326:0-341:1 *)
+    Source: 'tests/src/loops.rs', lines 329:0-344:1 *)
 unfold
 let list_nth_shared_mut_loop_pair_merge_loop_decreases (t : Type0)
   (ls0 : list_t t) (ls1 : list_t t) (i : u32) : nat =
   admit ()
 
 (** [loops::ignore_input_mut_borrow]: decreases clause
-    Source: 'tests/src/loops.rs', lines 345:0-349:1 *)
+    Source: 'tests/src/loops.rs', lines 348:0-352:1 *)
 unfold let ignore_input_mut_borrow_loop_decreases (i : u32) : nat = admit ()
 
 (** [loops::incr_ignore_input_mut_borrow]: decreases clause
-    Source: 'tests/src/loops.rs', lines 353:0-358:1 *)
+    Source: 'tests/src/loops.rs', lines 356:0-361:1 *)
 unfold
 let incr_ignore_input_mut_borrow_loop_decreases (i : u32) : nat = admit ()
 
 (** [loops::ignore_input_shared_borrow]: decreases clause
-    Source: 'tests/src/loops.rs', lines 362:0-366:1 *)
+    Source: 'tests/src/loops.rs', lines 365:0-369:1 *)
 unfold let ignore_input_shared_borrow_loop_decreases (i : u32) : nat = admit ()
 

--- a/tests/fstar/misc/Loops.Funs.fst
+++ b/tests/fstar/misc/Loops.Funs.fst
@@ -8,7 +8,7 @@ include Loops.Clauses
 #set-options "--z3rlimit 50 --fuel 1 --ifuel 1"
 
 (** [loops::sum]: loop 0:
-    Source: 'tests/src/loops.rs', lines 4:0-14:1 *)
+    Source: 'tests/src/loops.rs', lines 7:0-17:1 *)
 let rec sum_loop
   (max : u32) (i : u32) (s : u32) :
   Tot (result u32) (decreases (sum_loop_decreases max i s))
@@ -18,12 +18,12 @@ let rec sum_loop
   else u32_mul s 2
 
 (** [loops::sum]:
-    Source: 'tests/src/loops.rs', lines 4:0-4:27 *)
+    Source: 'tests/src/loops.rs', lines 7:0-7:27 *)
 let sum (max : u32) : result u32 =
   sum_loop max 0 0
 
 (** [loops::sum_with_mut_borrows]: loop 0:
-    Source: 'tests/src/loops.rs', lines 19:0-31:1 *)
+    Source: 'tests/src/loops.rs', lines 22:0-34:1 *)
 let rec sum_with_mut_borrows_loop
   (max : u32) (i : u32) (s : u32) :
   Tot (result u32) (decreases (sum_with_mut_borrows_loop_decreases max i s))
@@ -36,12 +36,12 @@ let rec sum_with_mut_borrows_loop
   else u32_mul s 2
 
 (** [loops::sum_with_mut_borrows]:
-    Source: 'tests/src/loops.rs', lines 19:0-19:44 *)
+    Source: 'tests/src/loops.rs', lines 22:0-22:44 *)
 let sum_with_mut_borrows (max : u32) : result u32 =
   sum_with_mut_borrows_loop max 0 0
 
 (** [loops::sum_with_shared_borrows]: loop 0:
-    Source: 'tests/src/loops.rs', lines 34:0-48:1 *)
+    Source: 'tests/src/loops.rs', lines 37:0-51:1 *)
 let rec sum_with_shared_borrows_loop
   (max : u32) (i : u32) (s : u32) :
   Tot (result u32) (decreases (sum_with_shared_borrows_loop_decreases max i s))
@@ -54,12 +54,12 @@ let rec sum_with_shared_borrows_loop
   else u32_mul s 2
 
 (** [loops::sum_with_shared_borrows]:
-    Source: 'tests/src/loops.rs', lines 34:0-34:47 *)
+    Source: 'tests/src/loops.rs', lines 37:0-37:47 *)
 let sum_with_shared_borrows (max : u32) : result u32 =
   sum_with_shared_borrows_loop max 0 0
 
 (** [loops::sum_array]: loop 0:
-    Source: 'tests/src/loops.rs', lines 50:0-58:1 *)
+    Source: 'tests/src/loops.rs', lines 53:0-61:1 *)
 let rec sum_array_loop
   (n : usize) (a : array u32 n) (i : usize) (s : u32) :
   Tot (result u32) (decreases (sum_array_loop_decreases n a i s))
@@ -73,12 +73,12 @@ let rec sum_array_loop
   else Ok s
 
 (** [loops::sum_array]:
-    Source: 'tests/src/loops.rs', lines 50:0-50:52 *)
+    Source: 'tests/src/loops.rs', lines 53:0-53:52 *)
 let sum_array (n : usize) (a : array u32 n) : result u32 =
   sum_array_loop n a 0 0
 
 (** [loops::clear]: loop 0:
-    Source: 'tests/src/loops.rs', lines 62:0-68:1 *)
+    Source: 'tests/src/loops.rs', lines 65:0-71:1 *)
 let rec clear_loop
   (v : alloc_vec_Vec u32) (i : usize) :
   Tot (result (alloc_vec_Vec u32)) (decreases (clear_loop_decreases v i))
@@ -95,12 +95,12 @@ let rec clear_loop
   else Ok v
 
 (** [loops::clear]:
-    Source: 'tests/src/loops.rs', lines 62:0-62:30 *)
+    Source: 'tests/src/loops.rs', lines 65:0-65:30 *)
 let clear (v : alloc_vec_Vec u32) : result (alloc_vec_Vec u32) =
   clear_loop v 0
 
 (** [loops::list_mem]: loop 0:
-    Source: 'tests/src/loops.rs', lines 76:0-85:1 *)
+    Source: 'tests/src/loops.rs', lines 79:0-88:1 *)
 let rec list_mem_loop
   (x : u32) (ls : list_t u32) :
   Tot (result bool) (decreases (list_mem_loop_decreases x ls))
@@ -111,12 +111,12 @@ let rec list_mem_loop
   end
 
 (** [loops::list_mem]:
-    Source: 'tests/src/loops.rs', lines 76:0-76:52 *)
+    Source: 'tests/src/loops.rs', lines 79:0-79:52 *)
 let list_mem (x : u32) (ls : list_t u32) : result bool =
   list_mem_loop x ls
 
 (** [loops::list_nth_mut_loop]: loop 0:
-    Source: 'tests/src/loops.rs', lines 88:0-98:1 *)
+    Source: 'tests/src/loops.rs', lines 91:0-101:1 *)
 let rec list_nth_mut_loop_loop
   (t : Type0) (ls : list_t t) (i : u32) :
   Tot (result (t & (t -> result (list_t t))))
@@ -135,7 +135,7 @@ let rec list_nth_mut_loop_loop
   end
 
 (** [loops::list_nth_mut_loop]:
-    Source: 'tests/src/loops.rs', lines 88:0-88:71 *)
+    Source: 'tests/src/loops.rs', lines 91:0-91:71 *)
 let list_nth_mut_loop
   (t : Type0) (ls : list_t t) (i : u32) :
   result (t & (t -> result (list_t t)))
@@ -143,7 +143,7 @@ let list_nth_mut_loop
   list_nth_mut_loop_loop t ls i
 
 (** [loops::list_nth_shared_loop]: loop 0:
-    Source: 'tests/src/loops.rs', lines 101:0-111:1 *)
+    Source: 'tests/src/loops.rs', lines 104:0-114:1 *)
 let rec list_nth_shared_loop_loop
   (t : Type0) (ls : list_t t) (i : u32) :
   Tot (result t) (decreases (list_nth_shared_loop_loop_decreases t ls i))
@@ -157,12 +157,12 @@ let rec list_nth_shared_loop_loop
   end
 
 (** [loops::list_nth_shared_loop]:
-    Source: 'tests/src/loops.rs', lines 101:0-101:66 *)
+    Source: 'tests/src/loops.rs', lines 104:0-104:66 *)
 let list_nth_shared_loop (t : Type0) (ls : list_t t) (i : u32) : result t =
   list_nth_shared_loop_loop t ls i
 
 (** [loops::get_elem_mut]: loop 0:
-    Source: 'tests/src/loops.rs', lines 113:0-127:1 *)
+    Source: 'tests/src/loops.rs', lines 116:0-130:1 *)
 let rec get_elem_mut_loop
   (x : usize) (ls : list_t usize) :
   Tot (result (usize & (usize -> result (list_t usize))))
@@ -180,7 +180,7 @@ let rec get_elem_mut_loop
   end
 
 (** [loops::get_elem_mut]:
-    Source: 'tests/src/loops.rs', lines 113:0-113:73 *)
+    Source: 'tests/src/loops.rs', lines 116:0-116:73 *)
 let get_elem_mut
   (slots : alloc_vec_Vec (list_t usize)) (x : usize) :
   result (usize & (usize -> result (alloc_vec_Vec (list_t usize))))
@@ -193,7 +193,7 @@ let get_elem_mut
   Ok (i, back1)
 
 (** [loops::get_elem_shared]: loop 0:
-    Source: 'tests/src/loops.rs', lines 129:0-143:1 *)
+    Source: 'tests/src/loops.rs', lines 132:0-146:1 *)
 let rec get_elem_shared_loop
   (x : usize) (ls : list_t usize) :
   Tot (result usize) (decreases (get_elem_shared_loop_decreases x ls))
@@ -204,7 +204,7 @@ let rec get_elem_shared_loop
   end
 
 (** [loops::get_elem_shared]:
-    Source: 'tests/src/loops.rs', lines 129:0-129:68 *)
+    Source: 'tests/src/loops.rs', lines 132:0-132:68 *)
 let get_elem_shared
   (slots : alloc_vec_Vec (list_t usize)) (x : usize) : result usize =
   let* ls =
@@ -213,7 +213,7 @@ let get_elem_shared
   get_elem_shared_loop x ls
 
 (** [loops::id_mut]:
-    Source: 'tests/src/loops.rs', lines 145:0-145:50 *)
+    Source: 'tests/src/loops.rs', lines 148:0-148:50 *)
 let id_mut
   (t : Type0) (ls : list_t t) :
   result ((list_t t) & (list_t t -> result (list_t t)))
@@ -221,12 +221,12 @@ let id_mut
   Ok (ls, Ok)
 
 (** [loops::id_shared]:
-    Source: 'tests/src/loops.rs', lines 149:0-149:45 *)
+    Source: 'tests/src/loops.rs', lines 152:0-152:45 *)
 let id_shared (t : Type0) (ls : list_t t) : result (list_t t) =
   Ok ls
 
 (** [loops::list_nth_mut_loop_with_id]: loop 0:
-    Source: 'tests/src/loops.rs', lines 154:0-165:1 *)
+    Source: 'tests/src/loops.rs', lines 157:0-168:1 *)
 let rec list_nth_mut_loop_with_id_loop
   (t : Type0) (i : u32) (ls : list_t t) :
   Tot (result (t & (t -> result (list_t t))))
@@ -245,7 +245,7 @@ let rec list_nth_mut_loop_with_id_loop
   end
 
 (** [loops::list_nth_mut_loop_with_id]:
-    Source: 'tests/src/loops.rs', lines 154:0-154:75 *)
+    Source: 'tests/src/loops.rs', lines 157:0-157:75 *)
 let list_nth_mut_loop_with_id
   (t : Type0) (ls : list_t t) (i : u32) :
   result (t & (t -> result (list_t t)))
@@ -256,7 +256,7 @@ let list_nth_mut_loop_with_id
   Ok (x, back1)
 
 (** [loops::list_nth_shared_loop_with_id]: loop 0:
-    Source: 'tests/src/loops.rs', lines 168:0-179:1 *)
+    Source: 'tests/src/loops.rs', lines 171:0-182:1 *)
 let rec list_nth_shared_loop_with_id_loop
   (t : Type0) (i : u32) (ls : list_t t) :
   Tot (result t)
@@ -271,13 +271,13 @@ let rec list_nth_shared_loop_with_id_loop
   end
 
 (** [loops::list_nth_shared_loop_with_id]:
-    Source: 'tests/src/loops.rs', lines 168:0-168:70 *)
+    Source: 'tests/src/loops.rs', lines 171:0-171:70 *)
 let list_nth_shared_loop_with_id
   (t : Type0) (ls : list_t t) (i : u32) : result t =
   let* ls1 = id_shared t ls in list_nth_shared_loop_with_id_loop t i ls1
 
 (** [loops::list_nth_mut_loop_pair]: loop 0:
-    Source: 'tests/src/loops.rs', lines 184:0-205:1 *)
+    Source: 'tests/src/loops.rs', lines 187:0-208:1 *)
 let rec list_nth_mut_loop_pair_loop
   (t : Type0) (ls0 : list_t t) (ls1 : list_t t) (i : u32) :
   Tot (result ((t & t) & (t -> result (list_t t)) & (t -> result (list_t t))))
@@ -306,7 +306,7 @@ let rec list_nth_mut_loop_pair_loop
   end
 
 (** [loops::list_nth_mut_loop_pair]:
-    Source: 'tests/src/loops.rs', lines 184:0-188:27 *)
+    Source: 'tests/src/loops.rs', lines 187:0-191:27 *)
 let list_nth_mut_loop_pair
   (t : Type0) (ls0 : list_t t) (ls1 : list_t t) (i : u32) :
   result ((t & t) & (t -> result (list_t t)) & (t -> result (list_t t)))
@@ -314,7 +314,7 @@ let list_nth_mut_loop_pair
   list_nth_mut_loop_pair_loop t ls0 ls1 i
 
 (** [loops::list_nth_shared_loop_pair]: loop 0:
-    Source: 'tests/src/loops.rs', lines 208:0-229:1 *)
+    Source: 'tests/src/loops.rs', lines 211:0-232:1 *)
 let rec list_nth_shared_loop_pair_loop
   (t : Type0) (ls0 : list_t t) (ls1 : list_t t) (i : u32) :
   Tot (result (t & t))
@@ -333,13 +333,13 @@ let rec list_nth_shared_loop_pair_loop
   end
 
 (** [loops::list_nth_shared_loop_pair]:
-    Source: 'tests/src/loops.rs', lines 208:0-212:19 *)
+    Source: 'tests/src/loops.rs', lines 211:0-215:19 *)
 let list_nth_shared_loop_pair
   (t : Type0) (ls0 : list_t t) (ls1 : list_t t) (i : u32) : result (t & t) =
   list_nth_shared_loop_pair_loop t ls0 ls1 i
 
 (** [loops::list_nth_mut_loop_pair_merge]: loop 0:
-    Source: 'tests/src/loops.rs', lines 233:0-248:1 *)
+    Source: 'tests/src/loops.rs', lines 236:0-251:1 *)
 let rec list_nth_mut_loop_pair_merge_loop
   (t : Type0) (ls0 : list_t t) (ls1 : list_t t) (i : u32) :
   Tot (result ((t & t) & ((t & t) -> result ((list_t t) & (list_t t)))))
@@ -369,7 +369,7 @@ let rec list_nth_mut_loop_pair_merge_loop
   end
 
 (** [loops::list_nth_mut_loop_pair_merge]:
-    Source: 'tests/src/loops.rs', lines 233:0-237:27 *)
+    Source: 'tests/src/loops.rs', lines 236:0-240:27 *)
 let list_nth_mut_loop_pair_merge
   (t : Type0) (ls0 : list_t t) (ls1 : list_t t) (i : u32) :
   result ((t & t) & ((t & t) -> result ((list_t t) & (list_t t))))
@@ -377,7 +377,7 @@ let list_nth_mut_loop_pair_merge
   list_nth_mut_loop_pair_merge_loop t ls0 ls1 i
 
 (** [loops::list_nth_shared_loop_pair_merge]: loop 0:
-    Source: 'tests/src/loops.rs', lines 251:0-266:1 *)
+    Source: 'tests/src/loops.rs', lines 254:0-269:1 *)
 let rec list_nth_shared_loop_pair_merge_loop
   (t : Type0) (ls0 : list_t t) (ls1 : list_t t) (i : u32) :
   Tot (result (t & t))
@@ -398,13 +398,13 @@ let rec list_nth_shared_loop_pair_merge_loop
   end
 
 (** [loops::list_nth_shared_loop_pair_merge]:
-    Source: 'tests/src/loops.rs', lines 251:0-255:19 *)
+    Source: 'tests/src/loops.rs', lines 254:0-258:19 *)
 let list_nth_shared_loop_pair_merge
   (t : Type0) (ls0 : list_t t) (ls1 : list_t t) (i : u32) : result (t & t) =
   list_nth_shared_loop_pair_merge_loop t ls0 ls1 i
 
 (** [loops::list_nth_mut_shared_loop_pair]: loop 0:
-    Source: 'tests/src/loops.rs', lines 269:0-284:1 *)
+    Source: 'tests/src/loops.rs', lines 272:0-287:1 *)
 let rec list_nth_mut_shared_loop_pair_loop
   (t : Type0) (ls0 : list_t t) (ls1 : list_t t) (i : u32) :
   Tot (result ((t & t) & (t -> result (list_t t))))
@@ -428,7 +428,7 @@ let rec list_nth_mut_shared_loop_pair_loop
   end
 
 (** [loops::list_nth_mut_shared_loop_pair]:
-    Source: 'tests/src/loops.rs', lines 269:0-273:23 *)
+    Source: 'tests/src/loops.rs', lines 272:0-276:23 *)
 let list_nth_mut_shared_loop_pair
   (t : Type0) (ls0 : list_t t) (ls1 : list_t t) (i : u32) :
   result ((t & t) & (t -> result (list_t t)))
@@ -436,7 +436,7 @@ let list_nth_mut_shared_loop_pair
   list_nth_mut_shared_loop_pair_loop t ls0 ls1 i
 
 (** [loops::list_nth_mut_shared_loop_pair_merge]: loop 0:
-    Source: 'tests/src/loops.rs', lines 288:0-303:1 *)
+    Source: 'tests/src/loops.rs', lines 291:0-306:1 *)
 let rec list_nth_mut_shared_loop_pair_merge_loop
   (t : Type0) (ls0 : list_t t) (ls1 : list_t t) (i : u32) :
   Tot (result ((t & t) & (t -> result (list_t t))))
@@ -461,7 +461,7 @@ let rec list_nth_mut_shared_loop_pair_merge_loop
   end
 
 (** [loops::list_nth_mut_shared_loop_pair_merge]:
-    Source: 'tests/src/loops.rs', lines 288:0-292:23 *)
+    Source: 'tests/src/loops.rs', lines 291:0-295:23 *)
 let list_nth_mut_shared_loop_pair_merge
   (t : Type0) (ls0 : list_t t) (ls1 : list_t t) (i : u32) :
   result ((t & t) & (t -> result (list_t t)))
@@ -469,7 +469,7 @@ let list_nth_mut_shared_loop_pair_merge
   list_nth_mut_shared_loop_pair_merge_loop t ls0 ls1 i
 
 (** [loops::list_nth_shared_mut_loop_pair]: loop 0:
-    Source: 'tests/src/loops.rs', lines 307:0-322:1 *)
+    Source: 'tests/src/loops.rs', lines 310:0-325:1 *)
 let rec list_nth_shared_mut_loop_pair_loop
   (t : Type0) (ls0 : list_t t) (ls1 : list_t t) (i : u32) :
   Tot (result ((t & t) & (t -> result (list_t t))))
@@ -493,7 +493,7 @@ let rec list_nth_shared_mut_loop_pair_loop
   end
 
 (** [loops::list_nth_shared_mut_loop_pair]:
-    Source: 'tests/src/loops.rs', lines 307:0-311:23 *)
+    Source: 'tests/src/loops.rs', lines 310:0-314:23 *)
 let list_nth_shared_mut_loop_pair
   (t : Type0) (ls0 : list_t t) (ls1 : list_t t) (i : u32) :
   result ((t & t) & (t -> result (list_t t)))
@@ -501,7 +501,7 @@ let list_nth_shared_mut_loop_pair
   list_nth_shared_mut_loop_pair_loop t ls0 ls1 i
 
 (** [loops::list_nth_shared_mut_loop_pair_merge]: loop 0:
-    Source: 'tests/src/loops.rs', lines 326:0-341:1 *)
+    Source: 'tests/src/loops.rs', lines 329:0-344:1 *)
 let rec list_nth_shared_mut_loop_pair_merge_loop
   (t : Type0) (ls0 : list_t t) (ls1 : list_t t) (i : u32) :
   Tot (result ((t & t) & (t -> result (list_t t))))
@@ -526,7 +526,7 @@ let rec list_nth_shared_mut_loop_pair_merge_loop
   end
 
 (** [loops::list_nth_shared_mut_loop_pair_merge]:
-    Source: 'tests/src/loops.rs', lines 326:0-330:23 *)
+    Source: 'tests/src/loops.rs', lines 329:0-333:23 *)
 let list_nth_shared_mut_loop_pair_merge
   (t : Type0) (ls0 : list_t t) (ls1 : list_t t) (i : u32) :
   result ((t & t) & (t -> result (list_t t)))
@@ -534,7 +534,7 @@ let list_nth_shared_mut_loop_pair_merge
   list_nth_shared_mut_loop_pair_merge_loop t ls0 ls1 i
 
 (** [loops::ignore_input_mut_borrow]: loop 0:
-    Source: 'tests/src/loops.rs', lines 345:0-349:1 *)
+    Source: 'tests/src/loops.rs', lines 348:0-352:1 *)
 let rec ignore_input_mut_borrow_loop
   (i : u32) :
   Tot (result unit) (decreases (ignore_input_mut_borrow_loop_decreases i))
@@ -544,12 +544,12 @@ let rec ignore_input_mut_borrow_loop
   else Ok ()
 
 (** [loops::ignore_input_mut_borrow]:
-    Source: 'tests/src/loops.rs', lines 345:0-345:56 *)
+    Source: 'tests/src/loops.rs', lines 348:0-348:56 *)
 let ignore_input_mut_borrow (_a : u32) (i : u32) : result u32 =
   let* _ = ignore_input_mut_borrow_loop i in Ok _a
 
 (** [loops::incr_ignore_input_mut_borrow]: loop 0:
-    Source: 'tests/src/loops.rs', lines 353:0-358:1 *)
+    Source: 'tests/src/loops.rs', lines 356:0-361:1 *)
 let rec incr_ignore_input_mut_borrow_loop
   (i : u32) :
   Tot (result unit) (decreases (incr_ignore_input_mut_borrow_loop_decreases i))
@@ -559,14 +559,14 @@ let rec incr_ignore_input_mut_borrow_loop
   else Ok ()
 
 (** [loops::incr_ignore_input_mut_borrow]:
-    Source: 'tests/src/loops.rs', lines 353:0-353:60 *)
+    Source: 'tests/src/loops.rs', lines 356:0-356:60 *)
 let incr_ignore_input_mut_borrow (a : u32) (i : u32) : result u32 =
   let* a1 = u32_add a 1 in
   let* _ = incr_ignore_input_mut_borrow_loop i in
   Ok a1
 
 (** [loops::ignore_input_shared_borrow]: loop 0:
-    Source: 'tests/src/loops.rs', lines 362:0-366:1 *)
+    Source: 'tests/src/loops.rs', lines 365:0-369:1 *)
 let rec ignore_input_shared_borrow_loop
   (i : u32) :
   Tot (result unit) (decreases (ignore_input_shared_borrow_loop_decreases i))
@@ -576,7 +576,7 @@ let rec ignore_input_shared_borrow_loop
   else Ok ()
 
 (** [loops::ignore_input_shared_borrow]:
-    Source: 'tests/src/loops.rs', lines 362:0-362:59 *)
+    Source: 'tests/src/loops.rs', lines 365:0-365:59 *)
 let ignore_input_shared_borrow (_a : u32) (i : u32) : result u32 =
   let* _ = ignore_input_shared_borrow_loop i in Ok _a
 

--- a/tests/fstar/misc/Loops.Types.fst
+++ b/tests/fstar/misc/Loops.Types.fst
@@ -6,7 +6,7 @@ open Primitives
 #set-options "--z3rlimit 50 --fuel 1 --ifuel 1"
 
 (** [loops::List]
-    Source: 'tests/src/loops.rs', lines 70:0-70:16 *)
+    Source: 'tests/src/loops.rs', lines 73:0-73:16 *)
 type list_t (t : Type0) =
 | List_Cons : t -> list_t t -> list_t t
 | List_Nil : list_t t

--- a/tests/fstar/misc/NoNestedBorrows.fst
+++ b/tests/fstar/misc/NoNestedBorrows.fst
@@ -6,54 +6,54 @@ open Primitives
 #set-options "--z3rlimit 50 --fuel 1 --ifuel 1"
 
 (** [no_nested_borrows::Pair]
-    Source: 'tests/src/no_nested_borrows.rs', lines 4:0-4:23 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 6:0-6:23 *)
 type pair_t (t1 t2 : Type0) = { x : t1; y : t2; }
 
 (** [no_nested_borrows::List]
-    Source: 'tests/src/no_nested_borrows.rs', lines 9:0-9:16 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 11:0-11:16 *)
 type list_t (t : Type0) =
 | List_Cons : t -> list_t t -> list_t t
 | List_Nil : list_t t
 
 (** [no_nested_borrows::One]
-    Source: 'tests/src/no_nested_borrows.rs', lines 20:0-20:16 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 22:0-22:16 *)
 type one_t (t1 : Type0) = | One_One : t1 -> one_t t1
 
 (** [no_nested_borrows::EmptyEnum]
-    Source: 'tests/src/no_nested_borrows.rs', lines 26:0-26:18 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 28:0-28:18 *)
 type emptyEnum_t = | EmptyEnum_Empty : emptyEnum_t
 
 (** [no_nested_borrows::Enum]
-    Source: 'tests/src/no_nested_borrows.rs', lines 32:0-32:13 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 34:0-34:13 *)
 type enum_t = | Enum_Variant1 : enum_t | Enum_Variant2 : enum_t
 
 (** [no_nested_borrows::EmptyStruct]
-    Source: 'tests/src/no_nested_borrows.rs', lines 39:0-39:22 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 41:0-41:22 *)
 type emptyStruct_t = unit
 
 (** [no_nested_borrows::Sum]
-    Source: 'tests/src/no_nested_borrows.rs', lines 41:0-41:20 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 43:0-43:20 *)
 type sum_t (t1 t2 : Type0) =
 | Sum_Left : t1 -> sum_t t1 t2
 | Sum_Right : t2 -> sum_t t1 t2
 
 (** [no_nested_borrows::cast_u32_to_i32]:
-    Source: 'tests/src/no_nested_borrows.rs', lines 46:0-46:37 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 48:0-48:37 *)
 let cast_u32_to_i32 (x : u32) : result i32 =
   scalar_cast U32 I32 x
 
 (** [no_nested_borrows::cast_bool_to_i32]:
-    Source: 'tests/src/no_nested_borrows.rs', lines 50:0-50:39 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 52:0-52:39 *)
 let cast_bool_to_i32 (x : bool) : result i32 =
   scalar_cast_bool I32 x
 
 (** [no_nested_borrows::cast_bool_to_bool]:
-    Source: 'tests/src/no_nested_borrows.rs', lines 55:0-55:41 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 57:0-57:41 *)
 let cast_bool_to_bool (x : bool) : result bool =
   Ok x
 
 (** [no_nested_borrows::test2]:
-    Source: 'tests/src/no_nested_borrows.rs', lines 60:0-60:14 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 62:0-62:14 *)
 let test2 : result unit =
   let* _ = u32_add 23 44 in Ok ()
 
@@ -61,12 +61,12 @@ let test2 : result unit =
 let _ = assert_norm (test2 = Ok ())
 
 (** [no_nested_borrows::get_max]:
-    Source: 'tests/src/no_nested_borrows.rs', lines 72:0-72:37 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 74:0-74:37 *)
 let get_max (x : u32) (y : u32) : result u32 =
   if x >= y then Ok x else Ok y
 
 (** [no_nested_borrows::test3]:
-    Source: 'tests/src/no_nested_borrows.rs', lines 80:0-80:14 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 82:0-82:14 *)
 let test3 : result unit =
   let* x = get_max 4 3 in
   let* y = get_max 10 11 in
@@ -77,7 +77,7 @@ let test3 : result unit =
 let _ = assert_norm (test3 = Ok ())
 
 (** [no_nested_borrows::test_neg1]:
-    Source: 'tests/src/no_nested_borrows.rs', lines 87:0-87:18 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 89:0-89:18 *)
 let test_neg1 : result unit =
   let* y = i32_neg 3 in if not (y = -3) then Fail Failure else Ok ()
 
@@ -85,7 +85,7 @@ let test_neg1 : result unit =
 let _ = assert_norm (test_neg1 = Ok ())
 
 (** [no_nested_borrows::refs_test1]:
-    Source: 'tests/src/no_nested_borrows.rs', lines 94:0-94:19 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 96:0-96:19 *)
 let refs_test1 : result unit =
   if not (1 = 1) then Fail Failure else Ok ()
 
@@ -93,7 +93,7 @@ let refs_test1 : result unit =
 let _ = assert_norm (refs_test1 = Ok ())
 
 (** [no_nested_borrows::refs_test2]:
-    Source: 'tests/src/no_nested_borrows.rs', lines 105:0-105:19 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 107:0-107:19 *)
 let refs_test2 : result unit =
   if not (2 = 2)
   then Fail Failure
@@ -109,7 +109,7 @@ let refs_test2 : result unit =
 let _ = assert_norm (refs_test2 = Ok ())
 
 (** [no_nested_borrows::test_list1]:
-    Source: 'tests/src/no_nested_borrows.rs', lines 121:0-121:19 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 123:0-123:19 *)
 let test_list1 : result unit =
   Ok ()
 
@@ -117,7 +117,7 @@ let test_list1 : result unit =
 let _ = assert_norm (test_list1 = Ok ())
 
 (** [no_nested_borrows::test_box1]:
-    Source: 'tests/src/no_nested_borrows.rs', lines 126:0-126:18 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 128:0-128:18 *)
 let test_box1 : result unit =
   let* (_, deref_mut_back) = alloc_boxed_Box_deref_mut i32 0 in
   let* b = deref_mut_back 1 in
@@ -128,22 +128,22 @@ let test_box1 : result unit =
 let _ = assert_norm (test_box1 = Ok ())
 
 (** [no_nested_borrows::copy_int]:
-    Source: 'tests/src/no_nested_borrows.rs', lines 136:0-136:30 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 138:0-138:30 *)
 let copy_int (x : i32) : result i32 =
   Ok x
 
 (** [no_nested_borrows::test_unreachable]:
-    Source: 'tests/src/no_nested_borrows.rs', lines 142:0-142:32 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 144:0-144:32 *)
 let test_unreachable (b : bool) : result unit =
   if b then Fail Failure else Ok ()
 
 (** [no_nested_borrows::test_panic]:
-    Source: 'tests/src/no_nested_borrows.rs', lines 150:0-150:26 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 152:0-152:26 *)
 let test_panic (b : bool) : result unit =
   if b then Fail Failure else Ok ()
 
 (** [no_nested_borrows::test_copy_int]:
-    Source: 'tests/src/no_nested_borrows.rs', lines 157:0-157:22 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 159:0-159:22 *)
 let test_copy_int : result unit =
   let* y = copy_int 0 in if not (0 = y) then Fail Failure else Ok ()
 
@@ -151,12 +151,12 @@ let test_copy_int : result unit =
 let _ = assert_norm (test_copy_int = Ok ())
 
 (** [no_nested_borrows::is_cons]:
-    Source: 'tests/src/no_nested_borrows.rs', lines 164:0-164:38 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 166:0-166:38 *)
 let is_cons (t : Type0) (l : list_t t) : result bool =
   begin match l with | List_Cons _ _ -> Ok true | List_Nil -> Ok false end
 
 (** [no_nested_borrows::test_is_cons]:
-    Source: 'tests/src/no_nested_borrows.rs', lines 171:0-171:21 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 173:0-173:21 *)
 let test_is_cons : result unit =
   let* b = is_cons i32 (List_Cons 0 List_Nil) in
   if not b then Fail Failure else Ok ()
@@ -165,7 +165,7 @@ let test_is_cons : result unit =
 let _ = assert_norm (test_is_cons = Ok ())
 
 (** [no_nested_borrows::split_list]:
-    Source: 'tests/src/no_nested_borrows.rs', lines 177:0-177:48 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 179:0-179:48 *)
 let split_list (t : Type0) (l : list_t t) : result (t & (list_t t)) =
   begin match l with
   | List_Cons hd tl -> Ok (hd, tl)
@@ -173,7 +173,7 @@ let split_list (t : Type0) (l : list_t t) : result (t & (list_t t)) =
   end
 
 (** [no_nested_borrows::test_split_list]:
-    Source: 'tests/src/no_nested_borrows.rs', lines 185:0-185:24 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 187:0-187:24 *)
 let test_split_list : result unit =
   let* p = split_list i32 (List_Cons 0 List_Nil) in
   let (hd, _) = p in
@@ -183,7 +183,7 @@ let test_split_list : result unit =
 let _ = assert_norm (test_split_list = Ok ())
 
 (** [no_nested_borrows::choose]:
-    Source: 'tests/src/no_nested_borrows.rs', lines 192:0-192:70 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 194:0-194:70 *)
 let choose
   (t : Type0) (b : bool) (x : t) (y : t) : result (t & (t -> result (t & t))) =
   if b
@@ -191,7 +191,7 @@ let choose
   else let back = fun ret -> Ok (x, ret) in Ok (y, back)
 
 (** [no_nested_borrows::choose_test]:
-    Source: 'tests/src/no_nested_borrows.rs', lines 200:0-200:20 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 202:0-202:20 *)
 let choose_test : result unit =
   let* (z, choose_back) = choose i32 true 0 0 in
   let* z1 = i32_add z 1 in
@@ -207,24 +207,24 @@ let choose_test : result unit =
 let _ = assert_norm (choose_test = Ok ())
 
 (** [no_nested_borrows::test_char]:
-    Source: 'tests/src/no_nested_borrows.rs', lines 212:0-212:26 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 214:0-214:26 *)
 let test_char : result char =
   Ok 'a'
 
 (** [no_nested_borrows::Tree]
-    Source: 'tests/src/no_nested_borrows.rs', lines 217:0-217:16 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 219:0-219:16 *)
 type tree_t (t : Type0) =
 | Tree_Leaf : t -> tree_t t
 | Tree_Node : t -> nodeElem_t t -> tree_t t -> tree_t t
 
 (** [no_nested_borrows::NodeElem]
-    Source: 'tests/src/no_nested_borrows.rs', lines 222:0-222:20 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 224:0-224:20 *)
 and nodeElem_t (t : Type0) =
 | NodeElem_Cons : tree_t t -> nodeElem_t t -> nodeElem_t t
 | NodeElem_Nil : nodeElem_t t
 
 (** [no_nested_borrows::list_length]:
-    Source: 'tests/src/no_nested_borrows.rs', lines 257:0-257:48 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 259:0-259:48 *)
 let rec list_length (t : Type0) (l : list_t t) : result u32 =
   begin match l with
   | List_Cons _ l1 -> let* i = list_length t l1 in u32_add 1 i
@@ -232,7 +232,7 @@ let rec list_length (t : Type0) (l : list_t t) : result u32 =
   end
 
 (** [no_nested_borrows::list_nth_shared]:
-    Source: 'tests/src/no_nested_borrows.rs', lines 265:0-265:62 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 267:0-267:62 *)
 let rec list_nth_shared (t : Type0) (l : list_t t) (i : u32) : result t =
   begin match l with
   | List_Cons x tl ->
@@ -241,7 +241,7 @@ let rec list_nth_shared (t : Type0) (l : list_t t) (i : u32) : result t =
   end
 
 (** [no_nested_borrows::list_nth_mut]:
-    Source: 'tests/src/no_nested_borrows.rs', lines 281:0-281:67 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 283:0-283:67 *)
 let rec list_nth_mut
   (t : Type0) (l : list_t t) (i : u32) :
   result (t & (t -> result (list_t t)))
@@ -260,7 +260,7 @@ let rec list_nth_mut
   end
 
 (** [no_nested_borrows::list_rev_aux]:
-    Source: 'tests/src/no_nested_borrows.rs', lines 297:0-297:63 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 299:0-299:63 *)
 let rec list_rev_aux
   (t : Type0) (li : list_t t) (lo : list_t t) : result (list_t t) =
   begin match li with
@@ -269,13 +269,13 @@ let rec list_rev_aux
   end
 
 (** [no_nested_borrows::list_rev]:
-    Source: 'tests/src/no_nested_borrows.rs', lines 311:0-311:42 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 313:0-313:42 *)
 let list_rev (t : Type0) (l : list_t t) : result (list_t t) =
   let (li, _) = core_mem_replace (list_t t) l List_Nil in
   list_rev_aux t li List_Nil
 
 (** [no_nested_borrows::test_list_functions]:
-    Source: 'tests/src/no_nested_borrows.rs', lines 316:0-316:28 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 318:0-318:28 *)
 let test_list_functions : result unit =
   let l = List_Cons 2 List_Nil in
   let l1 = List_Cons 1 l in
@@ -312,7 +312,7 @@ let test_list_functions : result unit =
 let _ = assert_norm (test_list_functions = Ok ())
 
 (** [no_nested_borrows::id_mut_pair1]:
-    Source: 'tests/src/no_nested_borrows.rs', lines 332:0-332:89 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 334:0-334:89 *)
 let id_mut_pair1
   (t1 t2 : Type0) (x : t1) (y : t2) :
   result ((t1 & t2) & ((t1 & t2) -> result (t1 & t2)))
@@ -320,7 +320,7 @@ let id_mut_pair1
   Ok ((x, y), Ok)
 
 (** [no_nested_borrows::id_mut_pair2]:
-    Source: 'tests/src/no_nested_borrows.rs', lines 336:0-336:88 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 338:0-338:88 *)
 let id_mut_pair2
   (t1 t2 : Type0) (p : (t1 & t2)) :
   result ((t1 & t2) & ((t1 & t2) -> result (t1 & t2)))
@@ -328,7 +328,7 @@ let id_mut_pair2
   let (x, x1) = p in Ok ((x, x1), Ok)
 
 (** [no_nested_borrows::id_mut_pair3]:
-    Source: 'tests/src/no_nested_borrows.rs', lines 340:0-340:93 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 342:0-342:93 *)
 let id_mut_pair3
   (t1 t2 : Type0) (x : t1) (y : t2) :
   result ((t1 & t2) & (t1 -> result t1) & (t2 -> result t2))
@@ -336,7 +336,7 @@ let id_mut_pair3
   Ok ((x, y), Ok, Ok)
 
 (** [no_nested_borrows::id_mut_pair4]:
-    Source: 'tests/src/no_nested_borrows.rs', lines 344:0-344:92 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 346:0-346:92 *)
 let id_mut_pair4
   (t1 t2 : Type0) (p : (t1 & t2)) :
   result ((t1 & t2) & (t1 -> result t1) & (t2 -> result t2))
@@ -344,35 +344,35 @@ let id_mut_pair4
   let (x, x1) = p in Ok ((x, x1), Ok, Ok)
 
 (** [no_nested_borrows::StructWithTuple]
-    Source: 'tests/src/no_nested_borrows.rs', lines 351:0-351:34 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 353:0-353:34 *)
 type structWithTuple_t (t1 t2 : Type0) = { p : (t1 & t2); }
 
 (** [no_nested_borrows::new_tuple1]:
-    Source: 'tests/src/no_nested_borrows.rs', lines 355:0-355:48 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 357:0-357:48 *)
 let new_tuple1 : result (structWithTuple_t u32 u32) =
   Ok { p = (1, 2) }
 
 (** [no_nested_borrows::new_tuple2]:
-    Source: 'tests/src/no_nested_borrows.rs', lines 359:0-359:48 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 361:0-361:48 *)
 let new_tuple2 : result (structWithTuple_t i16 i16) =
   Ok { p = (1, 2) }
 
 (** [no_nested_borrows::new_tuple3]:
-    Source: 'tests/src/no_nested_borrows.rs', lines 363:0-363:48 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 365:0-365:48 *)
 let new_tuple3 : result (structWithTuple_t u64 i64) =
   Ok { p = (1, 2) }
 
 (** [no_nested_borrows::StructWithPair]
-    Source: 'tests/src/no_nested_borrows.rs', lines 368:0-368:33 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 370:0-370:33 *)
 type structWithPair_t (t1 t2 : Type0) = { p : pair_t t1 t2; }
 
 (** [no_nested_borrows::new_pair1]:
-    Source: 'tests/src/no_nested_borrows.rs', lines 372:0-372:46 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 374:0-374:46 *)
 let new_pair1 : result (structWithPair_t u32 u32) =
   Ok { p = { x = 1; y = 2 } }
 
 (** [no_nested_borrows::test_constants]:
-    Source: 'tests/src/no_nested_borrows.rs', lines 380:0-380:23 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 382:0-382:23 *)
 let test_constants : result unit =
   let* swt = new_tuple1 in
   let (i, _) = swt.p in
@@ -396,7 +396,7 @@ let test_constants : result unit =
 let _ = assert_norm (test_constants = Ok ())
 
 (** [no_nested_borrows::test_weird_borrows1]:
-    Source: 'tests/src/no_nested_borrows.rs', lines 389:0-389:28 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 391:0-391:28 *)
 let test_weird_borrows1 : result unit =
   Ok ()
 
@@ -404,71 +404,71 @@ let test_weird_borrows1 : result unit =
 let _ = assert_norm (test_weird_borrows1 = Ok ())
 
 (** [no_nested_borrows::test_mem_replace]:
-    Source: 'tests/src/no_nested_borrows.rs', lines 399:0-399:37 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 401:0-401:37 *)
 let test_mem_replace (px : u32) : result u32 =
   let (y, _) = core_mem_replace u32 px 1 in
   if not (y = 0) then Fail Failure else Ok 2
 
 (** [no_nested_borrows::test_shared_borrow_bool1]:
-    Source: 'tests/src/no_nested_borrows.rs', lines 406:0-406:47 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 408:0-408:47 *)
 let test_shared_borrow_bool1 (b : bool) : result u32 =
   if b then Ok 0 else Ok 1
 
 (** [no_nested_borrows::test_shared_borrow_bool2]:
-    Source: 'tests/src/no_nested_borrows.rs', lines 419:0-419:40 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 421:0-421:40 *)
 let test_shared_borrow_bool2 : result u32 =
   Ok 0
 
 (** [no_nested_borrows::test_shared_borrow_enum1]:
-    Source: 'tests/src/no_nested_borrows.rs', lines 434:0-434:52 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 436:0-436:52 *)
 let test_shared_borrow_enum1 (l : list_t u32) : result u32 =
   begin match l with | List_Cons _ _ -> Ok 1 | List_Nil -> Ok 0 end
 
 (** [no_nested_borrows::test_shared_borrow_enum2]:
-    Source: 'tests/src/no_nested_borrows.rs', lines 446:0-446:40 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 448:0-448:40 *)
 let test_shared_borrow_enum2 : result u32 =
   Ok 0
 
 (** [no_nested_borrows::incr]:
-    Source: 'tests/src/no_nested_borrows.rs', lines 457:0-457:24 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 459:0-459:24 *)
 let incr (x : u32) : result u32 =
   u32_add x 1
 
 (** [no_nested_borrows::call_incr]:
-    Source: 'tests/src/no_nested_borrows.rs', lines 461:0-461:35 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 463:0-463:35 *)
 let call_incr (x : u32) : result u32 =
   incr x
 
 (** [no_nested_borrows::read_then_incr]:
-    Source: 'tests/src/no_nested_borrows.rs', lines 466:0-466:41 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 468:0-468:41 *)
 let read_then_incr (x : u32) : result (u32 & u32) =
   let* x1 = u32_add x 1 in Ok (x, x1)
 
 (** [no_nested_borrows::Tuple]
-    Source: 'tests/src/no_nested_borrows.rs', lines 472:0-472:24 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 474:0-474:24 *)
 type tuple_t (t1 t2 : Type0) = t1 * t2
 
 (** [no_nested_borrows::use_tuple_struct]:
-    Source: 'tests/src/no_nested_borrows.rs', lines 474:0-474:48 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 476:0-476:48 *)
 let use_tuple_struct (x : tuple_t u32 u32) : result (tuple_t u32 u32) =
   let (_, i) = x in Ok (1, i)
 
 (** [no_nested_borrows::create_tuple_struct]:
-    Source: 'tests/src/no_nested_borrows.rs', lines 478:0-478:61 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 480:0-480:61 *)
 let create_tuple_struct (x : u32) (y : u64) : result (tuple_t u32 u64) =
   Ok (x, y)
 
 (** [no_nested_borrows::IdType]
-    Source: 'tests/src/no_nested_borrows.rs', lines 483:0-483:20 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 485:0-485:20 *)
 type idType_t (t : Type0) = t
 
 (** [no_nested_borrows::use_id_type]:
-    Source: 'tests/src/no_nested_borrows.rs', lines 485:0-485:40 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 487:0-487:40 *)
 let use_id_type (t : Type0) (x : idType_t t) : result t =
   Ok x
 
 (** [no_nested_borrows::create_id_type]:
-    Source: 'tests/src/no_nested_borrows.rs', lines 489:0-489:43 *)
+    Source: 'tests/src/no_nested_borrows.rs', lines 491:0-491:43 *)
 let create_id_type (t : Type0) (x : t) : result (idType_t t) =
   Ok x
 

--- a/tests/fstar/misc/Paper.fst
+++ b/tests/fstar/misc/Paper.fst
@@ -6,12 +6,12 @@ open Primitives
 #set-options "--z3rlimit 50 --fuel 1 --ifuel 1"
 
 (** [paper::ref_incr]:
-    Source: 'tests/src/paper.rs', lines 4:0-4:28 *)
+    Source: 'tests/src/paper.rs', lines 6:0-6:28 *)
 let ref_incr (x : i32) : result i32 =
   i32_add x 1
 
 (** [paper::test_incr]:
-    Source: 'tests/src/paper.rs', lines 8:0-8:18 *)
+    Source: 'tests/src/paper.rs', lines 10:0-10:18 *)
 let test_incr : result unit =
   let* x = ref_incr 0 in if not (x = 1) then Fail Failure else Ok ()
 
@@ -19,7 +19,7 @@ let test_incr : result unit =
 let _ = assert_norm (test_incr = Ok ())
 
 (** [paper::choose]:
-    Source: 'tests/src/paper.rs', lines 15:0-15:70 *)
+    Source: 'tests/src/paper.rs', lines 17:0-17:70 *)
 let choose
   (t : Type0) (b : bool) (x : t) (y : t) : result (t & (t -> result (t & t))) =
   if b
@@ -27,7 +27,7 @@ let choose
   else let back = fun ret -> Ok (x, ret) in Ok (y, back)
 
 (** [paper::test_choose]:
-    Source: 'tests/src/paper.rs', lines 23:0-23:20 *)
+    Source: 'tests/src/paper.rs', lines 25:0-25:20 *)
 let test_choose : result unit =
   let* (z, choose_back) = choose i32 true 0 0 in
   let* z1 = i32_add z 1 in
@@ -43,13 +43,13 @@ let test_choose : result unit =
 let _ = assert_norm (test_choose = Ok ())
 
 (** [paper::List]
-    Source: 'tests/src/paper.rs', lines 35:0-35:16 *)
+    Source: 'tests/src/paper.rs', lines 37:0-37:16 *)
 type list_t (t : Type0) =
 | List_Cons : t -> list_t t -> list_t t
 | List_Nil : list_t t
 
 (** [paper::list_nth_mut]:
-    Source: 'tests/src/paper.rs', lines 42:0-42:67 *)
+    Source: 'tests/src/paper.rs', lines 44:0-44:67 *)
 let rec list_nth_mut
   (t : Type0) (l : list_t t) (i : u32) :
   result (t & (t -> result (list_t t)))
@@ -68,7 +68,7 @@ let rec list_nth_mut
   end
 
 (** [paper::sum]:
-    Source: 'tests/src/paper.rs', lines 57:0-57:32 *)
+    Source: 'tests/src/paper.rs', lines 59:0-59:32 *)
 let rec sum (l : list_t i32) : result i32 =
   begin match l with
   | List_Cons x tl -> let* i = sum tl in i32_add x i
@@ -76,7 +76,7 @@ let rec sum (l : list_t i32) : result i32 =
   end
 
 (** [paper::test_nth]:
-    Source: 'tests/src/paper.rs', lines 68:0-68:17 *)
+    Source: 'tests/src/paper.rs', lines 70:0-70:17 *)
 let test_nth : result unit =
   let l = List_Cons 3 List_Nil in
   let l1 = List_Cons 2 l in
@@ -90,7 +90,7 @@ let test_nth : result unit =
 let _ = assert_norm (test_nth = Ok ())
 
 (** [paper::call_choose]:
-    Source: 'tests/src/paper.rs', lines 76:0-76:44 *)
+    Source: 'tests/src/paper.rs', lines 78:0-78:44 *)
 let call_choose (p : (u32 & u32)) : result u32 =
   let (px, py) = p in
   let* (pz, choose_back) = choose u32 true px py in

--- a/tests/fstar/misc/PoloniusList.fst
+++ b/tests/fstar/misc/PoloniusList.fst
@@ -6,13 +6,13 @@ open Primitives
 #set-options "--z3rlimit 50 --fuel 1 --ifuel 1"
 
 (** [polonius_list::List]
-    Source: 'tests/src/polonius_list.rs', lines 3:0-3:16 *)
+    Source: 'tests/src/polonius_list.rs', lines 5:0-5:16 *)
 type list_t (t : Type0) =
 | List_Cons : t -> list_t t -> list_t t
 | List_Nil : list_t t
 
 (** [polonius_list::get_list_at_x]:
-    Source: 'tests/src/polonius_list.rs', lines 13:0-13:76 *)
+    Source: 'tests/src/polonius_list.rs', lines 15:0-15:76 *)
 let rec get_list_at_x
   (ls : list_t u32) (x : u32) :
   result ((list_t u32) & (list_t u32 -> result (list_t u32)))

--- a/tests/fstar/traits/Traits.fst
+++ b/tests/fstar/traits/Traits.fst
@@ -6,20 +6,20 @@ open Primitives
 #set-options "--z3rlimit 50 --fuel 1 --ifuel 1"
 
 (** Trait declaration: [traits::BoolTrait]
-    Source: 'tests/src/traits.rs', lines 1:0-1:19 *)
+    Source: 'tests/src/traits.rs', lines 2:0-2:19 *)
 noeq type boolTrait_t (self : Type0) = { get_bool : self -> result bool; }
 
 (** [traits::{(traits::BoolTrait for bool)}::get_bool]:
-    Source: 'tests/src/traits.rs', lines 12:4-12:30 *)
+    Source: 'tests/src/traits.rs', lines 13:4-13:30 *)
 let boolTraitBool_get_bool (self : bool) : result bool =
   Ok self
 
 (** Trait implementation: [traits::{(traits::BoolTrait for bool)}]
-    Source: 'tests/src/traits.rs', lines 11:0-11:23 *)
+    Source: 'tests/src/traits.rs', lines 12:0-12:23 *)
 let boolTraitBool : boolTrait_t bool = { get_bool = boolTraitBool_get_bool; }
 
 (** [traits::BoolTrait::ret_true]:
-    Source: 'tests/src/traits.rs', lines 6:4-6:30 *)
+    Source: 'tests/src/traits.rs', lines 7:4-7:30 *)
 let boolTrait_ret_true
   (#self : Type0) (self_clause : boolTrait_t self) (self1 : self) :
   result bool
@@ -27,49 +27,49 @@ let boolTrait_ret_true
   Ok true
 
 (** [traits::test_bool_trait_bool]:
-    Source: 'tests/src/traits.rs', lines 17:0-17:44 *)
+    Source: 'tests/src/traits.rs', lines 18:0-18:44 *)
 let test_bool_trait_bool (x : bool) : result bool =
   let* b = boolTraitBool_get_bool x in
   if b then boolTrait_ret_true boolTraitBool x else Ok false
 
 (** [traits::{(traits::BoolTrait for core::option::Option<T>)#1}::get_bool]:
-    Source: 'tests/src/traits.rs', lines 23:4-23:30 *)
+    Source: 'tests/src/traits.rs', lines 24:4-24:30 *)
 let boolTraitOption_get_bool (t : Type0) (self : option t) : result bool =
   begin match self with | None -> Ok false | Some _ -> Ok true end
 
 (** Trait implementation: [traits::{(traits::BoolTrait for core::option::Option<T>)#1}]
-    Source: 'tests/src/traits.rs', lines 22:0-22:31 *)
+    Source: 'tests/src/traits.rs', lines 23:0-23:31 *)
 let boolTraitOption (t : Type0) : boolTrait_t (option t) = {
   get_bool = boolTraitOption_get_bool t;
 }
 
 (** [traits::test_bool_trait_option]:
-    Source: 'tests/src/traits.rs', lines 31:0-31:54 *)
+    Source: 'tests/src/traits.rs', lines 32:0-32:54 *)
 let test_bool_trait_option (t : Type0) (x : option t) : result bool =
   let* b = boolTraitOption_get_bool t x in
   if b then boolTrait_ret_true (boolTraitOption t) x else Ok false
 
 (** [traits::test_bool_trait]:
-    Source: 'tests/src/traits.rs', lines 35:0-35:50 *)
+    Source: 'tests/src/traits.rs', lines 36:0-36:50 *)
 let test_bool_trait
   (t : Type0) (boolTraitInst : boolTrait_t t) (x : t) : result bool =
   boolTraitInst.get_bool x
 
 (** Trait declaration: [traits::ToU64]
-    Source: 'tests/src/traits.rs', lines 39:0-39:15 *)
+    Source: 'tests/src/traits.rs', lines 40:0-40:15 *)
 noeq type toU64_t (self : Type0) = { to_u64 : self -> result u64; }
 
 (** [traits::{(traits::ToU64 for u64)#2}::to_u64]:
-    Source: 'tests/src/traits.rs', lines 44:4-44:26 *)
+    Source: 'tests/src/traits.rs', lines 45:4-45:26 *)
 let toU64U64_to_u64 (self : u64) : result u64 =
   Ok self
 
 (** Trait implementation: [traits::{(traits::ToU64 for u64)#2}]
-    Source: 'tests/src/traits.rs', lines 43:0-43:18 *)
+    Source: 'tests/src/traits.rs', lines 44:0-44:18 *)
 let toU64U64 : toU64_t u64 = { to_u64 = toU64U64_to_u64; }
 
 (** [traits::{(traits::ToU64 for (A, A))#3}::to_u64]:
-    Source: 'tests/src/traits.rs', lines 50:4-50:26 *)
+    Source: 'tests/src/traits.rs', lines 51:4-51:26 *)
 let toU64Pair_to_u64
   (a : Type0) (toU64Inst : toU64_t a) (self : (a & a)) : result u64 =
   let (x, x1) = self in
@@ -78,75 +78,75 @@ let toU64Pair_to_u64
   u64_add i i1
 
 (** Trait implementation: [traits::{(traits::ToU64 for (A, A))#3}]
-    Source: 'tests/src/traits.rs', lines 49:0-49:31 *)
+    Source: 'tests/src/traits.rs', lines 50:0-50:31 *)
 let toU64Pair (a : Type0) (toU64Inst : toU64_t a) : toU64_t (a & a) = {
   to_u64 = toU64Pair_to_u64 a toU64Inst;
 }
 
 (** [traits::f]:
-    Source: 'tests/src/traits.rs', lines 55:0-55:36 *)
+    Source: 'tests/src/traits.rs', lines 56:0-56:36 *)
 let f (t : Type0) (toU64Inst : toU64_t t) (x : (t & t)) : result u64 =
   toU64Pair_to_u64 t toU64Inst x
 
 (** [traits::g]:
-    Source: 'tests/src/traits.rs', lines 59:0-61:18 *)
+    Source: 'tests/src/traits.rs', lines 60:0-62:18 *)
 let g
   (t : Type0) (toU64PairInst : toU64_t (t & t)) (x : (t & t)) : result u64 =
   toU64PairInst.to_u64 x
 
 (** [traits::h0]:
-    Source: 'tests/src/traits.rs', lines 66:0-66:24 *)
+    Source: 'tests/src/traits.rs', lines 67:0-67:24 *)
 let h0 (x : u64) : result u64 =
   toU64U64_to_u64 x
 
 (** [traits::Wrapper]
-    Source: 'tests/src/traits.rs', lines 70:0-70:21 *)
+    Source: 'tests/src/traits.rs', lines 71:0-71:21 *)
 type wrapper_t (t : Type0) = { x : t; }
 
 (** [traits::{(traits::ToU64 for traits::Wrapper<T>)#4}::to_u64]:
-    Source: 'tests/src/traits.rs', lines 75:4-75:26 *)
+    Source: 'tests/src/traits.rs', lines 76:4-76:26 *)
 let toU64traitsWrapper_to_u64
   (t : Type0) (toU64Inst : toU64_t t) (self : wrapper_t t) : result u64 =
   toU64Inst.to_u64 self.x
 
 (** Trait implementation: [traits::{(traits::ToU64 for traits::Wrapper<T>)#4}]
-    Source: 'tests/src/traits.rs', lines 74:0-74:35 *)
+    Source: 'tests/src/traits.rs', lines 75:0-75:35 *)
 let toU64traitsWrapper (t : Type0) (toU64Inst : toU64_t t) : toU64_t (wrapper_t
   t) = {
   to_u64 = toU64traitsWrapper_to_u64 t toU64Inst;
 }
 
 (** [traits::h1]:
-    Source: 'tests/src/traits.rs', lines 80:0-80:33 *)
+    Source: 'tests/src/traits.rs', lines 81:0-81:33 *)
 let h1 (x : wrapper_t u64) : result u64 =
   toU64traitsWrapper_to_u64 u64 toU64U64 x
 
 (** [traits::h2]:
-    Source: 'tests/src/traits.rs', lines 84:0-84:41 *)
+    Source: 'tests/src/traits.rs', lines 85:0-85:41 *)
 let h2 (t : Type0) (toU64Inst : toU64_t t) (x : wrapper_t t) : result u64 =
   toU64traitsWrapper_to_u64 t toU64Inst x
 
 (** Trait declaration: [traits::ToType]
-    Source: 'tests/src/traits.rs', lines 88:0-88:19 *)
+    Source: 'tests/src/traits.rs', lines 89:0-89:19 *)
 noeq type toType_t (self t : Type0) = { to_type : self -> result t; }
 
 (** [traits::{(traits::ToType<bool> for u64)#5}::to_type]:
-    Source: 'tests/src/traits.rs', lines 93:4-93:28 *)
+    Source: 'tests/src/traits.rs', lines 94:4-94:28 *)
 let toTypeU64Bool_to_type (self : u64) : result bool =
   Ok (self > 0)
 
 (** Trait implementation: [traits::{(traits::ToType<bool> for u64)#5}]
-    Source: 'tests/src/traits.rs', lines 92:0-92:25 *)
+    Source: 'tests/src/traits.rs', lines 93:0-93:25 *)
 let toTypeU64Bool : toType_t u64 bool = { to_type = toTypeU64Bool_to_type; }
 
 (** Trait declaration: [traits::OfType]
-    Source: 'tests/src/traits.rs', lines 98:0-98:16 *)
+    Source: 'tests/src/traits.rs', lines 99:0-99:16 *)
 noeq type ofType_t (self : Type0) = {
   of_type : (t : Type0) -> (toTypeInst : toType_t t self) -> t -> result self;
 }
 
 (** [traits::h3]:
-    Source: 'tests/src/traits.rs', lines 104:0-104:50 *)
+    Source: 'tests/src/traits.rs', lines 105:0-105:50 *)
 let h3
   (t1 t2 : Type0) (ofTypeInst : ofType_t t1) (toTypeInst : toType_t t2 t1)
   (y : t2) :
@@ -155,14 +155,14 @@ let h3
   ofTypeInst.of_type t2 toTypeInst y
 
 (** Trait declaration: [traits::OfTypeBis]
-    Source: 'tests/src/traits.rs', lines 109:0-109:36 *)
+    Source: 'tests/src/traits.rs', lines 110:0-110:36 *)
 noeq type ofTypeBis_t (self t : Type0) = {
   toTypeInst : toType_t t self;
   of_type : t -> result self;
 }
 
 (** [traits::h4]:
-    Source: 'tests/src/traits.rs', lines 118:0-118:57 *)
+    Source: 'tests/src/traits.rs', lines 119:0-119:57 *)
 let h4
   (t1 t2 : Type0) (ofTypeBisInst : ofTypeBis_t t1 t2) (toTypeInst : toType_t t2
   t1) (y : t2) :
@@ -171,34 +171,34 @@ let h4
   ofTypeBisInst.of_type y
 
 (** [traits::TestType]
-    Source: 'tests/src/traits.rs', lines 122:0-122:22 *)
+    Source: 'tests/src/traits.rs', lines 123:0-123:22 *)
 type testType_t (t : Type0) = t
 
 (** [traits::{traits::TestType<T>#6}::test::TestType1]
-    Source: 'tests/src/traits.rs', lines 127:8-127:24 *)
+    Source: 'tests/src/traits.rs', lines 128:8-128:24 *)
 type testType_test_TestType1_t = u64
 
 (** Trait declaration: [traits::{traits::TestType<T>#6}::test::TestTrait]
-    Source: 'tests/src/traits.rs', lines 128:8-128:23 *)
+    Source: 'tests/src/traits.rs', lines 129:8-129:23 *)
 noeq type testType_test_TestTrait_t (self : Type0) = {
   test : self -> result bool;
 }
 
 (** [traits::{traits::TestType<T>#6}::test::{(traits::{traits::TestType<T>#6}::test::TestTrait for traits::{traits::TestType<T>#6}::test::TestType1)}::test]:
-    Source: 'tests/src/traits.rs', lines 139:12-139:34 *)
+    Source: 'tests/src/traits.rs', lines 140:12-140:34 *)
 let testType_test_TestTraittraitsTestTypetestTestType1_test
   (self : testType_test_TestType1_t) : result bool =
   Ok (self > 1)
 
 (** Trait implementation: [traits::{traits::TestType<T>#6}::test::{(traits::{traits::TestType<T>#6}::test::TestTrait for traits::{traits::TestType<T>#6}::test::TestType1)}]
-    Source: 'tests/src/traits.rs', lines 138:8-138:36 *)
+    Source: 'tests/src/traits.rs', lines 139:8-139:36 *)
 let testType_test_TestTraittraitsTestTypetestTestType1 :
   testType_test_TestTrait_t testType_test_TestType1_t = {
   test = testType_test_TestTraittraitsTestTypetestTestType1_test;
 }
 
 (** [traits::{traits::TestType<T>#6}::test]:
-    Source: 'tests/src/traits.rs', lines 126:4-126:36 *)
+    Source: 'tests/src/traits.rs', lines 127:4-127:36 *)
 let testType_test
   (t : Type0) (toU64Inst : toU64_t t) (self : testType_t t) (x : t) :
   result bool
@@ -209,11 +209,11 @@ let testType_test
   else Ok false
 
 (** [traits::BoolWrapper]
-    Source: 'tests/src/traits.rs', lines 150:0-150:22 *)
+    Source: 'tests/src/traits.rs', lines 151:0-151:22 *)
 type boolWrapper_t = bool
 
 (** [traits::{(traits::ToType<T> for traits::BoolWrapper)#7}::to_type]:
-    Source: 'tests/src/traits.rs', lines 156:4-156:25 *)
+    Source: 'tests/src/traits.rs', lines 157:4-157:25 *)
 let toTypetraitsBoolWrapperT_to_type
   (t : Type0) (toTypeBoolTInst : toType_t bool t) (self : boolWrapper_t) :
   result t
@@ -221,14 +221,14 @@ let toTypetraitsBoolWrapperT_to_type
   toTypeBoolTInst.to_type self
 
 (** Trait implementation: [traits::{(traits::ToType<T> for traits::BoolWrapper)#7}]
-    Source: 'tests/src/traits.rs', lines 152:0-152:33 *)
+    Source: 'tests/src/traits.rs', lines 153:0-153:33 *)
 let toTypetraitsBoolWrapperT (t : Type0) (toTypeBoolTInst : toType_t bool t) :
   toType_t boolWrapper_t t = {
   to_type = toTypetraitsBoolWrapperT_to_type t toTypeBoolTInst;
 }
 
 (** [traits::WithConstTy::LEN2]
-    Source: 'tests/src/traits.rs', lines 164:4-164:21 *)
+    Source: 'tests/src/traits.rs', lines 165:4-165:21 *)
 let with_const_ty_len2_default_body (self : Type0) (len : usize)
   : result usize =
   Ok 32
@@ -236,7 +236,7 @@ let with_const_ty_len2_default (self : Type0) (len : usize) : usize =
   eval_global (with_const_ty_len2_default_body self len)
 
 (** Trait declaration: [traits::WithConstTy]
-    Source: 'tests/src/traits.rs', lines 161:0-161:39 *)
+    Source: 'tests/src/traits.rs', lines 162:0-162:39 *)
 noeq type withConstTy_t (self : Type0) (len : usize) = {
   cLEN1 : usize;
   cLEN2 : usize;
@@ -247,18 +247,18 @@ noeq type withConstTy_t (self : Type0) (len : usize) = {
 }
 
 (** [traits::{(traits::WithConstTy<32: usize> for bool)#8}::LEN1]
-    Source: 'tests/src/traits.rs', lines 175:4-175:21 *)
+    Source: 'tests/src/traits.rs', lines 176:4-176:21 *)
 let with_const_ty_bool32_len1_body : result usize = Ok 12
 let with_const_ty_bool32_len1 : usize =
   eval_global with_const_ty_bool32_len1_body
 
 (** [traits::{(traits::WithConstTy<32: usize> for bool)#8}::f]:
-    Source: 'tests/src/traits.rs', lines 180:4-180:39 *)
+    Source: 'tests/src/traits.rs', lines 181:4-181:39 *)
 let withConstTyBool32_f (i : u64) (a : array u8 32) : result u64 =
   Ok i
 
 (** Trait implementation: [traits::{(traits::WithConstTy<32: usize> for bool)#8}]
-    Source: 'tests/src/traits.rs', lines 174:0-174:29 *)
+    Source: 'tests/src/traits.rs', lines 175:0-175:29 *)
 let withConstTyBool32 : withConstTy_t bool 32 = {
   cLEN1 = with_const_ty_bool32_len1;
   cLEN2 = with_const_ty_len2_default bool 32;
@@ -269,7 +269,7 @@ let withConstTyBool32 : withConstTy_t bool 32 = {
 }
 
 (** [traits::use_with_const_ty1]:
-    Source: 'tests/src/traits.rs', lines 183:0-183:75 *)
+    Source: 'tests/src/traits.rs', lines 184:0-184:75 *)
 let use_with_const_ty1
   (h : Type0) (len : usize) (withConstTyInst : withConstTy_t h len) :
   result usize
@@ -277,7 +277,7 @@ let use_with_const_ty1
   Ok withConstTyInst.cLEN1
 
 (** [traits::use_with_const_ty2]:
-    Source: 'tests/src/traits.rs', lines 187:0-187:73 *)
+    Source: 'tests/src/traits.rs', lines 188:0-188:73 *)
 let use_with_const_ty2
   (h : Type0) (len : usize) (withConstTyInst : withConstTy_t h len)
   (w : withConstTyInst.tW) :
@@ -286,7 +286,7 @@ let use_with_const_ty2
   Ok ()
 
 (** [traits::use_with_const_ty3]:
-    Source: 'tests/src/traits.rs', lines 189:0-189:80 *)
+    Source: 'tests/src/traits.rs', lines 190:0-190:80 *)
 let use_with_const_ty3
   (h : Type0) (len : usize) (withConstTyInst : withConstTy_t h len)
   (x : withConstTyInst.tW) :
@@ -295,12 +295,12 @@ let use_with_const_ty3
   withConstTyInst.tW_clause_0.to_u64 x
 
 (** [traits::test_where1]:
-    Source: 'tests/src/traits.rs', lines 193:0-193:40 *)
+    Source: 'tests/src/traits.rs', lines 194:0-194:40 *)
 let test_where1 (t : Type0) (_x : t) : result unit =
   Ok ()
 
 (** [traits::test_where2]:
-    Source: 'tests/src/traits.rs', lines 194:0-194:57 *)
+    Source: 'tests/src/traits.rs', lines 195:0-195:57 *)
 let test_where2
   (t : Type0) (withConstTyT32Inst : withConstTy_t t 32) (_x : u32) :
   result unit
@@ -308,7 +308,7 @@ let test_where2
   Ok ()
 
 (** Trait declaration: [traits::ParentTrait0]
-    Source: 'tests/src/traits.rs', lines 200:0-200:22 *)
+    Source: 'tests/src/traits.rs', lines 201:0-201:22 *)
 noeq type parentTrait0_t (self : Type0) = {
   tW : Type0;
   get_name : self -> result string;
@@ -316,24 +316,24 @@ noeq type parentTrait0_t (self : Type0) = {
 }
 
 (** Trait declaration: [traits::ParentTrait1]
-    Source: 'tests/src/traits.rs', lines 205:0-205:22 *)
+    Source: 'tests/src/traits.rs', lines 206:0-206:22 *)
 type parentTrait1_t (self : Type0) = unit
 
 (** Trait declaration: [traits::ChildTrait]
-    Source: 'tests/src/traits.rs', lines 206:0-206:49 *)
+    Source: 'tests/src/traits.rs', lines 207:0-207:49 *)
 noeq type childTrait_t (self : Type0) = {
   parentTrait0Inst : parentTrait0_t self;
   parentTrait1Inst : parentTrait1_t self;
 }
 
 (** [traits::test_child_trait1]:
-    Source: 'tests/src/traits.rs', lines 209:0-209:56 *)
+    Source: 'tests/src/traits.rs', lines 210:0-210:56 *)
 let test_child_trait1
   (t : Type0) (childTraitInst : childTrait_t t) (x : t) : result string =
   childTraitInst.parentTrait0Inst.get_name x
 
 (** [traits::test_child_trait2]:
-    Source: 'tests/src/traits.rs', lines 213:0-213:54 *)
+    Source: 'tests/src/traits.rs', lines 214:0-214:54 *)
 let test_child_trait2
   (t : Type0) (childTraitInst : childTrait_t t) (x : t) :
   result childTraitInst.parentTrait0Inst.tW
@@ -341,7 +341,7 @@ let test_child_trait2
   childTraitInst.parentTrait0Inst.get_w x
 
 (** [traits::order1]:
-    Source: 'tests/src/traits.rs', lines 219:0-219:59 *)
+    Source: 'tests/src/traits.rs', lines 220:0-220:59 *)
 let order1
   (t u : Type0) (parentTrait0Inst : parentTrait0_t t) (parentTrait0Inst1 :
   parentTrait0_t u) :
@@ -350,27 +350,27 @@ let order1
   Ok ()
 
 (** Trait declaration: [traits::ChildTrait1]
-    Source: 'tests/src/traits.rs', lines 222:0-222:35 *)
+    Source: 'tests/src/traits.rs', lines 223:0-223:35 *)
 noeq type childTrait1_t (self : Type0) = {
   parentTrait1Inst : parentTrait1_t self;
 }
 
 (** Trait implementation: [traits::{(traits::ParentTrait1 for usize)#9}]
-    Source: 'tests/src/traits.rs', lines 224:0-224:27 *)
+    Source: 'tests/src/traits.rs', lines 225:0-225:27 *)
 let parentTrait1Usize : parentTrait1_t usize = ()
 
 (** Trait implementation: [traits::{(traits::ChildTrait1 for usize)#10}]
-    Source: 'tests/src/traits.rs', lines 225:0-225:26 *)
+    Source: 'tests/src/traits.rs', lines 226:0-226:26 *)
 let childTrait1Usize : childTrait1_t usize = {
   parentTrait1Inst = parentTrait1Usize;
 }
 
 (** Trait declaration: [traits::Iterator]
-    Source: 'tests/src/traits.rs', lines 229:0-229:18 *)
+    Source: 'tests/src/traits.rs', lines 230:0-230:18 *)
 noeq type iterator_t (self : Type0) = { tItem : Type0; }
 
 (** Trait declaration: [traits::IntoIterator]
-    Source: 'tests/src/traits.rs', lines 233:0-233:22 *)
+    Source: 'tests/src/traits.rs', lines 234:0-234:22 *)
 noeq type intoIterator_t (self : Type0) = {
   tItem : Type0;
   tIntoIter : Type0;
@@ -379,107 +379,107 @@ noeq type intoIterator_t (self : Type0) = {
 }
 
 (** Trait declaration: [traits::FromResidual]
-    Source: 'tests/src/traits.rs', lines 250:0-250:21 *)
+    Source: 'tests/src/traits.rs', lines 251:0-251:21 *)
 type fromResidual_t (self t : Type0) = unit
 
 (** Trait declaration: [traits::Try]
-    Source: 'tests/src/traits.rs', lines 246:0-246:48 *)
+    Source: 'tests/src/traits.rs', lines 247:0-247:48 *)
 noeq type try_t (self : Type0) = {
   tResidual : Type0;
   fromResidualSelftraitsTryResidualInst : fromResidual_t self tResidual;
 }
 
 (** Trait declaration: [traits::WithTarget]
-    Source: 'tests/src/traits.rs', lines 252:0-252:20 *)
+    Source: 'tests/src/traits.rs', lines 253:0-253:20 *)
 noeq type withTarget_t (self : Type0) = { tTarget : Type0; }
 
 (** Trait declaration: [traits::ParentTrait2]
-    Source: 'tests/src/traits.rs', lines 256:0-256:22 *)
+    Source: 'tests/src/traits.rs', lines 257:0-257:22 *)
 noeq type parentTrait2_t (self : Type0) = {
   tU : Type0;
   tU_clause_0 : withTarget_t tU;
 }
 
 (** Trait declaration: [traits::ChildTrait2]
-    Source: 'tests/src/traits.rs', lines 260:0-260:35 *)
+    Source: 'tests/src/traits.rs', lines 261:0-261:35 *)
 noeq type childTrait2_t (self : Type0) = {
   parentTrait2Inst : parentTrait2_t self;
   convert : parentTrait2Inst.tU -> result parentTrait2Inst.tU_clause_0.tTarget;
 }
 
 (** Trait implementation: [traits::{(traits::WithTarget for u32)#11}]
-    Source: 'tests/src/traits.rs', lines 264:0-264:23 *)
+    Source: 'tests/src/traits.rs', lines 265:0-265:23 *)
 let withTargetU32 : withTarget_t u32 = { tTarget = u32; }
 
 (** Trait implementation: [traits::{(traits::ParentTrait2 for u32)#12}]
-    Source: 'tests/src/traits.rs', lines 268:0-268:25 *)
+    Source: 'tests/src/traits.rs', lines 269:0-269:25 *)
 let parentTrait2U32 : parentTrait2_t u32 = {
   tU = u32;
   tU_clause_0 = withTargetU32;
 }
 
 (** [traits::{(traits::ChildTrait2 for u32)#13}::convert]:
-    Source: 'tests/src/traits.rs', lines 273:4-273:29 *)
+    Source: 'tests/src/traits.rs', lines 274:4-274:29 *)
 let childTrait2U32_convert (x : u32) : result u32 =
   Ok x
 
 (** Trait implementation: [traits::{(traits::ChildTrait2 for u32)#13}]
-    Source: 'tests/src/traits.rs', lines 272:0-272:24 *)
+    Source: 'tests/src/traits.rs', lines 273:0-273:24 *)
 let childTrait2U32 : childTrait2_t u32 = {
   parentTrait2Inst = parentTrait2U32;
   convert = childTrait2U32_convert;
 }
 
 (** Trait declaration: [traits::CFnOnce]
-    Source: 'tests/src/traits.rs', lines 286:0-286:23 *)
+    Source: 'tests/src/traits.rs', lines 287:0-287:23 *)
 noeq type cFnOnce_t (self args : Type0) = {
   tOutput : Type0;
   call_once : self -> args -> result tOutput;
 }
 
 (** Trait declaration: [traits::CFnMut]
-    Source: 'tests/src/traits.rs', lines 292:0-292:37 *)
+    Source: 'tests/src/traits.rs', lines 293:0-293:37 *)
 noeq type cFnMut_t (self args : Type0) = {
   cFnOnceInst : cFnOnce_t self args;
   call_mut : self -> args -> result (cFnOnceInst.tOutput & self);
 }
 
 (** Trait declaration: [traits::CFn]
-    Source: 'tests/src/traits.rs', lines 296:0-296:33 *)
+    Source: 'tests/src/traits.rs', lines 297:0-297:33 *)
 noeq type cFn_t (self args : Type0) = {
   cFnMutInst : cFnMut_t self args;
   call : self -> args -> result cFnMutInst.cFnOnceInst.tOutput;
 }
 
 (** Trait declaration: [traits::GetTrait]
-    Source: 'tests/src/traits.rs', lines 300:0-300:18 *)
+    Source: 'tests/src/traits.rs', lines 301:0-301:18 *)
 noeq type getTrait_t (self : Type0) = { tW : Type0; get_w : self -> result tW;
 }
 
 (** [traits::test_get_trait]:
-    Source: 'tests/src/traits.rs', lines 305:0-305:49 *)
+    Source: 'tests/src/traits.rs', lines 306:0-306:49 *)
 let test_get_trait
   (t : Type0) (getTraitInst : getTrait_t t) (x : t) : result getTraitInst.tW =
   getTraitInst.get_w x
 
 (** Trait declaration: [traits::Trait]
-    Source: 'tests/src/traits.rs', lines 310:0-310:15 *)
+    Source: 'tests/src/traits.rs', lines 311:0-311:15 *)
 noeq type trait_t (self : Type0) = { cLEN : usize; }
 
 (** [traits::{(traits::Trait for @Array<T, N>)#14}::LEN]
-    Source: 'tests/src/traits.rs', lines 315:4-315:20 *)
+    Source: 'tests/src/traits.rs', lines 316:4-316:20 *)
 let trait_array_len_body (t : Type0) (n : usize) : result usize = Ok n
 let trait_array_len (t : Type0) (n : usize) : usize =
   eval_global (trait_array_len_body t n)
 
 (** Trait implementation: [traits::{(traits::Trait for @Array<T, N>)#14}]
-    Source: 'tests/src/traits.rs', lines 314:0-314:40 *)
+    Source: 'tests/src/traits.rs', lines 315:0-315:40 *)
 let traitArray (t : Type0) (n : usize) : trait_t (array t n) = {
   cLEN = trait_array_len t n;
 }
 
 (** [traits::{(traits::Trait for traits::Wrapper<T>)#15}::LEN]
-    Source: 'tests/src/traits.rs', lines 319:4-319:20 *)
+    Source: 'tests/src/traits.rs', lines 320:4-320:20 *)
 let traittraits_wrapper_len_body (t : Type0) (traitInst : trait_t t)
   : result usize =
   Ok 0
@@ -487,19 +487,19 @@ let traittraits_wrapper_len (t : Type0) (traitInst : trait_t t) : usize =
   eval_global (traittraits_wrapper_len_body t traitInst)
 
 (** Trait implementation: [traits::{(traits::Trait for traits::Wrapper<T>)#15}]
-    Source: 'tests/src/traits.rs', lines 318:0-318:35 *)
+    Source: 'tests/src/traits.rs', lines 319:0-319:35 *)
 let traittraitsWrapper (t : Type0) (traitInst : trait_t t) : trait_t (wrapper_t
   t) = {
   cLEN = traittraits_wrapper_len t traitInst;
 }
 
 (** [traits::use_wrapper_len]:
-    Source: 'tests/src/traits.rs', lines 322:0-322:43 *)
+    Source: 'tests/src/traits.rs', lines 323:0-323:43 *)
 let use_wrapper_len (t : Type0) (traitInst : trait_t t) : result usize =
   Ok (traittraitsWrapper t traitInst).cLEN
 
 (** [traits::Foo]
-    Source: 'tests/src/traits.rs', lines 326:0-326:20 *)
+    Source: 'tests/src/traits.rs', lines 327:0-327:20 *)
 type foo_t (t u : Type0) = { x : t; y : u; }
 
 (** [core::result::Result]
@@ -510,7 +510,7 @@ type core_result_Result_t (t e : Type0) =
 | Core_result_Result_Err : e -> core_result_Result_t t e
 
 (** [traits::{traits::Foo<T, U>#16}::FOO]
-    Source: 'tests/src/traits.rs', lines 332:4-332:33 *)
+    Source: 'tests/src/traits.rs', lines 333:4-333:33 *)
 let foo_foo_body (t u : Type0) (traitInst : trait_t t)
   : result (core_result_Result_t t i32) =
   Ok (Core_result_Result_Err 0)
@@ -519,13 +519,13 @@ let foo_foo (t u : Type0) (traitInst : trait_t t)
   eval_global (foo_foo_body t u traitInst)
 
 (** [traits::use_foo1]:
-    Source: 'tests/src/traits.rs', lines 335:0-335:48 *)
+    Source: 'tests/src/traits.rs', lines 336:0-336:48 *)
 let use_foo1
   (t u : Type0) (traitInst : trait_t t) : result (core_result_Result_t t i32) =
   Ok (foo_foo t u traitInst)
 
 (** [traits::use_foo2]:
-    Source: 'tests/src/traits.rs', lines 339:0-339:48 *)
+    Source: 'tests/src/traits.rs', lines 340:0-340:48 *)
 let use_foo2
   (t u : Type0) (traitInst : trait_t u) : result (core_result_Result_t u i32) =
   Ok (foo_foo u t traitInst)

--- a/tests/lean/Arrays.lean
+++ b/tests/lean/Arrays.lean
@@ -6,24 +6,24 @@ open Primitives
 namespace arrays
 
 /- [arrays::AB]
-   Source: 'tests/src/arrays.rs', lines 3:0-3:11 -/
+   Source: 'tests/src/arrays.rs', lines 6:0-6:11 -/
 inductive AB :=
 | A : AB
 | B : AB
 
 /- [arrays::incr]:
-   Source: 'tests/src/arrays.rs', lines 8:0-8:24 -/
+   Source: 'tests/src/arrays.rs', lines 11:0-11:24 -/
 def incr (x : U32) : Result U32 :=
   x + 1#u32
 
 /- [arrays::array_to_shared_slice_]:
-   Source: 'tests/src/arrays.rs', lines 16:0-16:53 -/
+   Source: 'tests/src/arrays.rs', lines 19:0-19:53 -/
 def array_to_shared_slice_
   (T : Type) (s : Array T 32#usize) : Result (Slice T) :=
   Array.to_slice T 32#usize s
 
 /- [arrays::array_to_mut_slice_]:
-   Source: 'tests/src/arrays.rs', lines 21:0-21:58 -/
+   Source: 'tests/src/arrays.rs', lines 24:0-24:58 -/
 def array_to_mut_slice_
   (T : Type) (s : Array T 32#usize) :
   Result ((Slice T) × (Slice T → Result (Array T 32#usize)))
@@ -31,42 +31,42 @@ def array_to_mut_slice_
   Array.to_slice_mut T 32#usize s
 
 /- [arrays::array_len]:
-   Source: 'tests/src/arrays.rs', lines 25:0-25:40 -/
+   Source: 'tests/src/arrays.rs', lines 28:0-28:40 -/
 def array_len (T : Type) (s : Array T 32#usize) : Result Usize :=
   do
   let s1 ← Array.to_slice T 32#usize s
   Result.ok (Slice.len T s1)
 
 /- [arrays::shared_array_len]:
-   Source: 'tests/src/arrays.rs', lines 29:0-29:48 -/
+   Source: 'tests/src/arrays.rs', lines 32:0-32:48 -/
 def shared_array_len (T : Type) (s : Array T 32#usize) : Result Usize :=
   do
   let s1 ← Array.to_slice T 32#usize s
   Result.ok (Slice.len T s1)
 
 /- [arrays::shared_slice_len]:
-   Source: 'tests/src/arrays.rs', lines 33:0-33:44 -/
+   Source: 'tests/src/arrays.rs', lines 36:0-36:44 -/
 def shared_slice_len (T : Type) (s : Slice T) : Result Usize :=
   Result.ok (Slice.len T s)
 
 /- [arrays::index_array_shared]:
-   Source: 'tests/src/arrays.rs', lines 37:0-37:57 -/
+   Source: 'tests/src/arrays.rs', lines 40:0-40:57 -/
 def index_array_shared
   (T : Type) (s : Array T 32#usize) (i : Usize) : Result T :=
   Array.index_usize T 32#usize s i
 
 /- [arrays::index_array_u32]:
-   Source: 'tests/src/arrays.rs', lines 44:0-44:53 -/
+   Source: 'tests/src/arrays.rs', lines 47:0-47:53 -/
 def index_array_u32 (s : Array U32 32#usize) (i : Usize) : Result U32 :=
   Array.index_usize U32 32#usize s i
 
 /- [arrays::index_array_copy]:
-   Source: 'tests/src/arrays.rs', lines 48:0-48:45 -/
+   Source: 'tests/src/arrays.rs', lines 51:0-51:45 -/
 def index_array_copy (x : Array U32 32#usize) : Result U32 :=
   Array.index_usize U32 32#usize x 0#usize
 
 /- [arrays::index_mut_array]:
-   Source: 'tests/src/arrays.rs', lines 52:0-52:62 -/
+   Source: 'tests/src/arrays.rs', lines 55:0-55:62 -/
 def index_mut_array
   (T : Type) (s : Array T 32#usize) (i : Usize) :
   Result (T × (T → Result (Array T 32#usize)))
@@ -74,12 +74,12 @@ def index_mut_array
   Array.index_mut_usize T 32#usize s i
 
 /- [arrays::index_slice]:
-   Source: 'tests/src/arrays.rs', lines 56:0-56:46 -/
+   Source: 'tests/src/arrays.rs', lines 59:0-59:46 -/
 def index_slice (T : Type) (s : Slice T) (i : Usize) : Result T :=
   Slice.index_usize T s i
 
 /- [arrays::index_mut_slice]:
-   Source: 'tests/src/arrays.rs', lines 60:0-60:58 -/
+   Source: 'tests/src/arrays.rs', lines 63:0-63:58 -/
 def index_mut_slice
   (T : Type) (s : Slice T) (i : Usize) :
   Result (T × (T → Result (Slice T)))
@@ -87,7 +87,7 @@ def index_mut_slice
   Slice.index_mut_usize T s i
 
 /- [arrays::slice_subslice_shared_]:
-   Source: 'tests/src/arrays.rs', lines 64:0-64:70 -/
+   Source: 'tests/src/arrays.rs', lines 67:0-67:70 -/
 def slice_subslice_shared_
   (x : Slice U32) (y : Usize) (z : Usize) : Result (Slice U32) :=
   core.slice.index.Slice.index U32 (core.ops.range.Range Usize)
@@ -95,7 +95,7 @@ def slice_subslice_shared_
     { start := y, end_ := z }
 
 /- [arrays::slice_subslice_mut_]:
-   Source: 'tests/src/arrays.rs', lines 68:0-68:75 -/
+   Source: 'tests/src/arrays.rs', lines 71:0-71:75 -/
 def slice_subslice_mut_
   (x : Slice U32) (y : Usize) (z : Usize) :
   Result ((Slice U32) × (Slice U32 → Result (Slice U32)))
@@ -108,12 +108,12 @@ def slice_subslice_mut_
   Result.ok (s, index_mut_back)
 
 /- [arrays::array_to_slice_shared_]:
-   Source: 'tests/src/arrays.rs', lines 72:0-72:54 -/
+   Source: 'tests/src/arrays.rs', lines 75:0-75:54 -/
 def array_to_slice_shared_ (x : Array U32 32#usize) : Result (Slice U32) :=
   Array.to_slice U32 32#usize x
 
 /- [arrays::array_to_slice_mut_]:
-   Source: 'tests/src/arrays.rs', lines 76:0-76:59 -/
+   Source: 'tests/src/arrays.rs', lines 79:0-79:59 -/
 def array_to_slice_mut_
   (x : Array U32 32#usize) :
   Result ((Slice U32) × (Slice U32 → Result (Array U32 32#usize)))
@@ -121,7 +121,7 @@ def array_to_slice_mut_
   Array.to_slice_mut U32 32#usize x
 
 /- [arrays::array_subslice_shared_]:
-   Source: 'tests/src/arrays.rs', lines 80:0-80:74 -/
+   Source: 'tests/src/arrays.rs', lines 83:0-83:74 -/
 def array_subslice_shared_
   (x : Array U32 32#usize) (y : Usize) (z : Usize) : Result (Slice U32) :=
   core.array.Array.index U32 (core.ops.range.Range Usize) 32#usize
@@ -130,7 +130,7 @@ def array_subslice_shared_
     { start := y, end_ := z }
 
 /- [arrays::array_subslice_mut_]:
-   Source: 'tests/src/arrays.rs', lines 84:0-84:79 -/
+   Source: 'tests/src/arrays.rs', lines 87:0-87:79 -/
 def array_subslice_mut_
   (x : Array U32 32#usize) (y : Usize) (z : Usize) :
   Result ((Slice U32) × (Slice U32 → Result (Array U32 32#usize)))
@@ -144,17 +144,17 @@ def array_subslice_mut_
   Result.ok (s, index_mut_back)
 
 /- [arrays::index_slice_0]:
-   Source: 'tests/src/arrays.rs', lines 88:0-88:38 -/
+   Source: 'tests/src/arrays.rs', lines 91:0-91:38 -/
 def index_slice_0 (T : Type) (s : Slice T) : Result T :=
   Slice.index_usize T s 0#usize
 
 /- [arrays::index_array_0]:
-   Source: 'tests/src/arrays.rs', lines 92:0-92:42 -/
+   Source: 'tests/src/arrays.rs', lines 95:0-95:42 -/
 def index_array_0 (T : Type) (s : Array T 32#usize) : Result T :=
   Array.index_usize T 32#usize s 0#usize
 
 /- [arrays::index_index_array]:
-   Source: 'tests/src/arrays.rs', lines 103:0-103:71 -/
+   Source: 'tests/src/arrays.rs', lines 106:0-106:71 -/
 def index_index_array
   (s : Array (Array U32 32#usize) 32#usize) (i : Usize) (j : Usize) :
   Result U32
@@ -164,7 +164,7 @@ def index_index_array
   Array.index_usize U32 32#usize a j
 
 /- [arrays::update_update_array]:
-   Source: 'tests/src/arrays.rs', lines 114:0-114:70 -/
+   Source: 'tests/src/arrays.rs', lines 117:0-117:70 -/
 def update_update_array
   (s : Array (Array U32 32#usize) 32#usize) (i : Usize) (j : Usize) :
   Result Unit
@@ -178,37 +178,37 @@ def update_update_array
   Result.ok ()
 
 /- [arrays::array_local_deep_copy]:
-   Source: 'tests/src/arrays.rs', lines 118:0-118:43 -/
+   Source: 'tests/src/arrays.rs', lines 121:0-121:43 -/
 def array_local_deep_copy (x : Array U32 32#usize) : Result Unit :=
   Result.ok ()
 
 /- [arrays::take_array]:
-   Source: 'tests/src/arrays.rs', lines 122:0-122:30 -/
+   Source: 'tests/src/arrays.rs', lines 125:0-125:30 -/
 def take_array (a : Array U32 2#usize) : Result Unit :=
   Result.ok ()
 
 /- [arrays::take_array_borrow]:
-   Source: 'tests/src/arrays.rs', lines 123:0-123:38 -/
+   Source: 'tests/src/arrays.rs', lines 126:0-126:38 -/
 def take_array_borrow (a : Array U32 2#usize) : Result Unit :=
   Result.ok ()
 
 /- [arrays::take_slice]:
-   Source: 'tests/src/arrays.rs', lines 124:0-124:28 -/
+   Source: 'tests/src/arrays.rs', lines 127:0-127:28 -/
 def take_slice (s : Slice U32) : Result Unit :=
   Result.ok ()
 
 /- [arrays::take_mut_slice]:
-   Source: 'tests/src/arrays.rs', lines 125:0-125:36 -/
+   Source: 'tests/src/arrays.rs', lines 128:0-128:36 -/
 def take_mut_slice (s : Slice U32) : Result (Slice U32) :=
   Result.ok s
 
 /- [arrays::const_array]:
-   Source: 'tests/src/arrays.rs', lines 127:0-127:32 -/
+   Source: 'tests/src/arrays.rs', lines 130:0-130:32 -/
 def const_array : Result (Array U32 2#usize) :=
   Result.ok (Array.make U32 2#usize [ 0#u32, 0#u32 ])
 
 /- [arrays::const_slice]:
-   Source: 'tests/src/arrays.rs', lines 131:0-131:20 -/
+   Source: 'tests/src/arrays.rs', lines 134:0-134:20 -/
 def const_slice : Result Unit :=
   do
   let _ ←
@@ -216,7 +216,7 @@ def const_slice : Result Unit :=
   Result.ok ()
 
 /- [arrays::take_all]:
-   Source: 'tests/src/arrays.rs', lines 141:0-141:17 -/
+   Source: 'tests/src/arrays.rs', lines 144:0-144:17 -/
 def take_all : Result Unit :=
   do
   let _ ← take_array (Array.make U32 2#usize [ 0#u32, 0#u32 ])
@@ -232,29 +232,29 @@ def take_all : Result Unit :=
   Result.ok ()
 
 /- [arrays::index_array]:
-   Source: 'tests/src/arrays.rs', lines 155:0-155:38 -/
+   Source: 'tests/src/arrays.rs', lines 158:0-158:38 -/
 def index_array (x : Array U32 2#usize) : Result U32 :=
   Array.index_usize U32 2#usize x 0#usize
 
 /- [arrays::index_array_borrow]:
-   Source: 'tests/src/arrays.rs', lines 158:0-158:46 -/
+   Source: 'tests/src/arrays.rs', lines 161:0-161:46 -/
 def index_array_borrow (x : Array U32 2#usize) : Result U32 :=
   Array.index_usize U32 2#usize x 0#usize
 
 /- [arrays::index_slice_u32_0]:
-   Source: 'tests/src/arrays.rs', lines 162:0-162:42 -/
+   Source: 'tests/src/arrays.rs', lines 165:0-165:42 -/
 def index_slice_u32_0 (x : Slice U32) : Result U32 :=
   Slice.index_usize U32 x 0#usize
 
 /- [arrays::index_mut_slice_u32_0]:
-   Source: 'tests/src/arrays.rs', lines 166:0-166:50 -/
+   Source: 'tests/src/arrays.rs', lines 169:0-169:50 -/
 def index_mut_slice_u32_0 (x : Slice U32) : Result (U32 × (Slice U32)) :=
   do
   let i ← Slice.index_usize U32 x 0#usize
   Result.ok (i, x)
 
 /- [arrays::index_all]:
-   Source: 'tests/src/arrays.rs', lines 170:0-170:25 -/
+   Source: 'tests/src/arrays.rs', lines 173:0-173:25 -/
 def index_all : Result U32 :=
   do
   let i ← index_array (Array.make U32 2#usize [ 0#u32, 0#u32 ])
@@ -274,7 +274,7 @@ def index_all : Result U32 :=
   Result.ok i8
 
 /- [arrays::update_array]:
-   Source: 'tests/src/arrays.rs', lines 184:0-184:36 -/
+   Source: 'tests/src/arrays.rs', lines 187:0-187:36 -/
 def update_array (x : Array U32 2#usize) : Result Unit :=
   do
   let (_, index_mut_back) ← Array.index_mut_usize U32 2#usize x 0#usize
@@ -282,7 +282,7 @@ def update_array (x : Array U32 2#usize) : Result Unit :=
   Result.ok ()
 
 /- [arrays::update_array_mut_borrow]:
-   Source: 'tests/src/arrays.rs', lines 187:0-187:48 -/
+   Source: 'tests/src/arrays.rs', lines 190:0-190:48 -/
 def update_array_mut_borrow
   (x : Array U32 2#usize) : Result (Array U32 2#usize) :=
   do
@@ -290,14 +290,14 @@ def update_array_mut_borrow
   index_mut_back 1#u32
 
 /- [arrays::update_mut_slice]:
-   Source: 'tests/src/arrays.rs', lines 190:0-190:38 -/
+   Source: 'tests/src/arrays.rs', lines 193:0-193:38 -/
 def update_mut_slice (x : Slice U32) : Result (Slice U32) :=
   do
   let (_, index_mut_back) ← Slice.index_mut_usize U32 x 0#usize
   index_mut_back 1#u32
 
 /- [arrays::update_all]:
-   Source: 'tests/src/arrays.rs', lines 194:0-194:19 -/
+   Source: 'tests/src/arrays.rs', lines 197:0-197:19 -/
 def update_all : Result Unit :=
   do
   let _ ← update_array (Array.make U32 2#usize [ 0#u32, 0#u32 ])
@@ -309,7 +309,7 @@ def update_all : Result Unit :=
   Result.ok ()
 
 /- [arrays::range_all]:
-   Source: 'tests/src/arrays.rs', lines 205:0-205:18 -/
+   Source: 'tests/src/arrays.rs', lines 208:0-208:18 -/
 def range_all : Result Unit :=
   do
   let (s, index_mut_back) ←
@@ -323,12 +323,12 @@ def range_all : Result Unit :=
   Result.ok ()
 
 /- [arrays::deref_array_borrow]:
-   Source: 'tests/src/arrays.rs', lines 214:0-214:46 -/
+   Source: 'tests/src/arrays.rs', lines 217:0-217:46 -/
 def deref_array_borrow (x : Array U32 2#usize) : Result U32 :=
   Array.index_usize U32 2#usize x 0#usize
 
 /- [arrays::deref_array_mut_borrow]:
-   Source: 'tests/src/arrays.rs', lines 219:0-219:54 -/
+   Source: 'tests/src/arrays.rs', lines 222:0-222:54 -/
 def deref_array_mut_borrow
   (x : Array U32 2#usize) : Result (U32 × (Array U32 2#usize)) :=
   do
@@ -336,17 +336,17 @@ def deref_array_mut_borrow
   Result.ok (i, x)
 
 /- [arrays::take_array_t]:
-   Source: 'tests/src/arrays.rs', lines 227:0-227:31 -/
+   Source: 'tests/src/arrays.rs', lines 230:0-230:31 -/
 def take_array_t (a : Array AB 2#usize) : Result Unit :=
   Result.ok ()
 
 /- [arrays::non_copyable_array]:
-   Source: 'tests/src/arrays.rs', lines 229:0-229:27 -/
+   Source: 'tests/src/arrays.rs', lines 232:0-232:27 -/
 def non_copyable_array : Result Unit :=
   take_array_t (Array.make AB 2#usize [ AB.A, AB.B ])
 
 /- [arrays::sum]: loop 0:
-   Source: 'tests/src/arrays.rs', lines 242:0-250:1 -/
+   Source: 'tests/src/arrays.rs', lines 245:0-253:1 -/
 divergent def sum_loop (s : Slice U32) (sum1 : U32) (i : Usize) : Result U32 :=
   let i1 := Slice.len U32 s
   if i < i1
@@ -359,12 +359,12 @@ divergent def sum_loop (s : Slice U32) (sum1 : U32) (i : Usize) : Result U32 :=
   else Result.ok sum1
 
 /- [arrays::sum]:
-   Source: 'tests/src/arrays.rs', lines 242:0-242:28 -/
+   Source: 'tests/src/arrays.rs', lines 245:0-245:28 -/
 def sum (s : Slice U32) : Result U32 :=
   sum_loop s 0#u32 0#usize
 
 /- [arrays::sum2]: loop 0:
-   Source: 'tests/src/arrays.rs', lines 252:0-261:1 -/
+   Source: 'tests/src/arrays.rs', lines 255:0-264:1 -/
 divergent def sum2_loop
   (s : Slice U32) (s2 : Slice U32) (sum1 : U32) (i : Usize) : Result U32 :=
   let i1 := Slice.len U32 s
@@ -380,7 +380,7 @@ divergent def sum2_loop
   else Result.ok sum1
 
 /- [arrays::sum2]:
-   Source: 'tests/src/arrays.rs', lines 252:0-252:41 -/
+   Source: 'tests/src/arrays.rs', lines 255:0-255:41 -/
 def sum2 (s : Slice U32) (s2 : Slice U32) : Result U32 :=
   let i := Slice.len U32 s
   let i1 := Slice.len U32 s2
@@ -389,7 +389,7 @@ def sum2 (s : Slice U32) (s2 : Slice U32) : Result U32 :=
   else sum2_loop s s2 0#u32 0#usize
 
 /- [arrays::f0]:
-   Source: 'tests/src/arrays.rs', lines 263:0-263:11 -/
+   Source: 'tests/src/arrays.rs', lines 266:0-266:11 -/
 def f0 : Result Unit :=
   do
   let (s, to_slice_mut_back) ←
@@ -400,7 +400,7 @@ def f0 : Result Unit :=
   Result.ok ()
 
 /- [arrays::f1]:
-   Source: 'tests/src/arrays.rs', lines 268:0-268:11 -/
+   Source: 'tests/src/arrays.rs', lines 271:0-271:11 -/
 def f1 : Result Unit :=
   do
   let (_, index_mut_back) ←
@@ -410,12 +410,12 @@ def f1 : Result Unit :=
   Result.ok ()
 
 /- [arrays::f2]:
-   Source: 'tests/src/arrays.rs', lines 273:0-273:17 -/
+   Source: 'tests/src/arrays.rs', lines 276:0-276:17 -/
 def f2 (i : U32) : Result Unit :=
   Result.ok ()
 
 /- [arrays::f4]:
-   Source: 'tests/src/arrays.rs', lines 282:0-282:54 -/
+   Source: 'tests/src/arrays.rs', lines 285:0-285:54 -/
 def f4 (x : Array U32 32#usize) (y : Usize) (z : Usize) : Result (Slice U32) :=
   core.array.Array.index U32 (core.ops.range.Range Usize) 32#usize
     (core.ops.index.IndexSliceTIInst U32 (core.ops.range.Range Usize)
@@ -423,7 +423,7 @@ def f4 (x : Array U32 32#usize) (y : Usize) (z : Usize) : Result (Slice U32) :=
     { start := y, end_ := z }
 
 /- [arrays::f3]:
-   Source: 'tests/src/arrays.rs', lines 275:0-275:18 -/
+   Source: 'tests/src/arrays.rs', lines 278:0-278:18 -/
 def f3 : Result U32 :=
   do
   let i ←
@@ -437,17 +437,17 @@ def f3 : Result U32 :=
   sum2 s s1
 
 /- [arrays::SZ]
-   Source: 'tests/src/arrays.rs', lines 286:0-286:19 -/
+   Source: 'tests/src/arrays.rs', lines 289:0-289:19 -/
 def SZ_body : Result Usize := Result.ok 32#usize
 def SZ : Usize := eval_global SZ_body
 
 /- [arrays::f5]:
-   Source: 'tests/src/arrays.rs', lines 289:0-289:31 -/
+   Source: 'tests/src/arrays.rs', lines 292:0-292:31 -/
 def f5 (x : Array U32 32#usize) : Result U32 :=
   Array.index_usize U32 32#usize x 0#usize
 
 /- [arrays::ite]:
-   Source: 'tests/src/arrays.rs', lines 294:0-294:12 -/
+   Source: 'tests/src/arrays.rs', lines 297:0-297:12 -/
 def ite : Result Unit :=
   do
   let (s, to_slice_mut_back) ←
@@ -461,7 +461,7 @@ def ite : Result Unit :=
   Result.ok ()
 
 /- [arrays::zero_slice]: loop 0:
-   Source: 'tests/src/arrays.rs', lines 303:0-310:1 -/
+   Source: 'tests/src/arrays.rs', lines 306:0-313:1 -/
 divergent def zero_slice_loop
   (a : Slice U8) (i : Usize) (len : Usize) : Result (Slice U8) :=
   if i < len
@@ -474,13 +474,13 @@ divergent def zero_slice_loop
   else Result.ok a
 
 /- [arrays::zero_slice]:
-   Source: 'tests/src/arrays.rs', lines 303:0-303:31 -/
+   Source: 'tests/src/arrays.rs', lines 306:0-306:31 -/
 def zero_slice (a : Slice U8) : Result (Slice U8) :=
   let len := Slice.len U8 a
   zero_slice_loop a 0#usize len
 
 /- [arrays::iter_mut_slice]: loop 0:
-   Source: 'tests/src/arrays.rs', lines 312:0-318:1 -/
+   Source: 'tests/src/arrays.rs', lines 315:0-321:1 -/
 divergent def iter_mut_slice_loop (len : Usize) (i : Usize) : Result Unit :=
   if i < len
   then do
@@ -489,7 +489,7 @@ divergent def iter_mut_slice_loop (len : Usize) (i : Usize) : Result Unit :=
   else Result.ok ()
 
 /- [arrays::iter_mut_slice]:
-   Source: 'tests/src/arrays.rs', lines 312:0-312:35 -/
+   Source: 'tests/src/arrays.rs', lines 315:0-315:35 -/
 def iter_mut_slice (a : Slice U8) : Result (Slice U8) :=
   do
   let len := Slice.len U8 a
@@ -497,7 +497,7 @@ def iter_mut_slice (a : Slice U8) : Result (Slice U8) :=
   Result.ok a
 
 /- [arrays::sum_mut_slice]: loop 0:
-   Source: 'tests/src/arrays.rs', lines 320:0-328:1 -/
+   Source: 'tests/src/arrays.rs', lines 323:0-331:1 -/
 divergent def sum_mut_slice_loop
   (a : Slice U32) (i : Usize) (s : U32) : Result U32 :=
   let i1 := Slice.len U32 a
@@ -511,7 +511,7 @@ divergent def sum_mut_slice_loop
   else Result.ok s
 
 /- [arrays::sum_mut_slice]:
-   Source: 'tests/src/arrays.rs', lines 320:0-320:42 -/
+   Source: 'tests/src/arrays.rs', lines 323:0-323:42 -/
 def sum_mut_slice (a : Slice U32) : Result (U32 × (Slice U32)) :=
   do
   let i ← sum_mut_slice_loop a 0#usize 0#u32

--- a/tests/lean/Bitwise.lean
+++ b/tests/lean/Bitwise.lean
@@ -6,31 +6,31 @@ open Primitives
 namespace bitwise
 
 /- [bitwise::shift_u32]:
-   Source: 'tests/src/bitwise.rs', lines 3:0-3:31 -/
+   Source: 'tests/src/bitwise.rs', lines 4:0-4:31 -/
 def shift_u32 (a : U32) : Result U32 :=
   do
   let t ← a >>> 16#usize
   t <<< 16#usize
 
 /- [bitwise::shift_i32]:
-   Source: 'tests/src/bitwise.rs', lines 10:0-10:31 -/
+   Source: 'tests/src/bitwise.rs', lines 11:0-11:31 -/
 def shift_i32 (a : I32) : Result I32 :=
   do
   let t ← a >>> 16#isize
   t <<< 16#isize
 
 /- [bitwise::xor_u32]:
-   Source: 'tests/src/bitwise.rs', lines 17:0-17:37 -/
+   Source: 'tests/src/bitwise.rs', lines 18:0-18:37 -/
 def xor_u32 (a : U32) (b : U32) : Result U32 :=
   Result.ok (a ^^^ b)
 
 /- [bitwise::or_u32]:
-   Source: 'tests/src/bitwise.rs', lines 21:0-21:36 -/
+   Source: 'tests/src/bitwise.rs', lines 22:0-22:36 -/
 def or_u32 (a : U32) (b : U32) : Result U32 :=
   Result.ok (a ||| b)
 
 /- [bitwise::and_u32]:
-   Source: 'tests/src/bitwise.rs', lines 25:0-25:37 -/
+   Source: 'tests/src/bitwise.rs', lines 26:0-26:37 -/
 def and_u32 (a : U32) (b : U32) : Result U32 :=
   Result.ok (a &&& b)
 

--- a/tests/lean/Constants.lean
+++ b/tests/lean/Constants.lean
@@ -6,123 +6,123 @@ open Primitives
 namespace constants
 
 /- [constants::X0]
-   Source: 'tests/src/constants.rs', lines 5:0-5:17 -/
+   Source: 'tests/src/constants.rs', lines 7:0-7:17 -/
 def X0_body : Result U32 := Result.ok 0#u32
 def X0 : U32 := eval_global X0_body
 
 /- [constants::X1]
-   Source: 'tests/src/constants.rs', lines 7:0-7:17 -/
+   Source: 'tests/src/constants.rs', lines 9:0-9:17 -/
 def X1_body : Result U32 := Result.ok core_u32_max
 def X1 : U32 := eval_global X1_body
 
 /- [constants::X2]
-   Source: 'tests/src/constants.rs', lines 10:0-10:17 -/
+   Source: 'tests/src/constants.rs', lines 12:0-12:17 -/
 def X2_body : Result U32 := Result.ok 3#u32
 def X2 : U32 := eval_global X2_body
 
 /- [constants::incr]:
-   Source: 'tests/src/constants.rs', lines 17:0-17:32 -/
+   Source: 'tests/src/constants.rs', lines 19:0-19:32 -/
 def incr (n : U32) : Result U32 :=
   n + 1#u32
 
 /- [constants::X3]
-   Source: 'tests/src/constants.rs', lines 15:0-15:17 -/
+   Source: 'tests/src/constants.rs', lines 17:0-17:17 -/
 def X3_body : Result U32 := incr 32#u32
 def X3 : U32 := eval_global X3_body
 
 /- [constants::mk_pair0]:
-   Source: 'tests/src/constants.rs', lines 23:0-23:51 -/
+   Source: 'tests/src/constants.rs', lines 25:0-25:51 -/
 def mk_pair0 (x : U32) (y : U32) : Result (U32 × U32) :=
   Result.ok (x, y)
 
 /- [constants::Pair]
-   Source: 'tests/src/constants.rs', lines 36:0-36:23 -/
+   Source: 'tests/src/constants.rs', lines 38:0-38:23 -/
 structure Pair (T1 T2 : Type) where
   x : T1
   y : T2
 
 /- [constants::mk_pair1]:
-   Source: 'tests/src/constants.rs', lines 27:0-27:55 -/
+   Source: 'tests/src/constants.rs', lines 29:0-29:55 -/
 def mk_pair1 (x : U32) (y : U32) : Result (Pair U32 U32) :=
   Result.ok { x := x, y := y }
 
 /- [constants::P0]
-   Source: 'tests/src/constants.rs', lines 31:0-31:24 -/
+   Source: 'tests/src/constants.rs', lines 33:0-33:24 -/
 def P0_body : Result (U32 × U32) := mk_pair0 0#u32 1#u32
 def P0 : (U32 × U32) := eval_global P0_body
 
 /- [constants::P1]
-   Source: 'tests/src/constants.rs', lines 32:0-32:28 -/
+   Source: 'tests/src/constants.rs', lines 34:0-34:28 -/
 def P1_body : Result (Pair U32 U32) := mk_pair1 0#u32 1#u32
 def P1 : Pair U32 U32 := eval_global P1_body
 
 /- [constants::P2]
-   Source: 'tests/src/constants.rs', lines 33:0-33:24 -/
+   Source: 'tests/src/constants.rs', lines 35:0-35:24 -/
 def P2_body : Result (U32 × U32) := Result.ok (0#u32, 1#u32)
 def P2 : (U32 × U32) := eval_global P2_body
 
 /- [constants::P3]
-   Source: 'tests/src/constants.rs', lines 34:0-34:28 -/
+   Source: 'tests/src/constants.rs', lines 36:0-36:28 -/
 def P3_body : Result (Pair U32 U32) := Result.ok { x := 0#u32, y := 1#u32 }
 def P3 : Pair U32 U32 := eval_global P3_body
 
 /- [constants::Wrap]
-   Source: 'tests/src/constants.rs', lines 49:0-49:18 -/
+   Source: 'tests/src/constants.rs', lines 51:0-51:18 -/
 structure Wrap (T : Type) where
   value : T
 
 /- [constants::{constants::Wrap<T>}::new]:
-   Source: 'tests/src/constants.rs', lines 54:4-54:41 -/
+   Source: 'tests/src/constants.rs', lines 56:4-56:41 -/
 def Wrap.new (T : Type) (value : T) : Result (Wrap T) :=
   Result.ok { value := value }
 
 /- [constants::Y]
-   Source: 'tests/src/constants.rs', lines 41:0-41:22 -/
+   Source: 'tests/src/constants.rs', lines 43:0-43:22 -/
 def Y_body : Result (Wrap I32) := Wrap.new I32 2#i32
 def Y : Wrap I32 := eval_global Y_body
 
 /- [constants::unwrap_y]:
-   Source: 'tests/src/constants.rs', lines 43:0-43:30 -/
+   Source: 'tests/src/constants.rs', lines 45:0-45:30 -/
 def unwrap_y : Result I32 :=
   Result.ok Y.value
 
 /- [constants::YVAL]
-   Source: 'tests/src/constants.rs', lines 47:0-47:19 -/
+   Source: 'tests/src/constants.rs', lines 49:0-49:19 -/
 def YVAL_body : Result I32 := unwrap_y
 def YVAL : I32 := eval_global YVAL_body
 
 /- [constants::get_z1::Z1]
-   Source: 'tests/src/constants.rs', lines 62:4-62:17 -/
+   Source: 'tests/src/constants.rs', lines 64:4-64:17 -/
 def get_z1.Z1_body : Result I32 := Result.ok 3#i32
 def get_z1.Z1 : I32 := eval_global get_z1.Z1_body
 
 /- [constants::get_z1]:
-   Source: 'tests/src/constants.rs', lines 61:0-61:28 -/
+   Source: 'tests/src/constants.rs', lines 63:0-63:28 -/
 def get_z1 : Result I32 :=
   Result.ok get_z1.Z1
 
 /- [constants::add]:
-   Source: 'tests/src/constants.rs', lines 66:0-66:39 -/
+   Source: 'tests/src/constants.rs', lines 68:0-68:39 -/
 def add (a : I32) (b : I32) : Result I32 :=
   a + b
 
 /- [constants::Q1]
-   Source: 'tests/src/constants.rs', lines 74:0-74:17 -/
+   Source: 'tests/src/constants.rs', lines 76:0-76:17 -/
 def Q1_body : Result I32 := Result.ok 5#i32
 def Q1 : I32 := eval_global Q1_body
 
 /- [constants::Q2]
-   Source: 'tests/src/constants.rs', lines 75:0-75:17 -/
+   Source: 'tests/src/constants.rs', lines 77:0-77:17 -/
 def Q2_body : Result I32 := Result.ok Q1
 def Q2 : I32 := eval_global Q2_body
 
 /- [constants::Q3]
-   Source: 'tests/src/constants.rs', lines 76:0-76:17 -/
+   Source: 'tests/src/constants.rs', lines 78:0-78:17 -/
 def Q3_body : Result I32 := add Q2 3#i32
 def Q3 : I32 := eval_global Q3_body
 
 /- [constants::get_z2]:
-   Source: 'tests/src/constants.rs', lines 70:0-70:28 -/
+   Source: 'tests/src/constants.rs', lines 72:0-72:28 -/
 def get_z2 : Result I32 :=
   do
   let i ← get_z1
@@ -130,37 +130,37 @@ def get_z2 : Result I32 :=
   add Q1 i1
 
 /- [constants::S1]
-   Source: 'tests/src/constants.rs', lines 80:0-80:18 -/
+   Source: 'tests/src/constants.rs', lines 82:0-82:18 -/
 def S1_body : Result U32 := Result.ok 6#u32
 def S1 : U32 := eval_global S1_body
 
 /- [constants::S2]
-   Source: 'tests/src/constants.rs', lines 81:0-81:18 -/
+   Source: 'tests/src/constants.rs', lines 83:0-83:18 -/
 def S2_body : Result U32 := incr S1
 def S2 : U32 := eval_global S2_body
 
 /- [constants::S3]
-   Source: 'tests/src/constants.rs', lines 82:0-82:29 -/
+   Source: 'tests/src/constants.rs', lines 84:0-84:29 -/
 def S3_body : Result (Pair U32 U32) := Result.ok P3
 def S3 : Pair U32 U32 := eval_global S3_body
 
 /- [constants::S4]
-   Source: 'tests/src/constants.rs', lines 83:0-83:29 -/
+   Source: 'tests/src/constants.rs', lines 85:0-85:29 -/
 def S4_body : Result (Pair U32 U32) := mk_pair1 7#u32 8#u32
 def S4 : Pair U32 U32 := eval_global S4_body
 
 /- [constants::V]
-   Source: 'tests/src/constants.rs', lines 86:0-86:31 -/
+   Source: 'tests/src/constants.rs', lines 88:0-88:31 -/
 structure V (T : Type) (N : Usize) where
   x : Array T N
 
 /- [constants::{constants::V<T, N>#1}::LEN]
-   Source: 'tests/src/constants.rs', lines 91:4-91:24 -/
+   Source: 'tests/src/constants.rs', lines 93:4-93:24 -/
 def V.LEN_body (T : Type) (N : Usize) : Result Usize := Result.ok N
 def V.LEN (T : Type) (N : Usize) : Usize := eval_global (V.LEN_body T N)
 
 /- [constants::use_v]:
-   Source: 'tests/src/constants.rs', lines 94:0-94:42 -/
+   Source: 'tests/src/constants.rs', lines 96:0-96:42 -/
 def use_v (T : Type) (N : Usize) : Result Usize :=
   Result.ok (V.LEN T N)
 

--- a/tests/lean/Demo/Demo.lean
+++ b/tests/lean/Demo/Demo.lean
@@ -6,7 +6,7 @@ open Primitives
 namespace demo
 
 /- [demo::choose]:
-   Source: 'tests/src/demo.rs', lines 5:0-5:70 -/
+   Source: 'tests/src/demo.rs', lines 6:0-6:70 -/
 def choose
   (T : Type) (b : Bool) (x : T) (y : T) :
   Result (T × (T → Result (T × T)))
@@ -18,26 +18,26 @@ def choose
        Result.ok (y, back)
 
 /- [demo::mul2_add1]:
-   Source: 'tests/src/demo.rs', lines 13:0-13:31 -/
+   Source: 'tests/src/demo.rs', lines 14:0-14:31 -/
 def mul2_add1 (x : U32) : Result U32 :=
   do
   let i ← x + x
   i + 1#u32
 
 /- [demo::use_mul2_add1]:
-   Source: 'tests/src/demo.rs', lines 17:0-17:43 -/
+   Source: 'tests/src/demo.rs', lines 18:0-18:43 -/
 def use_mul2_add1 (x : U32) (y : U32) : Result U32 :=
   do
   let i ← mul2_add1 x
   i + y
 
 /- [demo::incr]:
-   Source: 'tests/src/demo.rs', lines 21:0-21:31 -/
+   Source: 'tests/src/demo.rs', lines 22:0-22:31 -/
 def incr (x : U32) : Result U32 :=
   x + 1#u32
 
 /- [demo::use_incr]:
-   Source: 'tests/src/demo.rs', lines 25:0-25:17 -/
+   Source: 'tests/src/demo.rs', lines 26:0-26:17 -/
 def use_incr : Result Unit :=
   do
   let x ← incr 0#u32
@@ -46,13 +46,13 @@ def use_incr : Result Unit :=
   Result.ok ()
 
 /- [demo::CList]
-   Source: 'tests/src/demo.rs', lines 34:0-34:17 -/
+   Source: 'tests/src/demo.rs', lines 35:0-35:17 -/
 inductive CList (T : Type) :=
 | CCons : T → CList T → CList T
 | CNil : CList T
 
 /- [demo::list_nth]:
-   Source: 'tests/src/demo.rs', lines 39:0-39:56 -/
+   Source: 'tests/src/demo.rs', lines 40:0-40:56 -/
 divergent def list_nth (T : Type) (l : CList T) (i : U32) : Result T :=
   match l with
   | CList.CCons x tl =>
@@ -64,7 +64,7 @@ divergent def list_nth (T : Type) (l : CList T) (i : U32) : Result T :=
   | CList.CNil => Result.fail .panic
 
 /- [demo::list_nth_mut]:
-   Source: 'tests/src/demo.rs', lines 54:0-54:68 -/
+   Source: 'tests/src/demo.rs', lines 55:0-55:68 -/
 divergent def list_nth_mut
   (T : Type) (l : CList T) (i : U32) :
   Result (T × (T → Result (CList T)))
@@ -88,7 +88,7 @@ divergent def list_nth_mut
   | CList.CNil => Result.fail .panic
 
 /- [demo::list_nth_mut1]: loop 0:
-   Source: 'tests/src/demo.rs', lines 69:0-78:1 -/
+   Source: 'tests/src/demo.rs', lines 70:0-79:1 -/
 divergent def list_nth_mut1_loop
   (T : Type) (l : CList T) (i : U32) :
   Result (T × (T → Result (CList T)))
@@ -111,7 +111,7 @@ divergent def list_nth_mut1_loop
   | CList.CNil => Result.fail .panic
 
 /- [demo::list_nth_mut1]:
-   Source: 'tests/src/demo.rs', lines 69:0-69:77 -/
+   Source: 'tests/src/demo.rs', lines 70:0-70:77 -/
 def list_nth_mut1
   (T : Type) (l : CList T) (i : U32) :
   Result (T × (T → Result (CList T)))
@@ -119,7 +119,7 @@ def list_nth_mut1
   list_nth_mut1_loop T l i
 
 /- [demo::i32_id]:
-   Source: 'tests/src/demo.rs', lines 80:0-80:28 -/
+   Source: 'tests/src/demo.rs', lines 81:0-81:28 -/
 divergent def i32_id (i : I32) : Result I32 :=
   if i = 0#i32
   then Result.ok 0#i32
@@ -129,7 +129,7 @@ divergent def i32_id (i : I32) : Result I32 :=
        i2 + 1#i32
 
 /- [demo::list_tail]:
-   Source: 'tests/src/demo.rs', lines 88:0-88:64 -/
+   Source: 'tests/src/demo.rs', lines 89:0-89:64 -/
 divergent def list_tail
   (T : Type) (l : CList T) :
   Result ((CList T) × (CList T → Result (CList T)))
@@ -147,25 +147,25 @@ divergent def list_tail
   | CList.CNil => Result.ok (CList.CNil, Result.ok)
 
 /- Trait declaration: [demo::Counter]
-   Source: 'tests/src/demo.rs', lines 97:0-97:17 -/
+   Source: 'tests/src/demo.rs', lines 98:0-98:17 -/
 structure Counter (Self : Type) where
   incr : Self → Result (Usize × Self)
 
 /- [demo::{(demo::Counter for usize)}::incr]:
-   Source: 'tests/src/demo.rs', lines 102:4-102:31 -/
+   Source: 'tests/src/demo.rs', lines 103:4-103:31 -/
 def CounterUsize.incr (self : Usize) : Result (Usize × Usize) :=
   do
   let self1 ← self + 1#usize
   Result.ok (self, self1)
 
 /- Trait implementation: [demo::{(demo::Counter for usize)}]
-   Source: 'tests/src/demo.rs', lines 101:0-101:22 -/
+   Source: 'tests/src/demo.rs', lines 102:0-102:22 -/
 def CounterUsize : Counter Usize := {
   incr := CounterUsize.incr
 }
 
 /- [demo::use_counter]:
-   Source: 'tests/src/demo.rs', lines 109:0-109:59 -/
+   Source: 'tests/src/demo.rs', lines 110:0-110:59 -/
 def use_counter
   (T : Type) (CounterInst : Counter T) (cnt : T) : Result (Usize × T) :=
   CounterInst.incr cnt

--- a/tests/lean/External/Funs.lean
+++ b/tests/lean/External/Funs.lean
@@ -15,12 +15,12 @@ def core.marker.CopyU32 : core.marker.Copy U32 := {
 }
 
 /- [external::use_get]:
-   Source: 'tests/src/external.rs', lines 5:0-5:37 -/
+   Source: 'tests/src/external.rs', lines 8:0-8:37 -/
 def use_get (rc : core.cell.Cell U32) (st : State) : Result (State × U32) :=
   core.cell.Cell.get U32 core.marker.CopyU32 rc st
 
 /- [external::incr]:
-   Source: 'tests/src/external.rs', lines 9:0-9:31 -/
+   Source: 'tests/src/external.rs', lines 12:0-12:31 -/
 def incr
   (rc : core.cell.Cell U32) (st : State) :
   Result (State × (core.cell.Cell U32))

--- a/tests/lean/Hashmap/Funs.lean
+++ b/tests/lean/Hashmap/Funs.lean
@@ -7,12 +7,12 @@ open Primitives
 namespace hashmap
 
 /- [hashmap::hash_key]:
-   Source: 'tests/src/hashmap.rs', lines 27:0-27:32 -/
+   Source: 'tests/src/hashmap.rs', lines 35:0-35:32 -/
 def hash_key (k : Usize) : Result Usize :=
   Result.ok k
 
 /- [hashmap::{hashmap::HashMap<T>}::allocate_slots]: loop 0:
-   Source: 'tests/src/hashmap.rs', lines 50:4-56:5 -/
+   Source: 'tests/src/hashmap.rs', lines 58:4-64:5 -/
 divergent def HashMap.allocate_slots_loop
   (T : Type) (slots : alloc.vec.Vec (List T)) (n : Usize) :
   Result (alloc.vec.Vec (List T))
@@ -26,7 +26,7 @@ divergent def HashMap.allocate_slots_loop
   else Result.ok slots
 
 /- [hashmap::{hashmap::HashMap<T>}::allocate_slots]:
-   Source: 'tests/src/hashmap.rs', lines 50:4-50:76 -/
+   Source: 'tests/src/hashmap.rs', lines 58:4-58:76 -/
 def HashMap.allocate_slots
   (T : Type) (slots : alloc.vec.Vec (List T)) (n : Usize) :
   Result (alloc.vec.Vec (List T))
@@ -34,7 +34,7 @@ def HashMap.allocate_slots
   HashMap.allocate_slots_loop T slots n
 
 /- [hashmap::{hashmap::HashMap<T>}::new_with_capacity]:
-   Source: 'tests/src/hashmap.rs', lines 59:4-63:13 -/
+   Source: 'tests/src/hashmap.rs', lines 67:4-71:13 -/
 def HashMap.new_with_capacity
   (T : Type) (capacity : Usize) (max_load_dividend : Usize)
   (max_load_divisor : Usize) :
@@ -53,12 +53,12 @@ def HashMap.new_with_capacity
     }
 
 /- [hashmap::{hashmap::HashMap<T>}::new]:
-   Source: 'tests/src/hashmap.rs', lines 75:4-75:24 -/
+   Source: 'tests/src/hashmap.rs', lines 83:4-83:24 -/
 def HashMap.new (T : Type) : Result (HashMap T) :=
   HashMap.new_with_capacity T 32#usize 4#usize 5#usize
 
 /- [hashmap::{hashmap::HashMap<T>}::clear]: loop 0:
-   Source: 'tests/src/hashmap.rs', lines 80:4-88:5 -/
+   Source: 'tests/src/hashmap.rs', lines 88:4-96:5 -/
 divergent def HashMap.clear_loop
   (T : Type) (slots : alloc.vec.Vec (List T)) (i : Usize) :
   Result (alloc.vec.Vec (List T))
@@ -76,19 +76,19 @@ divergent def HashMap.clear_loop
   else Result.ok slots
 
 /- [hashmap::{hashmap::HashMap<T>}::clear]:
-   Source: 'tests/src/hashmap.rs', lines 80:4-80:27 -/
+   Source: 'tests/src/hashmap.rs', lines 88:4-88:27 -/
 def HashMap.clear (T : Type) (self : HashMap T) : Result (HashMap T) :=
   do
   let hm ← HashMap.clear_loop T self.slots 0#usize
   Result.ok { self with num_entries := 0#usize, slots := hm }
 
 /- [hashmap::{hashmap::HashMap<T>}::len]:
-   Source: 'tests/src/hashmap.rs', lines 90:4-90:30 -/
+   Source: 'tests/src/hashmap.rs', lines 98:4-98:30 -/
 def HashMap.len (T : Type) (self : HashMap T) : Result Usize :=
   Result.ok self.num_entries
 
 /- [hashmap::{hashmap::HashMap<T>}::insert_in_list]: loop 0:
-   Source: 'tests/src/hashmap.rs', lines 97:4-114:5 -/
+   Source: 'tests/src/hashmap.rs', lines 105:4-122:5 -/
 divergent def HashMap.insert_in_list_loop
   (T : Type) (key : Usize) (value : T) (ls : List T) :
   Result (Bool × (List T))
@@ -104,7 +104,7 @@ divergent def HashMap.insert_in_list_loop
   | List.Nil => Result.ok (true, List.Cons key value List.Nil)
 
 /- [hashmap::{hashmap::HashMap<T>}::insert_in_list]:
-   Source: 'tests/src/hashmap.rs', lines 97:4-97:71 -/
+   Source: 'tests/src/hashmap.rs', lines 105:4-105:71 -/
 def HashMap.insert_in_list
   (T : Type) (key : Usize) (value : T) (ls : List T) :
   Result (Bool × (List T))
@@ -112,7 +112,7 @@ def HashMap.insert_in_list
   HashMap.insert_in_list_loop T key value ls
 
 /- [hashmap::{hashmap::HashMap<T>}::insert_no_resize]:
-   Source: 'tests/src/hashmap.rs', lines 117:4-117:54 -/
+   Source: 'tests/src/hashmap.rs', lines 125:4-125:54 -/
 def HashMap.insert_no_resize
   (T : Type) (self : HashMap T) (key : Usize) (value : T) :
   Result (HashMap T)
@@ -136,7 +136,7 @@ def HashMap.insert_no_resize
        Result.ok { self with slots := v }
 
 /- [hashmap::{hashmap::HashMap<T>}::move_elements_from_list]: loop 0:
-   Source: 'tests/src/hashmap.rs', lines 183:4-196:5 -/
+   Source: 'tests/src/hashmap.rs', lines 191:4-204:5 -/
 divergent def HashMap.move_elements_from_list_loop
   (T : Type) (ntable : HashMap T) (ls : List T) : Result (HashMap T) :=
   match ls with
@@ -147,13 +147,13 @@ divergent def HashMap.move_elements_from_list_loop
   | List.Nil => Result.ok ntable
 
 /- [hashmap::{hashmap::HashMap<T>}::move_elements_from_list]:
-   Source: 'tests/src/hashmap.rs', lines 183:4-183:72 -/
+   Source: 'tests/src/hashmap.rs', lines 191:4-191:72 -/
 def HashMap.move_elements_from_list
   (T : Type) (ntable : HashMap T) (ls : List T) : Result (HashMap T) :=
   HashMap.move_elements_from_list_loop T ntable ls
 
 /- [hashmap::{hashmap::HashMap<T>}::move_elements]: loop 0:
-   Source: 'tests/src/hashmap.rs', lines 171:4-180:5 -/
+   Source: 'tests/src/hashmap.rs', lines 179:4-188:5 -/
 divergent def HashMap.move_elements_loop
   (T : Type) (ntable : HashMap T) (slots : alloc.vec.Vec (List T)) (i : Usize)
   :
@@ -174,7 +174,7 @@ divergent def HashMap.move_elements_loop
   else Result.ok (ntable, slots)
 
 /- [hashmap::{hashmap::HashMap<T>}::move_elements]:
-   Source: 'tests/src/hashmap.rs', lines 171:4-171:95 -/
+   Source: 'tests/src/hashmap.rs', lines 179:4-179:95 -/
 def HashMap.move_elements
   (T : Type) (ntable : HashMap T) (slots : alloc.vec.Vec (List T)) (i : Usize)
   :
@@ -183,7 +183,7 @@ def HashMap.move_elements
   HashMap.move_elements_loop T ntable slots i
 
 /- [hashmap::{hashmap::HashMap<T>}::try_resize]:
-   Source: 'tests/src/hashmap.rs', lines 140:4-140:28 -/
+   Source: 'tests/src/hashmap.rs', lines 148:4-148:28 -/
 def HashMap.try_resize (T : Type) (self : HashMap T) : Result (HashMap T) :=
   do
   let max_usize ← Scalar.cast .Usize core_u32_max
@@ -207,7 +207,7 @@ def HashMap.try_resize (T : Type) (self : HashMap T) : Result (HashMap T) :=
   else Result.ok { self with max_load_factor := (i, i1) }
 
 /- [hashmap::{hashmap::HashMap<T>}::insert]:
-   Source: 'tests/src/hashmap.rs', lines 129:4-129:48 -/
+   Source: 'tests/src/hashmap.rs', lines 137:4-137:48 -/
 def HashMap.insert
   (T : Type) (self : HashMap T) (key : Usize) (value : T) :
   Result (HashMap T)
@@ -220,7 +220,7 @@ def HashMap.insert
   else Result.ok self1
 
 /- [hashmap::{hashmap::HashMap<T>}::contains_key_in_list]: loop 0:
-   Source: 'tests/src/hashmap.rs', lines 206:4-219:5 -/
+   Source: 'tests/src/hashmap.rs', lines 214:4-227:5 -/
 divergent def HashMap.contains_key_in_list_loop
   (T : Type) (key : Usize) (ls : List T) : Result Bool :=
   match ls with
@@ -231,13 +231,13 @@ divergent def HashMap.contains_key_in_list_loop
   | List.Nil => Result.ok false
 
 /- [hashmap::{hashmap::HashMap<T>}::contains_key_in_list]:
-   Source: 'tests/src/hashmap.rs', lines 206:4-206:68 -/
+   Source: 'tests/src/hashmap.rs', lines 214:4-214:68 -/
 def HashMap.contains_key_in_list
   (T : Type) (key : Usize) (ls : List T) : Result Bool :=
   HashMap.contains_key_in_list_loop T key ls
 
 /- [hashmap::{hashmap::HashMap<T>}::contains_key]:
-   Source: 'tests/src/hashmap.rs', lines 199:4-199:49 -/
+   Source: 'tests/src/hashmap.rs', lines 207:4-207:49 -/
 def HashMap.contains_key
   (T : Type) (self : HashMap T) (key : Usize) : Result Bool :=
   do
@@ -250,7 +250,7 @@ def HashMap.contains_key
   HashMap.contains_key_in_list T key l
 
 /- [hashmap::{hashmap::HashMap<T>}::get_in_list]: loop 0:
-   Source: 'tests/src/hashmap.rs', lines 224:4-237:5 -/
+   Source: 'tests/src/hashmap.rs', lines 232:4-245:5 -/
 divergent def HashMap.get_in_list_loop
   (T : Type) (key : Usize) (ls : List T) : Result T :=
   match ls with
@@ -261,12 +261,12 @@ divergent def HashMap.get_in_list_loop
   | List.Nil => Result.fail .panic
 
 /- [hashmap::{hashmap::HashMap<T>}::get_in_list]:
-   Source: 'tests/src/hashmap.rs', lines 224:4-224:70 -/
+   Source: 'tests/src/hashmap.rs', lines 232:4-232:70 -/
 def HashMap.get_in_list (T : Type) (key : Usize) (ls : List T) : Result T :=
   HashMap.get_in_list_loop T key ls
 
 /- [hashmap::{hashmap::HashMap<T>}::get]:
-   Source: 'tests/src/hashmap.rs', lines 239:4-239:55 -/
+   Source: 'tests/src/hashmap.rs', lines 247:4-247:55 -/
 def HashMap.get (T : Type) (self : HashMap T) (key : Usize) : Result T :=
   do
   let hash ← hash_key key
@@ -278,7 +278,7 @@ def HashMap.get (T : Type) (self : HashMap T) (key : Usize) : Result T :=
   HashMap.get_in_list T key l
 
 /- [hashmap::{hashmap::HashMap<T>}::get_mut_in_list]: loop 0:
-   Source: 'tests/src/hashmap.rs', lines 245:4-254:5 -/
+   Source: 'tests/src/hashmap.rs', lines 253:4-262:5 -/
 divergent def HashMap.get_mut_in_list_loop
   (T : Type) (ls : List T) (key : Usize) :
   Result (T × (T → Result (List T)))
@@ -301,7 +301,7 @@ divergent def HashMap.get_mut_in_list_loop
   | List.Nil => Result.fail .panic
 
 /- [hashmap::{hashmap::HashMap<T>}::get_mut_in_list]:
-   Source: 'tests/src/hashmap.rs', lines 245:4-245:86 -/
+   Source: 'tests/src/hashmap.rs', lines 253:4-253:86 -/
 def HashMap.get_mut_in_list
   (T : Type) (ls : List T) (key : Usize) :
   Result (T × (T → Result (List T)))
@@ -309,7 +309,7 @@ def HashMap.get_mut_in_list
   HashMap.get_mut_in_list_loop T ls key
 
 /- [hashmap::{hashmap::HashMap<T>}::get_mut]:
-   Source: 'tests/src/hashmap.rs', lines 257:4-257:67 -/
+   Source: 'tests/src/hashmap.rs', lines 265:4-265:67 -/
 def HashMap.get_mut
   (T : Type) (self : HashMap T) (key : Usize) :
   Result (T × (T → Result (HashMap T)))
@@ -331,7 +331,7 @@ def HashMap.get_mut
   Result.ok (t, back)
 
 /- [hashmap::{hashmap::HashMap<T>}::remove_from_list]: loop 0:
-   Source: 'tests/src/hashmap.rs', lines 265:4-291:5 -/
+   Source: 'tests/src/hashmap.rs', lines 273:4-299:5 -/
 divergent def HashMap.remove_from_list_loop
   (T : Type) (key : Usize) (ls : List T) : Result ((Option T) × (List T)) :=
   match ls with
@@ -350,13 +350,13 @@ divergent def HashMap.remove_from_list_loop
   | List.Nil => Result.ok (none, List.Nil)
 
 /- [hashmap::{hashmap::HashMap<T>}::remove_from_list]:
-   Source: 'tests/src/hashmap.rs', lines 265:4-265:69 -/
+   Source: 'tests/src/hashmap.rs', lines 273:4-273:69 -/
 def HashMap.remove_from_list
   (T : Type) (key : Usize) (ls : List T) : Result ((Option T) × (List T)) :=
   HashMap.remove_from_list_loop T key ls
 
 /- [hashmap::{hashmap::HashMap<T>}::remove]:
-   Source: 'tests/src/hashmap.rs', lines 294:4-294:52 -/
+   Source: 'tests/src/hashmap.rs', lines 302:4-302:52 -/
 def HashMap.remove
   (T : Type) (self : HashMap T) (key : Usize) :
   Result ((Option T) × (HashMap T))
@@ -381,7 +381,7 @@ def HashMap.remove
     Result.ok (some x1, { self with num_entries := i1, slots := v })
 
 /- [hashmap::test1]:
-   Source: 'tests/src/hashmap.rs', lines 315:0-315:10 -/
+   Source: 'tests/src/hashmap.rs', lines 323:0-323:10 -/
 def test1 : Result Unit :=
   do
   let hm ← HashMap.new U64

--- a/tests/lean/Hashmap/Types.lean
+++ b/tests/lean/Hashmap/Types.lean
@@ -6,13 +6,13 @@ open Primitives
 namespace hashmap
 
 /- [hashmap::List]
-   Source: 'tests/src/hashmap.rs', lines 19:0-19:16 -/
+   Source: 'tests/src/hashmap.rs', lines 27:0-27:16 -/
 inductive List (T : Type) :=
 | Cons : Usize → T → List T → List T
 | Nil : List T
 
 /- [hashmap::HashMap]
-   Source: 'tests/src/hashmap.rs', lines 35:0-35:21 -/
+   Source: 'tests/src/hashmap.rs', lines 43:0-43:21 -/
 structure HashMap (T : Type) where
   num_entries : Usize
   max_load_factor : (Usize × Usize)

--- a/tests/lean/HashmapMain/Funs.lean
+++ b/tests/lean/HashmapMain/Funs.lean
@@ -8,12 +8,12 @@ open Primitives
 namespace hashmap_main
 
 /- [hashmap_main::hashmap::hash_key]:
-   Source: 'tests/src/hashmap.rs', lines 27:0-27:32 -/
+   Source: 'tests/src/hashmap.rs', lines 35:0-35:32 -/
 def hashmap.hash_key (k : Usize) : Result Usize :=
   Result.ok k
 
 /- [hashmap_main::hashmap::{hashmap_main::hashmap::HashMap<T>}::allocate_slots]: loop 0:
-   Source: 'tests/src/hashmap.rs', lines 50:4-56:5 -/
+   Source: 'tests/src/hashmap.rs', lines 58:4-64:5 -/
 divergent def hashmap.HashMap.allocate_slots_loop
   (T : Type) (slots : alloc.vec.Vec (hashmap.List T)) (n : Usize) :
   Result (alloc.vec.Vec (hashmap.List T))
@@ -27,7 +27,7 @@ divergent def hashmap.HashMap.allocate_slots_loop
   else Result.ok slots
 
 /- [hashmap_main::hashmap::{hashmap_main::hashmap::HashMap<T>}::allocate_slots]:
-   Source: 'tests/src/hashmap.rs', lines 50:4-50:76 -/
+   Source: 'tests/src/hashmap.rs', lines 58:4-58:76 -/
 def hashmap.HashMap.allocate_slots
   (T : Type) (slots : alloc.vec.Vec (hashmap.List T)) (n : Usize) :
   Result (alloc.vec.Vec (hashmap.List T))
@@ -35,7 +35,7 @@ def hashmap.HashMap.allocate_slots
   hashmap.HashMap.allocate_slots_loop T slots n
 
 /- [hashmap_main::hashmap::{hashmap_main::hashmap::HashMap<T>}::new_with_capacity]:
-   Source: 'tests/src/hashmap.rs', lines 59:4-63:13 -/
+   Source: 'tests/src/hashmap.rs', lines 67:4-71:13 -/
 def hashmap.HashMap.new_with_capacity
   (T : Type) (capacity : Usize) (max_load_dividend : Usize)
   (max_load_divisor : Usize) :
@@ -56,12 +56,12 @@ def hashmap.HashMap.new_with_capacity
     }
 
 /- [hashmap_main::hashmap::{hashmap_main::hashmap::HashMap<T>}::new]:
-   Source: 'tests/src/hashmap.rs', lines 75:4-75:24 -/
+   Source: 'tests/src/hashmap.rs', lines 83:4-83:24 -/
 def hashmap.HashMap.new (T : Type) : Result (hashmap.HashMap T) :=
   hashmap.HashMap.new_with_capacity T 32#usize 4#usize 5#usize
 
 /- [hashmap_main::hashmap::{hashmap_main::hashmap::HashMap<T>}::clear]: loop 0:
-   Source: 'tests/src/hashmap.rs', lines 80:4-88:5 -/
+   Source: 'tests/src/hashmap.rs', lines 88:4-96:5 -/
 divergent def hashmap.HashMap.clear_loop
   (T : Type) (slots : alloc.vec.Vec (hashmap.List T)) (i : Usize) :
   Result (alloc.vec.Vec (hashmap.List T))
@@ -79,7 +79,7 @@ divergent def hashmap.HashMap.clear_loop
   else Result.ok slots
 
 /- [hashmap_main::hashmap::{hashmap_main::hashmap::HashMap<T>}::clear]:
-   Source: 'tests/src/hashmap.rs', lines 80:4-80:27 -/
+   Source: 'tests/src/hashmap.rs', lines 88:4-88:27 -/
 def hashmap.HashMap.clear
   (T : Type) (self : hashmap.HashMap T) : Result (hashmap.HashMap T) :=
   do
@@ -87,12 +87,12 @@ def hashmap.HashMap.clear
   Result.ok { self with num_entries := 0#usize, slots := hm }
 
 /- [hashmap_main::hashmap::{hashmap_main::hashmap::HashMap<T>}::len]:
-   Source: 'tests/src/hashmap.rs', lines 90:4-90:30 -/
+   Source: 'tests/src/hashmap.rs', lines 98:4-98:30 -/
 def hashmap.HashMap.len (T : Type) (self : hashmap.HashMap T) : Result Usize :=
   Result.ok self.num_entries
 
 /- [hashmap_main::hashmap::{hashmap_main::hashmap::HashMap<T>}::insert_in_list]: loop 0:
-   Source: 'tests/src/hashmap.rs', lines 97:4-114:5 -/
+   Source: 'tests/src/hashmap.rs', lines 105:4-122:5 -/
 divergent def hashmap.HashMap.insert_in_list_loop
   (T : Type) (key : Usize) (value : T) (ls : hashmap.List T) :
   Result (Bool × (hashmap.List T))
@@ -109,7 +109,7 @@ divergent def hashmap.HashMap.insert_in_list_loop
     Result.ok (true, hashmap.List.Cons key value hashmap.List.Nil)
 
 /- [hashmap_main::hashmap::{hashmap_main::hashmap::HashMap<T>}::insert_in_list]:
-   Source: 'tests/src/hashmap.rs', lines 97:4-97:71 -/
+   Source: 'tests/src/hashmap.rs', lines 105:4-105:71 -/
 def hashmap.HashMap.insert_in_list
   (T : Type) (key : Usize) (value : T) (ls : hashmap.List T) :
   Result (Bool × (hashmap.List T))
@@ -117,7 +117,7 @@ def hashmap.HashMap.insert_in_list
   hashmap.HashMap.insert_in_list_loop T key value ls
 
 /- [hashmap_main::hashmap::{hashmap_main::hashmap::HashMap<T>}::insert_no_resize]:
-   Source: 'tests/src/hashmap.rs', lines 117:4-117:54 -/
+   Source: 'tests/src/hashmap.rs', lines 125:4-125:54 -/
 def hashmap.HashMap.insert_no_resize
   (T : Type) (self : hashmap.HashMap T) (key : Usize) (value : T) :
   Result (hashmap.HashMap T)
@@ -142,7 +142,7 @@ def hashmap.HashMap.insert_no_resize
        Result.ok { self with slots := v }
 
 /- [hashmap_main::hashmap::{hashmap_main::hashmap::HashMap<T>}::move_elements_from_list]: loop 0:
-   Source: 'tests/src/hashmap.rs', lines 183:4-196:5 -/
+   Source: 'tests/src/hashmap.rs', lines 191:4-204:5 -/
 divergent def hashmap.HashMap.move_elements_from_list_loop
   (T : Type) (ntable : hashmap.HashMap T) (ls : hashmap.List T) :
   Result (hashmap.HashMap T)
@@ -155,7 +155,7 @@ divergent def hashmap.HashMap.move_elements_from_list_loop
   | hashmap.List.Nil => Result.ok ntable
 
 /- [hashmap_main::hashmap::{hashmap_main::hashmap::HashMap<T>}::move_elements_from_list]:
-   Source: 'tests/src/hashmap.rs', lines 183:4-183:72 -/
+   Source: 'tests/src/hashmap.rs', lines 191:4-191:72 -/
 def hashmap.HashMap.move_elements_from_list
   (T : Type) (ntable : hashmap.HashMap T) (ls : hashmap.List T) :
   Result (hashmap.HashMap T)
@@ -163,7 +163,7 @@ def hashmap.HashMap.move_elements_from_list
   hashmap.HashMap.move_elements_from_list_loop T ntable ls
 
 /- [hashmap_main::hashmap::{hashmap_main::hashmap::HashMap<T>}::move_elements]: loop 0:
-   Source: 'tests/src/hashmap.rs', lines 171:4-180:5 -/
+   Source: 'tests/src/hashmap.rs', lines 179:4-188:5 -/
 divergent def hashmap.HashMap.move_elements_loop
   (T : Type) (ntable : hashmap.HashMap T)
   (slots : alloc.vec.Vec (hashmap.List T)) (i : Usize) :
@@ -184,7 +184,7 @@ divergent def hashmap.HashMap.move_elements_loop
   else Result.ok (ntable, slots)
 
 /- [hashmap_main::hashmap::{hashmap_main::hashmap::HashMap<T>}::move_elements]:
-   Source: 'tests/src/hashmap.rs', lines 171:4-171:95 -/
+   Source: 'tests/src/hashmap.rs', lines 179:4-179:95 -/
 def hashmap.HashMap.move_elements
   (T : Type) (ntable : hashmap.HashMap T)
   (slots : alloc.vec.Vec (hashmap.List T)) (i : Usize) :
@@ -193,7 +193,7 @@ def hashmap.HashMap.move_elements
   hashmap.HashMap.move_elements_loop T ntable slots i
 
 /- [hashmap_main::hashmap::{hashmap_main::hashmap::HashMap<T>}::try_resize]:
-   Source: 'tests/src/hashmap.rs', lines 140:4-140:28 -/
+   Source: 'tests/src/hashmap.rs', lines 148:4-148:28 -/
 def hashmap.HashMap.try_resize
   (T : Type) (self : hashmap.HashMap T) : Result (hashmap.HashMap T) :=
   do
@@ -218,7 +218,7 @@ def hashmap.HashMap.try_resize
   else Result.ok { self with max_load_factor := (i, i1) }
 
 /- [hashmap_main::hashmap::{hashmap_main::hashmap::HashMap<T>}::insert]:
-   Source: 'tests/src/hashmap.rs', lines 129:4-129:48 -/
+   Source: 'tests/src/hashmap.rs', lines 137:4-137:48 -/
 def hashmap.HashMap.insert
   (T : Type) (self : hashmap.HashMap T) (key : Usize) (value : T) :
   Result (hashmap.HashMap T)
@@ -231,7 +231,7 @@ def hashmap.HashMap.insert
   else Result.ok self1
 
 /- [hashmap_main::hashmap::{hashmap_main::hashmap::HashMap<T>}::contains_key_in_list]: loop 0:
-   Source: 'tests/src/hashmap.rs', lines 206:4-219:5 -/
+   Source: 'tests/src/hashmap.rs', lines 214:4-227:5 -/
 divergent def hashmap.HashMap.contains_key_in_list_loop
   (T : Type) (key : Usize) (ls : hashmap.List T) : Result Bool :=
   match ls with
@@ -242,13 +242,13 @@ divergent def hashmap.HashMap.contains_key_in_list_loop
   | hashmap.List.Nil => Result.ok false
 
 /- [hashmap_main::hashmap::{hashmap_main::hashmap::HashMap<T>}::contains_key_in_list]:
-   Source: 'tests/src/hashmap.rs', lines 206:4-206:68 -/
+   Source: 'tests/src/hashmap.rs', lines 214:4-214:68 -/
 def hashmap.HashMap.contains_key_in_list
   (T : Type) (key : Usize) (ls : hashmap.List T) : Result Bool :=
   hashmap.HashMap.contains_key_in_list_loop T key ls
 
 /- [hashmap_main::hashmap::{hashmap_main::hashmap::HashMap<T>}::contains_key]:
-   Source: 'tests/src/hashmap.rs', lines 199:4-199:49 -/
+   Source: 'tests/src/hashmap.rs', lines 207:4-207:49 -/
 def hashmap.HashMap.contains_key
   (T : Type) (self : hashmap.HashMap T) (key : Usize) : Result Bool :=
   do
@@ -262,7 +262,7 @@ def hashmap.HashMap.contains_key
   hashmap.HashMap.contains_key_in_list T key l
 
 /- [hashmap_main::hashmap::{hashmap_main::hashmap::HashMap<T>}::get_in_list]: loop 0:
-   Source: 'tests/src/hashmap.rs', lines 224:4-237:5 -/
+   Source: 'tests/src/hashmap.rs', lines 232:4-245:5 -/
 divergent def hashmap.HashMap.get_in_list_loop
   (T : Type) (key : Usize) (ls : hashmap.List T) : Result T :=
   match ls with
@@ -273,13 +273,13 @@ divergent def hashmap.HashMap.get_in_list_loop
   | hashmap.List.Nil => Result.fail .panic
 
 /- [hashmap_main::hashmap::{hashmap_main::hashmap::HashMap<T>}::get_in_list]:
-   Source: 'tests/src/hashmap.rs', lines 224:4-224:70 -/
+   Source: 'tests/src/hashmap.rs', lines 232:4-232:70 -/
 def hashmap.HashMap.get_in_list
   (T : Type) (key : Usize) (ls : hashmap.List T) : Result T :=
   hashmap.HashMap.get_in_list_loop T key ls
 
 /- [hashmap_main::hashmap::{hashmap_main::hashmap::HashMap<T>}::get]:
-   Source: 'tests/src/hashmap.rs', lines 239:4-239:55 -/
+   Source: 'tests/src/hashmap.rs', lines 247:4-247:55 -/
 def hashmap.HashMap.get
   (T : Type) (self : hashmap.HashMap T) (key : Usize) : Result T :=
   do
@@ -293,7 +293,7 @@ def hashmap.HashMap.get
   hashmap.HashMap.get_in_list T key l
 
 /- [hashmap_main::hashmap::{hashmap_main::hashmap::HashMap<T>}::get_mut_in_list]: loop 0:
-   Source: 'tests/src/hashmap.rs', lines 245:4-254:5 -/
+   Source: 'tests/src/hashmap.rs', lines 253:4-262:5 -/
 divergent def hashmap.HashMap.get_mut_in_list_loop
   (T : Type) (ls : hashmap.List T) (key : Usize) :
   Result (T × (T → Result (hashmap.List T)))
@@ -316,7 +316,7 @@ divergent def hashmap.HashMap.get_mut_in_list_loop
   | hashmap.List.Nil => Result.fail .panic
 
 /- [hashmap_main::hashmap::{hashmap_main::hashmap::HashMap<T>}::get_mut_in_list]:
-   Source: 'tests/src/hashmap.rs', lines 245:4-245:86 -/
+   Source: 'tests/src/hashmap.rs', lines 253:4-253:86 -/
 def hashmap.HashMap.get_mut_in_list
   (T : Type) (ls : hashmap.List T) (key : Usize) :
   Result (T × (T → Result (hashmap.List T)))
@@ -324,7 +324,7 @@ def hashmap.HashMap.get_mut_in_list
   hashmap.HashMap.get_mut_in_list_loop T ls key
 
 /- [hashmap_main::hashmap::{hashmap_main::hashmap::HashMap<T>}::get_mut]:
-   Source: 'tests/src/hashmap.rs', lines 257:4-257:67 -/
+   Source: 'tests/src/hashmap.rs', lines 265:4-265:67 -/
 def hashmap.HashMap.get_mut
   (T : Type) (self : hashmap.HashMap T) (key : Usize) :
   Result (T × (T → Result (hashmap.HashMap T)))
@@ -347,7 +347,7 @@ def hashmap.HashMap.get_mut
   Result.ok (t, back)
 
 /- [hashmap_main::hashmap::{hashmap_main::hashmap::HashMap<T>}::remove_from_list]: loop 0:
-   Source: 'tests/src/hashmap.rs', lines 265:4-291:5 -/
+   Source: 'tests/src/hashmap.rs', lines 273:4-299:5 -/
 divergent def hashmap.HashMap.remove_from_list_loop
   (T : Type) (key : Usize) (ls : hashmap.List T) :
   Result ((Option T) × (hashmap.List T))
@@ -369,7 +369,7 @@ divergent def hashmap.HashMap.remove_from_list_loop
   | hashmap.List.Nil => Result.ok (none, hashmap.List.Nil)
 
 /- [hashmap_main::hashmap::{hashmap_main::hashmap::HashMap<T>}::remove_from_list]:
-   Source: 'tests/src/hashmap.rs', lines 265:4-265:69 -/
+   Source: 'tests/src/hashmap.rs', lines 273:4-273:69 -/
 def hashmap.HashMap.remove_from_list
   (T : Type) (key : Usize) (ls : hashmap.List T) :
   Result ((Option T) × (hashmap.List T))
@@ -377,7 +377,7 @@ def hashmap.HashMap.remove_from_list
   hashmap.HashMap.remove_from_list_loop T key ls
 
 /- [hashmap_main::hashmap::{hashmap_main::hashmap::HashMap<T>}::remove]:
-   Source: 'tests/src/hashmap.rs', lines 294:4-294:52 -/
+   Source: 'tests/src/hashmap.rs', lines 302:4-302:52 -/
 def hashmap.HashMap.remove
   (T : Type) (self : hashmap.HashMap T) (key : Usize) :
   Result ((Option T) × (hashmap.HashMap T))
@@ -403,7 +403,7 @@ def hashmap.HashMap.remove
     Result.ok (some x1, { self with num_entries := i1, slots := v })
 
 /- [hashmap_main::hashmap::test1]:
-   Source: 'tests/src/hashmap.rs', lines 315:0-315:10 -/
+   Source: 'tests/src/hashmap.rs', lines 323:0-323:10 -/
 def hashmap.test1 : Result Unit :=
   do
   let hm ← hashmap.HashMap.new U64
@@ -447,7 +447,7 @@ def hashmap.test1 : Result Unit :=
               else Result.ok ()
 
 /- [hashmap_main::insert_on_disk]:
-   Source: 'tests/src/hashmap_main.rs', lines 7:0-7:43 -/
+   Source: 'tests/src/hashmap_main.rs', lines 13:0-13:43 -/
 def insert_on_disk
   (key : Usize) (value : U64) (st : State) : Result (State × Unit) :=
   do
@@ -456,7 +456,7 @@ def insert_on_disk
   hashmap_utils.serialize hm1 st1
 
 /- [hashmap_main::main]:
-   Source: 'tests/src/hashmap_main.rs', lines 16:0-16:13 -/
+   Source: 'tests/src/hashmap_main.rs', lines 22:0-22:13 -/
 def main : Result Unit :=
   Result.ok ()
 

--- a/tests/lean/HashmapMain/FunsExternal_Template.lean
+++ b/tests/lean/HashmapMain/FunsExternal_Template.lean
@@ -7,12 +7,12 @@ open Primitives
 open hashmap_main
 
 /- [hashmap_main::hashmap_utils::deserialize]:
-   Source: 'tests/src/hashmap_utils.rs', lines 10:0-10:43 -/
+   Source: 'tests/src/hashmap_utils.rs', lines 11:0-11:43 -/
 axiom hashmap_utils.deserialize
   : State → Result (State × (hashmap.HashMap U64))
 
 /- [hashmap_main::hashmap_utils::serialize]:
-   Source: 'tests/src/hashmap_utils.rs', lines 5:0-5:42 -/
+   Source: 'tests/src/hashmap_utils.rs', lines 6:0-6:42 -/
 axiom hashmap_utils.serialize
   : hashmap.HashMap U64 → State → Result (State × Unit)
 

--- a/tests/lean/HashmapMain/Types.lean
+++ b/tests/lean/HashmapMain/Types.lean
@@ -7,13 +7,13 @@ open Primitives
 namespace hashmap_main
 
 /- [hashmap_main::hashmap::List]
-   Source: 'tests/src/hashmap.rs', lines 19:0-19:16 -/
+   Source: 'tests/src/hashmap.rs', lines 27:0-27:16 -/
 inductive hashmap.List (T : Type) :=
 | Cons : Usize → T → hashmap.List T → hashmap.List T
 | Nil : hashmap.List T
 
 /- [hashmap_main::hashmap::HashMap]
-   Source: 'tests/src/hashmap.rs', lines 35:0-35:21 -/
+   Source: 'tests/src/hashmap.rs', lines 43:0-43:21 -/
 structure hashmap.HashMap (T : Type) where
   num_entries : Usize
   max_load_factor : (Usize × Usize)

--- a/tests/lean/Loops.lean
+++ b/tests/lean/Loops.lean
@@ -6,7 +6,7 @@ open Primitives
 namespace loops
 
 /- [loops::sum]: loop 0:
-   Source: 'tests/src/loops.rs', lines 4:0-14:1 -/
+   Source: 'tests/src/loops.rs', lines 7:0-17:1 -/
 divergent def sum_loop (max : U32) (i : U32) (s : U32) : Result U32 :=
   if i < max
   then do
@@ -16,12 +16,12 @@ divergent def sum_loop (max : U32) (i : U32) (s : U32) : Result U32 :=
   else s * 2#u32
 
 /- [loops::sum]:
-   Source: 'tests/src/loops.rs', lines 4:0-4:27 -/
+   Source: 'tests/src/loops.rs', lines 7:0-7:27 -/
 def sum (max : U32) : Result U32 :=
   sum_loop max 0#u32 0#u32
 
 /- [loops::sum_with_mut_borrows]: loop 0:
-   Source: 'tests/src/loops.rs', lines 19:0-31:1 -/
+   Source: 'tests/src/loops.rs', lines 22:0-34:1 -/
 divergent def sum_with_mut_borrows_loop
   (max : U32) (i : U32) (s : U32) : Result U32 :=
   if i < max
@@ -33,12 +33,12 @@ divergent def sum_with_mut_borrows_loop
   else s * 2#u32
 
 /- [loops::sum_with_mut_borrows]:
-   Source: 'tests/src/loops.rs', lines 19:0-19:44 -/
+   Source: 'tests/src/loops.rs', lines 22:0-22:44 -/
 def sum_with_mut_borrows (max : U32) : Result U32 :=
   sum_with_mut_borrows_loop max 0#u32 0#u32
 
 /- [loops::sum_with_shared_borrows]: loop 0:
-   Source: 'tests/src/loops.rs', lines 34:0-48:1 -/
+   Source: 'tests/src/loops.rs', lines 37:0-51:1 -/
 divergent def sum_with_shared_borrows_loop
   (max : U32) (i : U32) (s : U32) : Result U32 :=
   if i < max
@@ -50,12 +50,12 @@ divergent def sum_with_shared_borrows_loop
   else s * 2#u32
 
 /- [loops::sum_with_shared_borrows]:
-   Source: 'tests/src/loops.rs', lines 34:0-34:47 -/
+   Source: 'tests/src/loops.rs', lines 37:0-37:47 -/
 def sum_with_shared_borrows (max : U32) : Result U32 :=
   sum_with_shared_borrows_loop max 0#u32 0#u32
 
 /- [loops::sum_array]: loop 0:
-   Source: 'tests/src/loops.rs', lines 50:0-58:1 -/
+   Source: 'tests/src/loops.rs', lines 53:0-61:1 -/
 divergent def sum_array_loop
   (N : Usize) (a : Array U32 N) (i : Usize) (s : U32) : Result U32 :=
   if i < N
@@ -68,12 +68,12 @@ divergent def sum_array_loop
   else Result.ok s
 
 /- [loops::sum_array]:
-   Source: 'tests/src/loops.rs', lines 50:0-50:52 -/
+   Source: 'tests/src/loops.rs', lines 53:0-53:52 -/
 def sum_array (N : Usize) (a : Array U32 N) : Result U32 :=
   sum_array_loop N a 0#usize 0#u32
 
 /- [loops::clear]: loop 0:
-   Source: 'tests/src/loops.rs', lines 62:0-68:1 -/
+   Source: 'tests/src/loops.rs', lines 65:0-71:1 -/
 divergent def clear_loop
   (v : alloc.vec.Vec U32) (i : Usize) : Result (alloc.vec.Vec U32) :=
   let i1 := alloc.vec.Vec.len U32 v
@@ -89,18 +89,18 @@ divergent def clear_loop
   else Result.ok v
 
 /- [loops::clear]:
-   Source: 'tests/src/loops.rs', lines 62:0-62:30 -/
+   Source: 'tests/src/loops.rs', lines 65:0-65:30 -/
 def clear (v : alloc.vec.Vec U32) : Result (alloc.vec.Vec U32) :=
   clear_loop v 0#usize
 
 /- [loops::List]
-   Source: 'tests/src/loops.rs', lines 70:0-70:16 -/
+   Source: 'tests/src/loops.rs', lines 73:0-73:16 -/
 inductive List (T : Type) :=
 | Cons : T → List T → List T
 | Nil : List T
 
 /- [loops::list_mem]: loop 0:
-   Source: 'tests/src/loops.rs', lines 76:0-85:1 -/
+   Source: 'tests/src/loops.rs', lines 79:0-88:1 -/
 divergent def list_mem_loop (x : U32) (ls : List U32) : Result Bool :=
   match ls with
   | List.Cons y tl => if y = x
@@ -109,12 +109,12 @@ divergent def list_mem_loop (x : U32) (ls : List U32) : Result Bool :=
   | List.Nil => Result.ok false
 
 /- [loops::list_mem]:
-   Source: 'tests/src/loops.rs', lines 76:0-76:52 -/
+   Source: 'tests/src/loops.rs', lines 79:0-79:52 -/
 def list_mem (x : U32) (ls : List U32) : Result Bool :=
   list_mem_loop x ls
 
 /- [loops::list_nth_mut_loop]: loop 0:
-   Source: 'tests/src/loops.rs', lines 88:0-98:1 -/
+   Source: 'tests/src/loops.rs', lines 91:0-101:1 -/
 divergent def list_nth_mut_loop_loop
   (T : Type) (ls : List T) (i : U32) : Result (T × (T → Result (List T))) :=
   match ls with
@@ -135,13 +135,13 @@ divergent def list_nth_mut_loop_loop
   | List.Nil => Result.fail .panic
 
 /- [loops::list_nth_mut_loop]:
-   Source: 'tests/src/loops.rs', lines 88:0-88:71 -/
+   Source: 'tests/src/loops.rs', lines 91:0-91:71 -/
 def list_nth_mut_loop
   (T : Type) (ls : List T) (i : U32) : Result (T × (T → Result (List T))) :=
   list_nth_mut_loop_loop T ls i
 
 /- [loops::list_nth_shared_loop]: loop 0:
-   Source: 'tests/src/loops.rs', lines 101:0-111:1 -/
+   Source: 'tests/src/loops.rs', lines 104:0-114:1 -/
 divergent def list_nth_shared_loop_loop
   (T : Type) (ls : List T) (i : U32) : Result T :=
   match ls with
@@ -154,12 +154,12 @@ divergent def list_nth_shared_loop_loop
   | List.Nil => Result.fail .panic
 
 /- [loops::list_nth_shared_loop]:
-   Source: 'tests/src/loops.rs', lines 101:0-101:66 -/
+   Source: 'tests/src/loops.rs', lines 104:0-104:66 -/
 def list_nth_shared_loop (T : Type) (ls : List T) (i : U32) : Result T :=
   list_nth_shared_loop_loop T ls i
 
 /- [loops::get_elem_mut]: loop 0:
-   Source: 'tests/src/loops.rs', lines 113:0-127:1 -/
+   Source: 'tests/src/loops.rs', lines 116:0-130:1 -/
 divergent def get_elem_mut_loop
   (x : Usize) (ls : List Usize) :
   Result (Usize × (Usize → Result (List Usize)))
@@ -181,7 +181,7 @@ divergent def get_elem_mut_loop
   | List.Nil => Result.fail .panic
 
 /- [loops::get_elem_mut]:
-   Source: 'tests/src/loops.rs', lines 113:0-113:73 -/
+   Source: 'tests/src/loops.rs', lines 116:0-116:73 -/
 def get_elem_mut
   (slots : alloc.vec.Vec (List Usize)) (x : Usize) :
   Result (Usize × (Usize → Result (alloc.vec.Vec (List Usize))))
@@ -197,7 +197,7 @@ def get_elem_mut
   Result.ok (i, back1)
 
 /- [loops::get_elem_shared]: loop 0:
-   Source: 'tests/src/loops.rs', lines 129:0-143:1 -/
+   Source: 'tests/src/loops.rs', lines 132:0-146:1 -/
 divergent def get_elem_shared_loop
   (x : Usize) (ls : List Usize) : Result Usize :=
   match ls with
@@ -207,7 +207,7 @@ divergent def get_elem_shared_loop
   | List.Nil => Result.fail .panic
 
 /- [loops::get_elem_shared]:
-   Source: 'tests/src/loops.rs', lines 129:0-129:68 -/
+   Source: 'tests/src/loops.rs', lines 132:0-132:68 -/
 def get_elem_shared
   (slots : alloc.vec.Vec (List Usize)) (x : Usize) : Result Usize :=
   do
@@ -217,7 +217,7 @@ def get_elem_shared
   get_elem_shared_loop x ls
 
 /- [loops::id_mut]:
-   Source: 'tests/src/loops.rs', lines 145:0-145:50 -/
+   Source: 'tests/src/loops.rs', lines 148:0-148:50 -/
 def id_mut
   (T : Type) (ls : List T) :
   Result ((List T) × (List T → Result (List T)))
@@ -225,12 +225,12 @@ def id_mut
   Result.ok (ls, Result.ok)
 
 /- [loops::id_shared]:
-   Source: 'tests/src/loops.rs', lines 149:0-149:45 -/
+   Source: 'tests/src/loops.rs', lines 152:0-152:45 -/
 def id_shared (T : Type) (ls : List T) : Result (List T) :=
   Result.ok ls
 
 /- [loops::list_nth_mut_loop_with_id]: loop 0:
-   Source: 'tests/src/loops.rs', lines 154:0-165:1 -/
+   Source: 'tests/src/loops.rs', lines 157:0-168:1 -/
 divergent def list_nth_mut_loop_with_id_loop
   (T : Type) (i : U32) (ls : List T) : Result (T × (T → Result (List T))) :=
   match ls with
@@ -251,7 +251,7 @@ divergent def list_nth_mut_loop_with_id_loop
   | List.Nil => Result.fail .panic
 
 /- [loops::list_nth_mut_loop_with_id]:
-   Source: 'tests/src/loops.rs', lines 154:0-154:75 -/
+   Source: 'tests/src/loops.rs', lines 157:0-157:75 -/
 def list_nth_mut_loop_with_id
   (T : Type) (ls : List T) (i : U32) : Result (T × (T → Result (List T))) :=
   do
@@ -263,7 +263,7 @@ def list_nth_mut_loop_with_id
   Result.ok (t, back1)
 
 /- [loops::list_nth_shared_loop_with_id]: loop 0:
-   Source: 'tests/src/loops.rs', lines 168:0-179:1 -/
+   Source: 'tests/src/loops.rs', lines 171:0-182:1 -/
 divergent def list_nth_shared_loop_with_id_loop
   (T : Type) (i : U32) (ls : List T) : Result T :=
   match ls with
@@ -276,7 +276,7 @@ divergent def list_nth_shared_loop_with_id_loop
   | List.Nil => Result.fail .panic
 
 /- [loops::list_nth_shared_loop_with_id]:
-   Source: 'tests/src/loops.rs', lines 168:0-168:70 -/
+   Source: 'tests/src/loops.rs', lines 171:0-171:70 -/
 def list_nth_shared_loop_with_id
   (T : Type) (ls : List T) (i : U32) : Result T :=
   do
@@ -284,7 +284,7 @@ def list_nth_shared_loop_with_id
   list_nth_shared_loop_with_id_loop T i ls1
 
 /- [loops::list_nth_mut_loop_pair]: loop 0:
-   Source: 'tests/src/loops.rs', lines 184:0-205:1 -/
+   Source: 'tests/src/loops.rs', lines 187:0-208:1 -/
 divergent def list_nth_mut_loop_pair_loop
   (T : Type) (ls0 : List T) (ls1 : List T) (i : U32) :
   Result ((T × T) × (T → Result (List T)) × (T → Result (List T)))
@@ -315,7 +315,7 @@ divergent def list_nth_mut_loop_pair_loop
   | List.Nil => Result.fail .panic
 
 /- [loops::list_nth_mut_loop_pair]:
-   Source: 'tests/src/loops.rs', lines 184:0-188:27 -/
+   Source: 'tests/src/loops.rs', lines 187:0-191:27 -/
 def list_nth_mut_loop_pair
   (T : Type) (ls0 : List T) (ls1 : List T) (i : U32) :
   Result ((T × T) × (T → Result (List T)) × (T → Result (List T)))
@@ -323,7 +323,7 @@ def list_nth_mut_loop_pair
   list_nth_mut_loop_pair_loop T ls0 ls1 i
 
 /- [loops::list_nth_shared_loop_pair]: loop 0:
-   Source: 'tests/src/loops.rs', lines 208:0-229:1 -/
+   Source: 'tests/src/loops.rs', lines 211:0-232:1 -/
 divergent def list_nth_shared_loop_pair_loop
   (T : Type) (ls0 : List T) (ls1 : List T) (i : U32) : Result (T × T) :=
   match ls0 with
@@ -339,13 +339,13 @@ divergent def list_nth_shared_loop_pair_loop
   | List.Nil => Result.fail .panic
 
 /- [loops::list_nth_shared_loop_pair]:
-   Source: 'tests/src/loops.rs', lines 208:0-212:19 -/
+   Source: 'tests/src/loops.rs', lines 211:0-215:19 -/
 def list_nth_shared_loop_pair
   (T : Type) (ls0 : List T) (ls1 : List T) (i : U32) : Result (T × T) :=
   list_nth_shared_loop_pair_loop T ls0 ls1 i
 
 /- [loops::list_nth_mut_loop_pair_merge]: loop 0:
-   Source: 'tests/src/loops.rs', lines 233:0-248:1 -/
+   Source: 'tests/src/loops.rs', lines 236:0-251:1 -/
 divergent def list_nth_mut_loop_pair_merge_loop
   (T : Type) (ls0 : List T) (ls1 : List T) (i : U32) :
   Result ((T × T) × ((T × T) → Result ((List T) × (List T))))
@@ -375,7 +375,7 @@ divergent def list_nth_mut_loop_pair_merge_loop
   | List.Nil => Result.fail .panic
 
 /- [loops::list_nth_mut_loop_pair_merge]:
-   Source: 'tests/src/loops.rs', lines 233:0-237:27 -/
+   Source: 'tests/src/loops.rs', lines 236:0-240:27 -/
 def list_nth_mut_loop_pair_merge
   (T : Type) (ls0 : List T) (ls1 : List T) (i : U32) :
   Result ((T × T) × ((T × T) → Result ((List T) × (List T))))
@@ -383,7 +383,7 @@ def list_nth_mut_loop_pair_merge
   list_nth_mut_loop_pair_merge_loop T ls0 ls1 i
 
 /- [loops::list_nth_shared_loop_pair_merge]: loop 0:
-   Source: 'tests/src/loops.rs', lines 251:0-266:1 -/
+   Source: 'tests/src/loops.rs', lines 254:0-269:1 -/
 divergent def list_nth_shared_loop_pair_merge_loop
   (T : Type) (ls0 : List T) (ls1 : List T) (i : U32) : Result (T × T) :=
   match ls0 with
@@ -400,13 +400,13 @@ divergent def list_nth_shared_loop_pair_merge_loop
   | List.Nil => Result.fail .panic
 
 /- [loops::list_nth_shared_loop_pair_merge]:
-   Source: 'tests/src/loops.rs', lines 251:0-255:19 -/
+   Source: 'tests/src/loops.rs', lines 254:0-258:19 -/
 def list_nth_shared_loop_pair_merge
   (T : Type) (ls0 : List T) (ls1 : List T) (i : U32) : Result (T × T) :=
   list_nth_shared_loop_pair_merge_loop T ls0 ls1 i
 
 /- [loops::list_nth_mut_shared_loop_pair]: loop 0:
-   Source: 'tests/src/loops.rs', lines 269:0-284:1 -/
+   Source: 'tests/src/loops.rs', lines 272:0-287:1 -/
 divergent def list_nth_mut_shared_loop_pair_loop
   (T : Type) (ls0 : List T) (ls1 : List T) (i : U32) :
   Result ((T × T) × (T → Result (List T)))
@@ -432,7 +432,7 @@ divergent def list_nth_mut_shared_loop_pair_loop
   | List.Nil => Result.fail .panic
 
 /- [loops::list_nth_mut_shared_loop_pair]:
-   Source: 'tests/src/loops.rs', lines 269:0-273:23 -/
+   Source: 'tests/src/loops.rs', lines 272:0-276:23 -/
 def list_nth_mut_shared_loop_pair
   (T : Type) (ls0 : List T) (ls1 : List T) (i : U32) :
   Result ((T × T) × (T → Result (List T)))
@@ -440,7 +440,7 @@ def list_nth_mut_shared_loop_pair
   list_nth_mut_shared_loop_pair_loop T ls0 ls1 i
 
 /- [loops::list_nth_mut_shared_loop_pair_merge]: loop 0:
-   Source: 'tests/src/loops.rs', lines 288:0-303:1 -/
+   Source: 'tests/src/loops.rs', lines 291:0-306:1 -/
 divergent def list_nth_mut_shared_loop_pair_merge_loop
   (T : Type) (ls0 : List T) (ls1 : List T) (i : U32) :
   Result ((T × T) × (T → Result (List T)))
@@ -466,7 +466,7 @@ divergent def list_nth_mut_shared_loop_pair_merge_loop
   | List.Nil => Result.fail .panic
 
 /- [loops::list_nth_mut_shared_loop_pair_merge]:
-   Source: 'tests/src/loops.rs', lines 288:0-292:23 -/
+   Source: 'tests/src/loops.rs', lines 291:0-295:23 -/
 def list_nth_mut_shared_loop_pair_merge
   (T : Type) (ls0 : List T) (ls1 : List T) (i : U32) :
   Result ((T × T) × (T → Result (List T)))
@@ -474,7 +474,7 @@ def list_nth_mut_shared_loop_pair_merge
   list_nth_mut_shared_loop_pair_merge_loop T ls0 ls1 i
 
 /- [loops::list_nth_shared_mut_loop_pair]: loop 0:
-   Source: 'tests/src/loops.rs', lines 307:0-322:1 -/
+   Source: 'tests/src/loops.rs', lines 310:0-325:1 -/
 divergent def list_nth_shared_mut_loop_pair_loop
   (T : Type) (ls0 : List T) (ls1 : List T) (i : U32) :
   Result ((T × T) × (T → Result (List T)))
@@ -500,7 +500,7 @@ divergent def list_nth_shared_mut_loop_pair_loop
   | List.Nil => Result.fail .panic
 
 /- [loops::list_nth_shared_mut_loop_pair]:
-   Source: 'tests/src/loops.rs', lines 307:0-311:23 -/
+   Source: 'tests/src/loops.rs', lines 310:0-314:23 -/
 def list_nth_shared_mut_loop_pair
   (T : Type) (ls0 : List T) (ls1 : List T) (i : U32) :
   Result ((T × T) × (T → Result (List T)))
@@ -508,7 +508,7 @@ def list_nth_shared_mut_loop_pair
   list_nth_shared_mut_loop_pair_loop T ls0 ls1 i
 
 /- [loops::list_nth_shared_mut_loop_pair_merge]: loop 0:
-   Source: 'tests/src/loops.rs', lines 326:0-341:1 -/
+   Source: 'tests/src/loops.rs', lines 329:0-344:1 -/
 divergent def list_nth_shared_mut_loop_pair_merge_loop
   (T : Type) (ls0 : List T) (ls1 : List T) (i : U32) :
   Result ((T × T) × (T → Result (List T)))
@@ -534,7 +534,7 @@ divergent def list_nth_shared_mut_loop_pair_merge_loop
   | List.Nil => Result.fail .panic
 
 /- [loops::list_nth_shared_mut_loop_pair_merge]:
-   Source: 'tests/src/loops.rs', lines 326:0-330:23 -/
+   Source: 'tests/src/loops.rs', lines 329:0-333:23 -/
 def list_nth_shared_mut_loop_pair_merge
   (T : Type) (ls0 : List T) (ls1 : List T) (i : U32) :
   Result ((T × T) × (T → Result (List T)))
@@ -542,7 +542,7 @@ def list_nth_shared_mut_loop_pair_merge
   list_nth_shared_mut_loop_pair_merge_loop T ls0 ls1 i
 
 /- [loops::ignore_input_mut_borrow]: loop 0:
-   Source: 'tests/src/loops.rs', lines 345:0-349:1 -/
+   Source: 'tests/src/loops.rs', lines 348:0-352:1 -/
 divergent def ignore_input_mut_borrow_loop (i : U32) : Result Unit :=
   if i > 0#u32
   then do
@@ -551,14 +551,14 @@ divergent def ignore_input_mut_borrow_loop (i : U32) : Result Unit :=
   else Result.ok ()
 
 /- [loops::ignore_input_mut_borrow]:
-   Source: 'tests/src/loops.rs', lines 345:0-345:56 -/
+   Source: 'tests/src/loops.rs', lines 348:0-348:56 -/
 def ignore_input_mut_borrow (_a : U32) (i : U32) : Result U32 :=
   do
   let _ ← ignore_input_mut_borrow_loop i
   Result.ok _a
 
 /- [loops::incr_ignore_input_mut_borrow]: loop 0:
-   Source: 'tests/src/loops.rs', lines 353:0-358:1 -/
+   Source: 'tests/src/loops.rs', lines 356:0-361:1 -/
 divergent def incr_ignore_input_mut_borrow_loop (i : U32) : Result Unit :=
   if i > 0#u32
   then do
@@ -567,7 +567,7 @@ divergent def incr_ignore_input_mut_borrow_loop (i : U32) : Result Unit :=
   else Result.ok ()
 
 /- [loops::incr_ignore_input_mut_borrow]:
-   Source: 'tests/src/loops.rs', lines 353:0-353:60 -/
+   Source: 'tests/src/loops.rs', lines 356:0-356:60 -/
 def incr_ignore_input_mut_borrow (a : U32) (i : U32) : Result U32 :=
   do
   let a1 ← a + 1#u32
@@ -575,7 +575,7 @@ def incr_ignore_input_mut_borrow (a : U32) (i : U32) : Result U32 :=
   Result.ok a1
 
 /- [loops::ignore_input_shared_borrow]: loop 0:
-   Source: 'tests/src/loops.rs', lines 362:0-366:1 -/
+   Source: 'tests/src/loops.rs', lines 365:0-369:1 -/
 divergent def ignore_input_shared_borrow_loop (i : U32) : Result Unit :=
   if i > 0#u32
   then do
@@ -584,7 +584,7 @@ divergent def ignore_input_shared_borrow_loop (i : U32) : Result Unit :=
   else Result.ok ()
 
 /- [loops::ignore_input_shared_borrow]:
-   Source: 'tests/src/loops.rs', lines 362:0-362:59 -/
+   Source: 'tests/src/loops.rs', lines 365:0-365:59 -/
 def ignore_input_shared_borrow (_a : U32) (i : U32) : Result U32 :=
   do
   let _ ← ignore_input_shared_borrow_loop i

--- a/tests/lean/NoNestedBorrows.lean
+++ b/tests/lean/NoNestedBorrows.lean
@@ -6,60 +6,60 @@ open Primitives
 namespace no_nested_borrows
 
 /- [no_nested_borrows::Pair]
-   Source: 'tests/src/no_nested_borrows.rs', lines 4:0-4:23 -/
+   Source: 'tests/src/no_nested_borrows.rs', lines 6:0-6:23 -/
 structure Pair (T1 T2 : Type) where
   x : T1
   y : T2
 
 /- [no_nested_borrows::List]
-   Source: 'tests/src/no_nested_borrows.rs', lines 9:0-9:16 -/
+   Source: 'tests/src/no_nested_borrows.rs', lines 11:0-11:16 -/
 inductive List (T : Type) :=
 | Cons : T → List T → List T
 | Nil : List T
 
 /- [no_nested_borrows::One]
-   Source: 'tests/src/no_nested_borrows.rs', lines 20:0-20:16 -/
+   Source: 'tests/src/no_nested_borrows.rs', lines 22:0-22:16 -/
 inductive One (T1 : Type) :=
 | One : T1 → One T1
 
 /- [no_nested_borrows::EmptyEnum]
-   Source: 'tests/src/no_nested_borrows.rs', lines 26:0-26:18 -/
+   Source: 'tests/src/no_nested_borrows.rs', lines 28:0-28:18 -/
 inductive EmptyEnum :=
 | Empty : EmptyEnum
 
 /- [no_nested_borrows::Enum]
-   Source: 'tests/src/no_nested_borrows.rs', lines 32:0-32:13 -/
+   Source: 'tests/src/no_nested_borrows.rs', lines 34:0-34:13 -/
 inductive Enum :=
 | Variant1 : Enum
 | Variant2 : Enum
 
 /- [no_nested_borrows::EmptyStruct]
-   Source: 'tests/src/no_nested_borrows.rs', lines 39:0-39:22 -/
+   Source: 'tests/src/no_nested_borrows.rs', lines 41:0-41:22 -/
 @[reducible] def EmptyStruct := Unit
 
 /- [no_nested_borrows::Sum]
-   Source: 'tests/src/no_nested_borrows.rs', lines 41:0-41:20 -/
+   Source: 'tests/src/no_nested_borrows.rs', lines 43:0-43:20 -/
 inductive Sum (T1 T2 : Type) :=
 | Left : T1 → Sum T1 T2
 | Right : T2 → Sum T1 T2
 
 /- [no_nested_borrows::cast_u32_to_i32]:
-   Source: 'tests/src/no_nested_borrows.rs', lines 46:0-46:37 -/
+   Source: 'tests/src/no_nested_borrows.rs', lines 48:0-48:37 -/
 def cast_u32_to_i32 (x : U32) : Result I32 :=
   Scalar.cast .I32 x
 
 /- [no_nested_borrows::cast_bool_to_i32]:
-   Source: 'tests/src/no_nested_borrows.rs', lines 50:0-50:39 -/
+   Source: 'tests/src/no_nested_borrows.rs', lines 52:0-52:39 -/
 def cast_bool_to_i32 (x : Bool) : Result I32 :=
   Scalar.cast_bool .I32 x
 
 /- [no_nested_borrows::cast_bool_to_bool]:
-   Source: 'tests/src/no_nested_borrows.rs', lines 55:0-55:41 -/
+   Source: 'tests/src/no_nested_borrows.rs', lines 57:0-57:41 -/
 def cast_bool_to_bool (x : Bool) : Result Bool :=
   Result.ok x
 
 /- [no_nested_borrows::test2]:
-   Source: 'tests/src/no_nested_borrows.rs', lines 60:0-60:14 -/
+   Source: 'tests/src/no_nested_borrows.rs', lines 62:0-62:14 -/
 def test2 : Result Unit :=
   do
   let _ ← 23#u32 + 44#u32
@@ -69,14 +69,14 @@ def test2 : Result Unit :=
 #assert (test2 == Result.ok ())
 
 /- [no_nested_borrows::get_max]:
-   Source: 'tests/src/no_nested_borrows.rs', lines 72:0-72:37 -/
+   Source: 'tests/src/no_nested_borrows.rs', lines 74:0-74:37 -/
 def get_max (x : U32) (y : U32) : Result U32 :=
   if x >= y
   then Result.ok x
   else Result.ok y
 
 /- [no_nested_borrows::test3]:
-   Source: 'tests/src/no_nested_borrows.rs', lines 80:0-80:14 -/
+   Source: 'tests/src/no_nested_borrows.rs', lines 82:0-82:14 -/
 def test3 : Result Unit :=
   do
   let x ← get_max 4#u32 3#u32
@@ -90,7 +90,7 @@ def test3 : Result Unit :=
 #assert (test3 == Result.ok ())
 
 /- [no_nested_borrows::test_neg1]:
-   Source: 'tests/src/no_nested_borrows.rs', lines 87:0-87:18 -/
+   Source: 'tests/src/no_nested_borrows.rs', lines 89:0-89:18 -/
 def test_neg1 : Result Unit :=
   do
   let y ← -. 3#i32
@@ -102,7 +102,7 @@ def test_neg1 : Result Unit :=
 #assert (test_neg1 == Result.ok ())
 
 /- [no_nested_borrows::refs_test1]:
-   Source: 'tests/src/no_nested_borrows.rs', lines 94:0-94:19 -/
+   Source: 'tests/src/no_nested_borrows.rs', lines 96:0-96:19 -/
 def refs_test1 : Result Unit :=
   if ¬ (1#i32 = 1#i32)
   then Result.fail .panic
@@ -112,7 +112,7 @@ def refs_test1 : Result Unit :=
 #assert (refs_test1 == Result.ok ())
 
 /- [no_nested_borrows::refs_test2]:
-   Source: 'tests/src/no_nested_borrows.rs', lines 105:0-105:19 -/
+   Source: 'tests/src/no_nested_borrows.rs', lines 107:0-107:19 -/
 def refs_test2 : Result Unit :=
   if ¬ (2#i32 = 2#i32)
   then Result.fail .panic
@@ -130,7 +130,7 @@ def refs_test2 : Result Unit :=
 #assert (refs_test2 == Result.ok ())
 
 /- [no_nested_borrows::test_list1]:
-   Source: 'tests/src/no_nested_borrows.rs', lines 121:0-121:19 -/
+   Source: 'tests/src/no_nested_borrows.rs', lines 123:0-123:19 -/
 def test_list1 : Result Unit :=
   Result.ok ()
 
@@ -138,7 +138,7 @@ def test_list1 : Result Unit :=
 #assert (test_list1 == Result.ok ())
 
 /- [no_nested_borrows::test_box1]:
-   Source: 'tests/src/no_nested_borrows.rs', lines 126:0-126:18 -/
+   Source: 'tests/src/no_nested_borrows.rs', lines 128:0-128:18 -/
 def test_box1 : Result Unit :=
   do
   let (_, deref_mut_back) ← alloc.boxed.Box.deref_mut I32 0#i32
@@ -152,26 +152,26 @@ def test_box1 : Result Unit :=
 #assert (test_box1 == Result.ok ())
 
 /- [no_nested_borrows::copy_int]:
-   Source: 'tests/src/no_nested_borrows.rs', lines 136:0-136:30 -/
+   Source: 'tests/src/no_nested_borrows.rs', lines 138:0-138:30 -/
 def copy_int (x : I32) : Result I32 :=
   Result.ok x
 
 /- [no_nested_borrows::test_unreachable]:
-   Source: 'tests/src/no_nested_borrows.rs', lines 142:0-142:32 -/
+   Source: 'tests/src/no_nested_borrows.rs', lines 144:0-144:32 -/
 def test_unreachable (b : Bool) : Result Unit :=
   if b
   then Result.fail .panic
   else Result.ok ()
 
 /- [no_nested_borrows::test_panic]:
-   Source: 'tests/src/no_nested_borrows.rs', lines 150:0-150:26 -/
+   Source: 'tests/src/no_nested_borrows.rs', lines 152:0-152:26 -/
 def test_panic (b : Bool) : Result Unit :=
   if b
   then Result.fail .panic
   else Result.ok ()
 
 /- [no_nested_borrows::test_copy_int]:
-   Source: 'tests/src/no_nested_borrows.rs', lines 157:0-157:22 -/
+   Source: 'tests/src/no_nested_borrows.rs', lines 159:0-159:22 -/
 def test_copy_int : Result Unit :=
   do
   let y ← copy_int 0#i32
@@ -183,14 +183,14 @@ def test_copy_int : Result Unit :=
 #assert (test_copy_int == Result.ok ())
 
 /- [no_nested_borrows::is_cons]:
-   Source: 'tests/src/no_nested_borrows.rs', lines 164:0-164:38 -/
+   Source: 'tests/src/no_nested_borrows.rs', lines 166:0-166:38 -/
 def is_cons (T : Type) (l : List T) : Result Bool :=
   match l with
   | List.Cons _ _ => Result.ok true
   | List.Nil => Result.ok false
 
 /- [no_nested_borrows::test_is_cons]:
-   Source: 'tests/src/no_nested_borrows.rs', lines 171:0-171:21 -/
+   Source: 'tests/src/no_nested_borrows.rs', lines 173:0-173:21 -/
 def test_is_cons : Result Unit :=
   do
   let b ← is_cons I32 (List.Cons 0#i32 List.Nil)
@@ -202,14 +202,14 @@ def test_is_cons : Result Unit :=
 #assert (test_is_cons == Result.ok ())
 
 /- [no_nested_borrows::split_list]:
-   Source: 'tests/src/no_nested_borrows.rs', lines 177:0-177:48 -/
+   Source: 'tests/src/no_nested_borrows.rs', lines 179:0-179:48 -/
 def split_list (T : Type) (l : List T) : Result (T × (List T)) :=
   match l with
   | List.Cons hd tl => Result.ok (hd, tl)
   | List.Nil => Result.fail .panic
 
 /- [no_nested_borrows::test_split_list]:
-   Source: 'tests/src/no_nested_borrows.rs', lines 185:0-185:24 -/
+   Source: 'tests/src/no_nested_borrows.rs', lines 187:0-187:24 -/
 def test_split_list : Result Unit :=
   do
   let p ← split_list I32 (List.Cons 0#i32 List.Nil)
@@ -222,7 +222,7 @@ def test_split_list : Result Unit :=
 #assert (test_split_list == Result.ok ())
 
 /- [no_nested_borrows::choose]:
-   Source: 'tests/src/no_nested_borrows.rs', lines 192:0-192:70 -/
+   Source: 'tests/src/no_nested_borrows.rs', lines 194:0-194:70 -/
 def choose
   (T : Type) (b : Bool) (x : T) (y : T) :
   Result (T × (T → Result (T × T)))
@@ -234,7 +234,7 @@ def choose
        Result.ok (y, back)
 
 /- [no_nested_borrows::choose_test]:
-   Source: 'tests/src/no_nested_borrows.rs', lines 200:0-200:20 -/
+   Source: 'tests/src/no_nested_borrows.rs', lines 202:0-202:20 -/
 def choose_test : Result Unit :=
   do
   let (z, choose_back) ← choose I32 true 0#i32 0#i32
@@ -254,20 +254,20 @@ def choose_test : Result Unit :=
 #assert (choose_test == Result.ok ())
 
 /- [no_nested_borrows::test_char]:
-   Source: 'tests/src/no_nested_borrows.rs', lines 212:0-212:26 -/
+   Source: 'tests/src/no_nested_borrows.rs', lines 214:0-214:26 -/
 def test_char : Result Char :=
   Result.ok 'a'
 
 mutual
 
 /- [no_nested_borrows::Tree]
-   Source: 'tests/src/no_nested_borrows.rs', lines 217:0-217:16 -/
+   Source: 'tests/src/no_nested_borrows.rs', lines 219:0-219:16 -/
 inductive Tree (T : Type) :=
 | Leaf : T → Tree T
 | Node : T → NodeElem T → Tree T → Tree T
 
 /- [no_nested_borrows::NodeElem]
-   Source: 'tests/src/no_nested_borrows.rs', lines 222:0-222:20 -/
+   Source: 'tests/src/no_nested_borrows.rs', lines 224:0-224:20 -/
 inductive NodeElem (T : Type) :=
 | Cons : Tree T → NodeElem T → NodeElem T
 | Nil : NodeElem T
@@ -275,7 +275,7 @@ inductive NodeElem (T : Type) :=
 end
 
 /- [no_nested_borrows::list_length]:
-   Source: 'tests/src/no_nested_borrows.rs', lines 257:0-257:48 -/
+   Source: 'tests/src/no_nested_borrows.rs', lines 259:0-259:48 -/
 divergent def list_length (T : Type) (l : List T) : Result U32 :=
   match l with
   | List.Cons _ l1 => do
@@ -284,7 +284,7 @@ divergent def list_length (T : Type) (l : List T) : Result U32 :=
   | List.Nil => Result.ok 0#u32
 
 /- [no_nested_borrows::list_nth_shared]:
-   Source: 'tests/src/no_nested_borrows.rs', lines 265:0-265:62 -/
+   Source: 'tests/src/no_nested_borrows.rs', lines 267:0-267:62 -/
 divergent def list_nth_shared (T : Type) (l : List T) (i : U32) : Result T :=
   match l with
   | List.Cons x tl =>
@@ -296,7 +296,7 @@ divergent def list_nth_shared (T : Type) (l : List T) (i : U32) : Result T :=
   | List.Nil => Result.fail .panic
 
 /- [no_nested_borrows::list_nth_mut]:
-   Source: 'tests/src/no_nested_borrows.rs', lines 281:0-281:67 -/
+   Source: 'tests/src/no_nested_borrows.rs', lines 283:0-283:67 -/
 divergent def list_nth_mut
   (T : Type) (l : List T) (i : U32) : Result (T × (T → Result (List T))) :=
   match l with
@@ -318,7 +318,7 @@ divergent def list_nth_mut
   | List.Nil => Result.fail .panic
 
 /- [no_nested_borrows::list_rev_aux]:
-   Source: 'tests/src/no_nested_borrows.rs', lines 297:0-297:63 -/
+   Source: 'tests/src/no_nested_borrows.rs', lines 299:0-299:63 -/
 divergent def list_rev_aux
   (T : Type) (li : List T) (lo : List T) : Result (List T) :=
   match li with
@@ -326,13 +326,13 @@ divergent def list_rev_aux
   | List.Nil => Result.ok lo
 
 /- [no_nested_borrows::list_rev]:
-   Source: 'tests/src/no_nested_borrows.rs', lines 311:0-311:42 -/
+   Source: 'tests/src/no_nested_borrows.rs', lines 313:0-313:42 -/
 def list_rev (T : Type) (l : List T) : Result (List T) :=
   let (li, _) := core.mem.replace (List T) l List.Nil
   list_rev_aux T li List.Nil
 
 /- [no_nested_borrows::test_list_functions]:
-   Source: 'tests/src/no_nested_borrows.rs', lines 316:0-316:28 -/
+   Source: 'tests/src/no_nested_borrows.rs', lines 318:0-318:28 -/
 def test_list_functions : Result Unit :=
   do
   let l := List.Cons 2#i32 List.Nil
@@ -379,7 +379,7 @@ def test_list_functions : Result Unit :=
 #assert (test_list_functions == Result.ok ())
 
 /- [no_nested_borrows::id_mut_pair1]:
-   Source: 'tests/src/no_nested_borrows.rs', lines 332:0-332:89 -/
+   Source: 'tests/src/no_nested_borrows.rs', lines 334:0-334:89 -/
 def id_mut_pair1
   (T1 T2 : Type) (x : T1) (y : T2) :
   Result ((T1 × T2) × ((T1 × T2) → Result (T1 × T2)))
@@ -387,7 +387,7 @@ def id_mut_pair1
   Result.ok ((x, y), Result.ok)
 
 /- [no_nested_borrows::id_mut_pair2]:
-   Source: 'tests/src/no_nested_borrows.rs', lines 336:0-336:88 -/
+   Source: 'tests/src/no_nested_borrows.rs', lines 338:0-338:88 -/
 def id_mut_pair2
   (T1 T2 : Type) (p : (T1 × T2)) :
   Result ((T1 × T2) × ((T1 × T2) → Result (T1 × T2)))
@@ -396,7 +396,7 @@ def id_mut_pair2
   Result.ok ((t, t1), Result.ok)
 
 /- [no_nested_borrows::id_mut_pair3]:
-   Source: 'tests/src/no_nested_borrows.rs', lines 340:0-340:93 -/
+   Source: 'tests/src/no_nested_borrows.rs', lines 342:0-342:93 -/
 def id_mut_pair3
   (T1 T2 : Type) (x : T1) (y : T2) :
   Result ((T1 × T2) × (T1 → Result T1) × (T2 → Result T2))
@@ -404,7 +404,7 @@ def id_mut_pair3
   Result.ok ((x, y), Result.ok, Result.ok)
 
 /- [no_nested_borrows::id_mut_pair4]:
-   Source: 'tests/src/no_nested_borrows.rs', lines 344:0-344:92 -/
+   Source: 'tests/src/no_nested_borrows.rs', lines 346:0-346:92 -/
 def id_mut_pair4
   (T1 T2 : Type) (p : (T1 × T2)) :
   Result ((T1 × T2) × (T1 → Result T1) × (T2 → Result T2))
@@ -413,37 +413,37 @@ def id_mut_pair4
   Result.ok ((t, t1), Result.ok, Result.ok)
 
 /- [no_nested_borrows::StructWithTuple]
-   Source: 'tests/src/no_nested_borrows.rs', lines 351:0-351:34 -/
+   Source: 'tests/src/no_nested_borrows.rs', lines 353:0-353:34 -/
 structure StructWithTuple (T1 T2 : Type) where
   p : (T1 × T2)
 
 /- [no_nested_borrows::new_tuple1]:
-   Source: 'tests/src/no_nested_borrows.rs', lines 355:0-355:48 -/
+   Source: 'tests/src/no_nested_borrows.rs', lines 357:0-357:48 -/
 def new_tuple1 : Result (StructWithTuple U32 U32) :=
   Result.ok { p := (1#u32, 2#u32) }
 
 /- [no_nested_borrows::new_tuple2]:
-   Source: 'tests/src/no_nested_borrows.rs', lines 359:0-359:48 -/
+   Source: 'tests/src/no_nested_borrows.rs', lines 361:0-361:48 -/
 def new_tuple2 : Result (StructWithTuple I16 I16) :=
   Result.ok { p := (1#i16, 2#i16) }
 
 /- [no_nested_borrows::new_tuple3]:
-   Source: 'tests/src/no_nested_borrows.rs', lines 363:0-363:48 -/
+   Source: 'tests/src/no_nested_borrows.rs', lines 365:0-365:48 -/
 def new_tuple3 : Result (StructWithTuple U64 I64) :=
   Result.ok { p := (1#u64, 2#i64) }
 
 /- [no_nested_borrows::StructWithPair]
-   Source: 'tests/src/no_nested_borrows.rs', lines 368:0-368:33 -/
+   Source: 'tests/src/no_nested_borrows.rs', lines 370:0-370:33 -/
 structure StructWithPair (T1 T2 : Type) where
   p : Pair T1 T2
 
 /- [no_nested_borrows::new_pair1]:
-   Source: 'tests/src/no_nested_borrows.rs', lines 372:0-372:46 -/
+   Source: 'tests/src/no_nested_borrows.rs', lines 374:0-374:46 -/
 def new_pair1 : Result (StructWithPair U32 U32) :=
   Result.ok { p := { x := 1#u32, y := 2#u32 } }
 
 /- [no_nested_borrows::test_constants]:
-   Source: 'tests/src/no_nested_borrows.rs', lines 380:0-380:23 -/
+   Source: 'tests/src/no_nested_borrows.rs', lines 382:0-382:23 -/
 def test_constants : Result Unit :=
   do
   let swt ← new_tuple1
@@ -473,7 +473,7 @@ def test_constants : Result Unit :=
 #assert (test_constants == Result.ok ())
 
 /- [no_nested_borrows::test_weird_borrows1]:
-   Source: 'tests/src/no_nested_borrows.rs', lines 389:0-389:28 -/
+   Source: 'tests/src/no_nested_borrows.rs', lines 391:0-391:28 -/
 def test_weird_borrows1 : Result Unit :=
   Result.ok ()
 
@@ -481,7 +481,7 @@ def test_weird_borrows1 : Result Unit :=
 #assert (test_weird_borrows1 == Result.ok ())
 
 /- [no_nested_borrows::test_mem_replace]:
-   Source: 'tests/src/no_nested_borrows.rs', lines 399:0-399:37 -/
+   Source: 'tests/src/no_nested_borrows.rs', lines 401:0-401:37 -/
 def test_mem_replace (px : U32) : Result U32 :=
   let (y, _) := core.mem.replace U32 px 1#u32
   if ¬ (y = 0#u32)
@@ -489,71 +489,71 @@ def test_mem_replace (px : U32) : Result U32 :=
   else Result.ok 2#u32
 
 /- [no_nested_borrows::test_shared_borrow_bool1]:
-   Source: 'tests/src/no_nested_borrows.rs', lines 406:0-406:47 -/
+   Source: 'tests/src/no_nested_borrows.rs', lines 408:0-408:47 -/
 def test_shared_borrow_bool1 (b : Bool) : Result U32 :=
   if b
   then Result.ok 0#u32
   else Result.ok 1#u32
 
 /- [no_nested_borrows::test_shared_borrow_bool2]:
-   Source: 'tests/src/no_nested_borrows.rs', lines 419:0-419:40 -/
+   Source: 'tests/src/no_nested_borrows.rs', lines 421:0-421:40 -/
 def test_shared_borrow_bool2 : Result U32 :=
   Result.ok 0#u32
 
 /- [no_nested_borrows::test_shared_borrow_enum1]:
-   Source: 'tests/src/no_nested_borrows.rs', lines 434:0-434:52 -/
+   Source: 'tests/src/no_nested_borrows.rs', lines 436:0-436:52 -/
 def test_shared_borrow_enum1 (l : List U32) : Result U32 :=
   match l with
   | List.Cons _ _ => Result.ok 1#u32
   | List.Nil => Result.ok 0#u32
 
 /- [no_nested_borrows::test_shared_borrow_enum2]:
-   Source: 'tests/src/no_nested_borrows.rs', lines 446:0-446:40 -/
+   Source: 'tests/src/no_nested_borrows.rs', lines 448:0-448:40 -/
 def test_shared_borrow_enum2 : Result U32 :=
   Result.ok 0#u32
 
 /- [no_nested_borrows::incr]:
-   Source: 'tests/src/no_nested_borrows.rs', lines 457:0-457:24 -/
+   Source: 'tests/src/no_nested_borrows.rs', lines 459:0-459:24 -/
 def incr (x : U32) : Result U32 :=
   x + 1#u32
 
 /- [no_nested_borrows::call_incr]:
-   Source: 'tests/src/no_nested_borrows.rs', lines 461:0-461:35 -/
+   Source: 'tests/src/no_nested_borrows.rs', lines 463:0-463:35 -/
 def call_incr (x : U32) : Result U32 :=
   incr x
 
 /- [no_nested_borrows::read_then_incr]:
-   Source: 'tests/src/no_nested_borrows.rs', lines 466:0-466:41 -/
+   Source: 'tests/src/no_nested_borrows.rs', lines 468:0-468:41 -/
 def read_then_incr (x : U32) : Result (U32 × U32) :=
   do
   let x1 ← x + 1#u32
   Result.ok (x, x1)
 
 /- [no_nested_borrows::Tuple]
-   Source: 'tests/src/no_nested_borrows.rs', lines 472:0-472:24 -/
+   Source: 'tests/src/no_nested_borrows.rs', lines 474:0-474:24 -/
 def Tuple (T1 T2 : Type) := T1 × T2
 
 /- [no_nested_borrows::use_tuple_struct]:
-   Source: 'tests/src/no_nested_borrows.rs', lines 474:0-474:48 -/
+   Source: 'tests/src/no_nested_borrows.rs', lines 476:0-476:48 -/
 def use_tuple_struct (x : Tuple U32 U32) : Result (Tuple U32 U32) :=
   Result.ok (1#u32, x.#1)
 
 /- [no_nested_borrows::create_tuple_struct]:
-   Source: 'tests/src/no_nested_borrows.rs', lines 478:0-478:61 -/
+   Source: 'tests/src/no_nested_borrows.rs', lines 480:0-480:61 -/
 def create_tuple_struct (x : U32) (y : U64) : Result (Tuple U32 U64) :=
   Result.ok (x, y)
 
 /- [no_nested_borrows::IdType]
-   Source: 'tests/src/no_nested_borrows.rs', lines 483:0-483:20 -/
+   Source: 'tests/src/no_nested_borrows.rs', lines 485:0-485:20 -/
 @[reducible] def IdType (T : Type) := T
 
 /- [no_nested_borrows::use_id_type]:
-   Source: 'tests/src/no_nested_borrows.rs', lines 485:0-485:40 -/
+   Source: 'tests/src/no_nested_borrows.rs', lines 487:0-487:40 -/
 def use_id_type (T : Type) (x : IdType T) : Result T :=
   Result.ok x
 
 /- [no_nested_borrows::create_id_type]:
-   Source: 'tests/src/no_nested_borrows.rs', lines 489:0-489:43 -/
+   Source: 'tests/src/no_nested_borrows.rs', lines 491:0-491:43 -/
 def create_id_type (T : Type) (x : T) : Result (IdType T) :=
   Result.ok x
 

--- a/tests/lean/Paper.lean
+++ b/tests/lean/Paper.lean
@@ -6,12 +6,12 @@ open Primitives
 namespace paper
 
 /- [paper::ref_incr]:
-   Source: 'tests/src/paper.rs', lines 4:0-4:28 -/
+   Source: 'tests/src/paper.rs', lines 6:0-6:28 -/
 def ref_incr (x : I32) : Result I32 :=
   x + 1#i32
 
 /- [paper::test_incr]:
-   Source: 'tests/src/paper.rs', lines 8:0-8:18 -/
+   Source: 'tests/src/paper.rs', lines 10:0-10:18 -/
 def test_incr : Result Unit :=
   do
   let x ← ref_incr 0#i32
@@ -23,7 +23,7 @@ def test_incr : Result Unit :=
 #assert (test_incr == Result.ok ())
 
 /- [paper::choose]:
-   Source: 'tests/src/paper.rs', lines 15:0-15:70 -/
+   Source: 'tests/src/paper.rs', lines 17:0-17:70 -/
 def choose
   (T : Type) (b : Bool) (x : T) (y : T) :
   Result (T × (T → Result (T × T)))
@@ -35,7 +35,7 @@ def choose
        Result.ok (y, back)
 
 /- [paper::test_choose]:
-   Source: 'tests/src/paper.rs', lines 23:0-23:20 -/
+   Source: 'tests/src/paper.rs', lines 25:0-25:20 -/
 def test_choose : Result Unit :=
   do
   let (z, choose_back) ← choose I32 true 0#i32 0#i32
@@ -55,13 +55,13 @@ def test_choose : Result Unit :=
 #assert (test_choose == Result.ok ())
 
 /- [paper::List]
-   Source: 'tests/src/paper.rs', lines 35:0-35:16 -/
+   Source: 'tests/src/paper.rs', lines 37:0-37:16 -/
 inductive List (T : Type) :=
 | Cons : T → List T → List T
 | Nil : List T
 
 /- [paper::list_nth_mut]:
-   Source: 'tests/src/paper.rs', lines 42:0-42:67 -/
+   Source: 'tests/src/paper.rs', lines 44:0-44:67 -/
 divergent def list_nth_mut
   (T : Type) (l : List T) (i : U32) : Result (T × (T → Result (List T))) :=
   match l with
@@ -83,7 +83,7 @@ divergent def list_nth_mut
   | List.Nil => Result.fail .panic
 
 /- [paper::sum]:
-   Source: 'tests/src/paper.rs', lines 57:0-57:32 -/
+   Source: 'tests/src/paper.rs', lines 59:0-59:32 -/
 divergent def sum (l : List I32) : Result I32 :=
   match l with
   | List.Cons x tl => do
@@ -92,7 +92,7 @@ divergent def sum (l : List I32) : Result I32 :=
   | List.Nil => Result.ok 0#i32
 
 /- [paper::test_nth]:
-   Source: 'tests/src/paper.rs', lines 68:0-68:17 -/
+   Source: 'tests/src/paper.rs', lines 70:0-70:17 -/
 def test_nth : Result Unit :=
   do
   let l := List.Cons 3#i32 List.Nil
@@ -109,7 +109,7 @@ def test_nth : Result Unit :=
 #assert (test_nth == Result.ok ())
 
 /- [paper::call_choose]:
-   Source: 'tests/src/paper.rs', lines 76:0-76:44 -/
+   Source: 'tests/src/paper.rs', lines 78:0-78:44 -/
 def call_choose (p : (U32 × U32)) : Result U32 :=
   do
   let (px, py) := p

--- a/tests/lean/PoloniusList.lean
+++ b/tests/lean/PoloniusList.lean
@@ -6,13 +6,13 @@ open Primitives
 namespace polonius_list
 
 /- [polonius_list::List]
-   Source: 'tests/src/polonius_list.rs', lines 3:0-3:16 -/
+   Source: 'tests/src/polonius_list.rs', lines 5:0-5:16 -/
 inductive List (T : Type) :=
 | Cons : T → List T → List T
 | Nil : List T
 
 /- [polonius_list::get_list_at_x]:
-   Source: 'tests/src/polonius_list.rs', lines 13:0-13:76 -/
+   Source: 'tests/src/polonius_list.rs', lines 15:0-15:76 -/
 divergent def get_list_at_x
   (ls : List U32) (x : U32) :
   Result ((List U32) × (List U32 → Result (List U32)))

--- a/tests/lean/Traits.lean
+++ b/tests/lean/Traits.lean
@@ -6,29 +6,29 @@ open Primitives
 namespace traits
 
 /- Trait declaration: [traits::BoolTrait]
-   Source: 'tests/src/traits.rs', lines 1:0-1:19 -/
+   Source: 'tests/src/traits.rs', lines 2:0-2:19 -/
 structure BoolTrait (Self : Type) where
   get_bool : Self → Result Bool
 
 /- [traits::{(traits::BoolTrait for bool)}::get_bool]:
-   Source: 'tests/src/traits.rs', lines 12:4-12:30 -/
+   Source: 'tests/src/traits.rs', lines 13:4-13:30 -/
 def BoolTraitBool.get_bool (self : Bool) : Result Bool :=
   Result.ok self
 
 /- Trait implementation: [traits::{(traits::BoolTrait for bool)}]
-   Source: 'tests/src/traits.rs', lines 11:0-11:23 -/
+   Source: 'tests/src/traits.rs', lines 12:0-12:23 -/
 def BoolTraitBool : BoolTrait Bool := {
   get_bool := BoolTraitBool.get_bool
 }
 
 /- [traits::BoolTrait::ret_true]:
-   Source: 'tests/src/traits.rs', lines 6:4-6:30 -/
+   Source: 'tests/src/traits.rs', lines 7:4-7:30 -/
 def BoolTrait.ret_true
   {Self : Type} (self_clause : BoolTrait Self) (self : Self) : Result Bool :=
   Result.ok true
 
 /- [traits::test_bool_trait_bool]:
-   Source: 'tests/src/traits.rs', lines 17:0-17:44 -/
+   Source: 'tests/src/traits.rs', lines 18:0-18:44 -/
 def test_bool_trait_bool (x : Bool) : Result Bool :=
   do
   let b ← BoolTraitBool.get_bool x
@@ -37,20 +37,20 @@ def test_bool_trait_bool (x : Bool) : Result Bool :=
   else Result.ok false
 
 /- [traits::{(traits::BoolTrait for core::option::Option<T>)#1}::get_bool]:
-   Source: 'tests/src/traits.rs', lines 23:4-23:30 -/
+   Source: 'tests/src/traits.rs', lines 24:4-24:30 -/
 def BoolTraitOption.get_bool (T : Type) (self : Option T) : Result Bool :=
   match self with
   | none => Result.ok false
   | some _ => Result.ok true
 
 /- Trait implementation: [traits::{(traits::BoolTrait for core::option::Option<T>)#1}]
-   Source: 'tests/src/traits.rs', lines 22:0-22:31 -/
+   Source: 'tests/src/traits.rs', lines 23:0-23:31 -/
 def BoolTraitOption (T : Type) : BoolTrait (Option T) := {
   get_bool := BoolTraitOption.get_bool T
 }
 
 /- [traits::test_bool_trait_option]:
-   Source: 'tests/src/traits.rs', lines 31:0-31:54 -/
+   Source: 'tests/src/traits.rs', lines 32:0-32:54 -/
 def test_bool_trait_option (T : Type) (x : Option T) : Result Bool :=
   do
   let b ← BoolTraitOption.get_bool T x
@@ -59,29 +59,29 @@ def test_bool_trait_option (T : Type) (x : Option T) : Result Bool :=
   else Result.ok false
 
 /- [traits::test_bool_trait]:
-   Source: 'tests/src/traits.rs', lines 35:0-35:50 -/
+   Source: 'tests/src/traits.rs', lines 36:0-36:50 -/
 def test_bool_trait
   (T : Type) (BoolTraitInst : BoolTrait T) (x : T) : Result Bool :=
   BoolTraitInst.get_bool x
 
 /- Trait declaration: [traits::ToU64]
-   Source: 'tests/src/traits.rs', lines 39:0-39:15 -/
+   Source: 'tests/src/traits.rs', lines 40:0-40:15 -/
 structure ToU64 (Self : Type) where
   to_u64 : Self → Result U64
 
 /- [traits::{(traits::ToU64 for u64)#2}::to_u64]:
-   Source: 'tests/src/traits.rs', lines 44:4-44:26 -/
+   Source: 'tests/src/traits.rs', lines 45:4-45:26 -/
 def ToU64U64.to_u64 (self : U64) : Result U64 :=
   Result.ok self
 
 /- Trait implementation: [traits::{(traits::ToU64 for u64)#2}]
-   Source: 'tests/src/traits.rs', lines 43:0-43:18 -/
+   Source: 'tests/src/traits.rs', lines 44:0-44:18 -/
 def ToU64U64 : ToU64 U64 := {
   to_u64 := ToU64U64.to_u64
 }
 
 /- [traits::{(traits::ToU64 for (A, A))#3}::to_u64]:
-   Source: 'tests/src/traits.rs', lines 50:4-50:26 -/
+   Source: 'tests/src/traits.rs', lines 51:4-51:26 -/
 def ToU64Pair.to_u64
   (A : Type) (ToU64Inst : ToU64 A) (self : (A × A)) : Result U64 :=
   do
@@ -91,78 +91,78 @@ def ToU64Pair.to_u64
   i + i1
 
 /- Trait implementation: [traits::{(traits::ToU64 for (A, A))#3}]
-   Source: 'tests/src/traits.rs', lines 49:0-49:31 -/
+   Source: 'tests/src/traits.rs', lines 50:0-50:31 -/
 def ToU64Pair (A : Type) (ToU64Inst : ToU64 A) : ToU64 (A × A) := {
   to_u64 := ToU64Pair.to_u64 A ToU64Inst
 }
 
 /- [traits::f]:
-   Source: 'tests/src/traits.rs', lines 55:0-55:36 -/
+   Source: 'tests/src/traits.rs', lines 56:0-56:36 -/
 def f (T : Type) (ToU64Inst : ToU64 T) (x : (T × T)) : Result U64 :=
   ToU64Pair.to_u64 T ToU64Inst x
 
 /- [traits::g]:
-   Source: 'tests/src/traits.rs', lines 59:0-61:18 -/
+   Source: 'tests/src/traits.rs', lines 60:0-62:18 -/
 def g
   (T : Type) (ToU64PairInst : ToU64 (T × T)) (x : (T × T)) : Result U64 :=
   ToU64PairInst.to_u64 x
 
 /- [traits::h0]:
-   Source: 'tests/src/traits.rs', lines 66:0-66:24 -/
+   Source: 'tests/src/traits.rs', lines 67:0-67:24 -/
 def h0 (x : U64) : Result U64 :=
   ToU64U64.to_u64 x
 
 /- [traits::Wrapper]
-   Source: 'tests/src/traits.rs', lines 70:0-70:21 -/
+   Source: 'tests/src/traits.rs', lines 71:0-71:21 -/
 structure Wrapper (T : Type) where
   x : T
 
 /- [traits::{(traits::ToU64 for traits::Wrapper<T>)#4}::to_u64]:
-   Source: 'tests/src/traits.rs', lines 75:4-75:26 -/
+   Source: 'tests/src/traits.rs', lines 76:4-76:26 -/
 def ToU64traitsWrapper.to_u64
   (T : Type) (ToU64Inst : ToU64 T) (self : Wrapper T) : Result U64 :=
   ToU64Inst.to_u64 self.x
 
 /- Trait implementation: [traits::{(traits::ToU64 for traits::Wrapper<T>)#4}]
-   Source: 'tests/src/traits.rs', lines 74:0-74:35 -/
+   Source: 'tests/src/traits.rs', lines 75:0-75:35 -/
 def ToU64traitsWrapper (T : Type) (ToU64Inst : ToU64 T) : ToU64 (Wrapper T)
   := {
   to_u64 := ToU64traitsWrapper.to_u64 T ToU64Inst
 }
 
 /- [traits::h1]:
-   Source: 'tests/src/traits.rs', lines 80:0-80:33 -/
+   Source: 'tests/src/traits.rs', lines 81:0-81:33 -/
 def h1 (x : Wrapper U64) : Result U64 :=
   ToU64traitsWrapper.to_u64 U64 ToU64U64 x
 
 /- [traits::h2]:
-   Source: 'tests/src/traits.rs', lines 84:0-84:41 -/
+   Source: 'tests/src/traits.rs', lines 85:0-85:41 -/
 def h2 (T : Type) (ToU64Inst : ToU64 T) (x : Wrapper T) : Result U64 :=
   ToU64traitsWrapper.to_u64 T ToU64Inst x
 
 /- Trait declaration: [traits::ToType]
-   Source: 'tests/src/traits.rs', lines 88:0-88:19 -/
+   Source: 'tests/src/traits.rs', lines 89:0-89:19 -/
 structure ToType (Self T : Type) where
   to_type : Self → Result T
 
 /- [traits::{(traits::ToType<bool> for u64)#5}::to_type]:
-   Source: 'tests/src/traits.rs', lines 93:4-93:28 -/
+   Source: 'tests/src/traits.rs', lines 94:4-94:28 -/
 def ToTypeU64Bool.to_type (self : U64) : Result Bool :=
   Result.ok (self > 0#u64)
 
 /- Trait implementation: [traits::{(traits::ToType<bool> for u64)#5}]
-   Source: 'tests/src/traits.rs', lines 92:0-92:25 -/
+   Source: 'tests/src/traits.rs', lines 93:0-93:25 -/
 def ToTypeU64Bool : ToType U64 Bool := {
   to_type := ToTypeU64Bool.to_type
 }
 
 /- Trait declaration: [traits::OfType]
-   Source: 'tests/src/traits.rs', lines 98:0-98:16 -/
+   Source: 'tests/src/traits.rs', lines 99:0-99:16 -/
 structure OfType (Self : Type) where
   of_type : forall (T : Type) (ToTypeInst : ToType T Self), T → Result Self
 
 /- [traits::h3]:
-   Source: 'tests/src/traits.rs', lines 104:0-104:50 -/
+   Source: 'tests/src/traits.rs', lines 105:0-105:50 -/
 def h3
   (T1 T2 : Type) (OfTypeInst : OfType T1) (ToTypeInst : ToType T2 T1) 
   (y : T2) :
@@ -171,13 +171,13 @@ def h3
   OfTypeInst.of_type T2 ToTypeInst y
 
 /- Trait declaration: [traits::OfTypeBis]
-   Source: 'tests/src/traits.rs', lines 109:0-109:36 -/
+   Source: 'tests/src/traits.rs', lines 110:0-110:36 -/
 structure OfTypeBis (Self T : Type) where
   ToTypeInst : ToType T Self
   of_type : T → Result Self
 
 /- [traits::h4]:
-   Source: 'tests/src/traits.rs', lines 118:0-118:57 -/
+   Source: 'tests/src/traits.rs', lines 119:0-119:57 -/
 def h4
   (T1 T2 : Type) (OfTypeBisInst : OfTypeBis T1 T2) (ToTypeInst : ToType T2 T1)
   (y : T2) :
@@ -186,33 +186,33 @@ def h4
   OfTypeBisInst.of_type y
 
 /- [traits::TestType]
-   Source: 'tests/src/traits.rs', lines 122:0-122:22 -/
+   Source: 'tests/src/traits.rs', lines 123:0-123:22 -/
 @[reducible] def TestType (T : Type) := T
 
 /- [traits::{traits::TestType<T>#6}::test::TestType1]
-   Source: 'tests/src/traits.rs', lines 127:8-127:24 -/
+   Source: 'tests/src/traits.rs', lines 128:8-128:24 -/
 @[reducible] def TestType.test.TestType1 := U64
 
 /- Trait declaration: [traits::{traits::TestType<T>#6}::test::TestTrait]
-   Source: 'tests/src/traits.rs', lines 128:8-128:23 -/
+   Source: 'tests/src/traits.rs', lines 129:8-129:23 -/
 structure TestType.test.TestTrait (Self : Type) where
   test : Self → Result Bool
 
 /- [traits::{traits::TestType<T>#6}::test::{(traits::{traits::TestType<T>#6}::test::TestTrait for traits::{traits::TestType<T>#6}::test::TestType1)}::test]:
-   Source: 'tests/src/traits.rs', lines 139:12-139:34 -/
+   Source: 'tests/src/traits.rs', lines 140:12-140:34 -/
 def TestType.test.TestTraittraitsTestTypetestTestType1.test
   (self : TestType.test.TestType1) : Result Bool :=
   Result.ok (self > 1#u64)
 
 /- Trait implementation: [traits::{traits::TestType<T>#6}::test::{(traits::{traits::TestType<T>#6}::test::TestTrait for traits::{traits::TestType<T>#6}::test::TestType1)}]
-   Source: 'tests/src/traits.rs', lines 138:8-138:36 -/
+   Source: 'tests/src/traits.rs', lines 139:8-139:36 -/
 def TestType.test.TestTraittraitsTestTypetestTestType1 :
   TestType.test.TestTrait TestType.test.TestType1 := {
   test := TestType.test.TestTraittraitsTestTypetestTestType1.test
 }
 
 /- [traits::{traits::TestType<T>#6}::test]:
-   Source: 'tests/src/traits.rs', lines 126:4-126:36 -/
+   Source: 'tests/src/traits.rs', lines 127:4-127:36 -/
 def TestType.test
   (T : Type) (ToU64Inst : ToU64 T) (self : TestType T) (x : T) : Result Bool :=
   do
@@ -222,11 +222,11 @@ def TestType.test
   else Result.ok false
 
 /- [traits::BoolWrapper]
-   Source: 'tests/src/traits.rs', lines 150:0-150:22 -/
+   Source: 'tests/src/traits.rs', lines 151:0-151:22 -/
 @[reducible] def BoolWrapper := Bool
 
 /- [traits::{(traits::ToType<T> for traits::BoolWrapper)#7}::to_type]:
-   Source: 'tests/src/traits.rs', lines 156:4-156:25 -/
+   Source: 'tests/src/traits.rs', lines 157:4-157:25 -/
 def ToTypetraitsBoolWrapperT.to_type
   (T : Type) (ToTypeBoolTInst : ToType Bool T) (self : BoolWrapper) :
   Result T
@@ -234,21 +234,21 @@ def ToTypetraitsBoolWrapperT.to_type
   ToTypeBoolTInst.to_type self
 
 /- Trait implementation: [traits::{(traits::ToType<T> for traits::BoolWrapper)#7}]
-   Source: 'tests/src/traits.rs', lines 152:0-152:33 -/
+   Source: 'tests/src/traits.rs', lines 153:0-153:33 -/
 def ToTypetraitsBoolWrapperT (T : Type) (ToTypeBoolTInst : ToType Bool T) :
   ToType BoolWrapper T := {
   to_type := ToTypetraitsBoolWrapperT.to_type T ToTypeBoolTInst
 }
 
 /- [traits::WithConstTy::LEN2]
-   Source: 'tests/src/traits.rs', lines 164:4-164:21 -/
+   Source: 'tests/src/traits.rs', lines 165:4-165:21 -/
 def WithConstTy.LEN2_default_body (Self : Type) (LEN : Usize) : Result Usize :=
   Result.ok 32#usize
 def WithConstTy.LEN2_default (Self : Type) (LEN : Usize) : Usize :=
   eval_global (WithConstTy.LEN2_default_body Self LEN)
 
 /- Trait declaration: [traits::WithConstTy]
-   Source: 'tests/src/traits.rs', lines 161:0-161:39 -/
+   Source: 'tests/src/traits.rs', lines 162:0-162:39 -/
 structure WithConstTy (Self : Type) (LEN : Usize) where
   LEN1 : Usize
   LEN2 : Usize
@@ -258,17 +258,17 @@ structure WithConstTy (Self : Type) (LEN : Usize) where
   f : W → Array U8 LEN → Result W
 
 /- [traits::{(traits::WithConstTy<32: usize> for bool)#8}::LEN1]
-   Source: 'tests/src/traits.rs', lines 175:4-175:21 -/
+   Source: 'tests/src/traits.rs', lines 176:4-176:21 -/
 def WithConstTyBool32.LEN1_body : Result Usize := Result.ok 12#usize
 def WithConstTyBool32.LEN1 : Usize := eval_global WithConstTyBool32.LEN1_body
 
 /- [traits::{(traits::WithConstTy<32: usize> for bool)#8}::f]:
-   Source: 'tests/src/traits.rs', lines 180:4-180:39 -/
+   Source: 'tests/src/traits.rs', lines 181:4-181:39 -/
 def WithConstTyBool32.f (i : U64) (a : Array U8 32#usize) : Result U64 :=
   Result.ok i
 
 /- Trait implementation: [traits::{(traits::WithConstTy<32: usize> for bool)#8}]
-   Source: 'tests/src/traits.rs', lines 174:0-174:29 -/
+   Source: 'tests/src/traits.rs', lines 175:0-175:29 -/
 def WithConstTyBool32 : WithConstTy Bool 32#usize := {
   LEN1 := WithConstTyBool32.LEN1
   LEN2 := WithConstTy.LEN2_default Bool 32#usize
@@ -279,7 +279,7 @@ def WithConstTyBool32 : WithConstTy Bool 32#usize := {
 }
 
 /- [traits::use_with_const_ty1]:
-   Source: 'tests/src/traits.rs', lines 183:0-183:75 -/
+   Source: 'tests/src/traits.rs', lines 184:0-184:75 -/
 def use_with_const_ty1
   (H : Type) (LEN : Usize) (WithConstTyInst : WithConstTy H LEN) :
   Result Usize
@@ -287,7 +287,7 @@ def use_with_const_ty1
   Result.ok WithConstTyInst.LEN1
 
 /- [traits::use_with_const_ty2]:
-   Source: 'tests/src/traits.rs', lines 187:0-187:73 -/
+   Source: 'tests/src/traits.rs', lines 188:0-188:73 -/
 def use_with_const_ty2
   (H : Type) (LEN : Usize) (WithConstTyInst : WithConstTy H LEN)
   (w : WithConstTyInst.W) :
@@ -296,7 +296,7 @@ def use_with_const_ty2
   Result.ok ()
 
 /- [traits::use_with_const_ty3]:
-   Source: 'tests/src/traits.rs', lines 189:0-189:80 -/
+   Source: 'tests/src/traits.rs', lines 190:0-190:80 -/
 def use_with_const_ty3
   (H : Type) (LEN : Usize) (WithConstTyInst : WithConstTy H LEN)
   (x : WithConstTyInst.W) :
@@ -305,12 +305,12 @@ def use_with_const_ty3
   WithConstTyInst.W_clause_0.to_u64 x
 
 /- [traits::test_where1]:
-   Source: 'tests/src/traits.rs', lines 193:0-193:40 -/
+   Source: 'tests/src/traits.rs', lines 194:0-194:40 -/
 def test_where1 (T : Type) (_x : T) : Result Unit :=
   Result.ok ()
 
 /- [traits::test_where2]:
-   Source: 'tests/src/traits.rs', lines 194:0-194:57 -/
+   Source: 'tests/src/traits.rs', lines 195:0-195:57 -/
 def test_where2
   (T : Type) (WithConstTyT32Inst : WithConstTy T 32#usize) (_x : U32) :
   Result Unit
@@ -318,30 +318,30 @@ def test_where2
   Result.ok ()
 
 /- Trait declaration: [traits::ParentTrait0]
-   Source: 'tests/src/traits.rs', lines 200:0-200:22 -/
+   Source: 'tests/src/traits.rs', lines 201:0-201:22 -/
 structure ParentTrait0 (Self : Type) where
   W : Type
   get_name : Self → Result String
   get_w : Self → Result W
 
 /- Trait declaration: [traits::ParentTrait1]
-   Source: 'tests/src/traits.rs', lines 205:0-205:22 -/
+   Source: 'tests/src/traits.rs', lines 206:0-206:22 -/
 structure ParentTrait1 (Self : Type) where
 
 /- Trait declaration: [traits::ChildTrait]
-   Source: 'tests/src/traits.rs', lines 206:0-206:49 -/
+   Source: 'tests/src/traits.rs', lines 207:0-207:49 -/
 structure ChildTrait (Self : Type) where
   ParentTrait0Inst : ParentTrait0 Self
   ParentTrait1Inst : ParentTrait1 Self
 
 /- [traits::test_child_trait1]:
-   Source: 'tests/src/traits.rs', lines 209:0-209:56 -/
+   Source: 'tests/src/traits.rs', lines 210:0-210:56 -/
 def test_child_trait1
   (T : Type) (ChildTraitInst : ChildTrait T) (x : T) : Result String :=
   ChildTraitInst.ParentTrait0Inst.get_name x
 
 /- [traits::test_child_trait2]:
-   Source: 'tests/src/traits.rs', lines 213:0-213:54 -/
+   Source: 'tests/src/traits.rs', lines 214:0-214:54 -/
 def test_child_trait2
   (T : Type) (ChildTraitInst : ChildTrait T) (x : T) :
   Result ChildTraitInst.ParentTrait0Inst.W
@@ -349,7 +349,7 @@ def test_child_trait2
   ChildTraitInst.ParentTrait0Inst.get_w x
 
 /- [traits::order1]:
-   Source: 'tests/src/traits.rs', lines 219:0-219:59 -/
+   Source: 'tests/src/traits.rs', lines 220:0-220:59 -/
 def order1
   (T U : Type) (ParentTrait0Inst : ParentTrait0 T) (ParentTrait0Inst1 :
   ParentTrait0 U) :
@@ -358,28 +358,28 @@ def order1
   Result.ok ()
 
 /- Trait declaration: [traits::ChildTrait1]
-   Source: 'tests/src/traits.rs', lines 222:0-222:35 -/
+   Source: 'tests/src/traits.rs', lines 223:0-223:35 -/
 structure ChildTrait1 (Self : Type) where
   ParentTrait1Inst : ParentTrait1 Self
 
 /- Trait implementation: [traits::{(traits::ParentTrait1 for usize)#9}]
-   Source: 'tests/src/traits.rs', lines 224:0-224:27 -/
+   Source: 'tests/src/traits.rs', lines 225:0-225:27 -/
 def ParentTrait1Usize : ParentTrait1 Usize := {
 }
 
 /- Trait implementation: [traits::{(traits::ChildTrait1 for usize)#10}]
-   Source: 'tests/src/traits.rs', lines 225:0-225:26 -/
+   Source: 'tests/src/traits.rs', lines 226:0-226:26 -/
 def ChildTrait1Usize : ChildTrait1 Usize := {
   ParentTrait1Inst := ParentTrait1Usize
 }
 
 /- Trait declaration: [traits::Iterator]
-   Source: 'tests/src/traits.rs', lines 229:0-229:18 -/
+   Source: 'tests/src/traits.rs', lines 230:0-230:18 -/
 structure Iterator (Self : Type) where
   Item : Type
 
 /- Trait declaration: [traits::IntoIterator]
-   Source: 'tests/src/traits.rs', lines 233:0-233:22 -/
+   Source: 'tests/src/traits.rs', lines 234:0-234:22 -/
 structure IntoIterator (Self : Type) where
   Item : Type
   IntoIter : Type
@@ -387,106 +387,106 @@ structure IntoIterator (Self : Type) where
   into_iter : Self → Result IntoIter
 
 /- Trait declaration: [traits::FromResidual]
-   Source: 'tests/src/traits.rs', lines 250:0-250:21 -/
+   Source: 'tests/src/traits.rs', lines 251:0-251:21 -/
 structure FromResidual (Self T : Type) where
 
 /- Trait declaration: [traits::Try]
-   Source: 'tests/src/traits.rs', lines 246:0-246:48 -/
+   Source: 'tests/src/traits.rs', lines 247:0-247:48 -/
 structure Try (Self : Type) where
   Residual : Type
   FromResidualSelftraitsTryResidualInst : FromResidual Self Residual
 
 /- Trait declaration: [traits::WithTarget]
-   Source: 'tests/src/traits.rs', lines 252:0-252:20 -/
+   Source: 'tests/src/traits.rs', lines 253:0-253:20 -/
 structure WithTarget (Self : Type) where
   Target : Type
 
 /- Trait declaration: [traits::ParentTrait2]
-   Source: 'tests/src/traits.rs', lines 256:0-256:22 -/
+   Source: 'tests/src/traits.rs', lines 257:0-257:22 -/
 structure ParentTrait2 (Self : Type) where
   U : Type
   U_clause_0 : WithTarget U
 
 /- Trait declaration: [traits::ChildTrait2]
-   Source: 'tests/src/traits.rs', lines 260:0-260:35 -/
+   Source: 'tests/src/traits.rs', lines 261:0-261:35 -/
 structure ChildTrait2 (Self : Type) where
   ParentTrait2Inst : ParentTrait2 Self
   convert : ParentTrait2Inst.U → Result ParentTrait2Inst.U_clause_0.Target
 
 /- Trait implementation: [traits::{(traits::WithTarget for u32)#11}]
-   Source: 'tests/src/traits.rs', lines 264:0-264:23 -/
+   Source: 'tests/src/traits.rs', lines 265:0-265:23 -/
 def WithTargetU32 : WithTarget U32 := {
   Target := U32
 }
 
 /- Trait implementation: [traits::{(traits::ParentTrait2 for u32)#12}]
-   Source: 'tests/src/traits.rs', lines 268:0-268:25 -/
+   Source: 'tests/src/traits.rs', lines 269:0-269:25 -/
 def ParentTrait2U32 : ParentTrait2 U32 := {
   U := U32
   U_clause_0 := WithTargetU32
 }
 
 /- [traits::{(traits::ChildTrait2 for u32)#13}::convert]:
-   Source: 'tests/src/traits.rs', lines 273:4-273:29 -/
+   Source: 'tests/src/traits.rs', lines 274:4-274:29 -/
 def ChildTrait2U32.convert (x : U32) : Result U32 :=
   Result.ok x
 
 /- Trait implementation: [traits::{(traits::ChildTrait2 for u32)#13}]
-   Source: 'tests/src/traits.rs', lines 272:0-272:24 -/
+   Source: 'tests/src/traits.rs', lines 273:0-273:24 -/
 def ChildTrait2U32 : ChildTrait2 U32 := {
   ParentTrait2Inst := ParentTrait2U32
   convert := ChildTrait2U32.convert
 }
 
 /- Trait declaration: [traits::CFnOnce]
-   Source: 'tests/src/traits.rs', lines 286:0-286:23 -/
+   Source: 'tests/src/traits.rs', lines 287:0-287:23 -/
 structure CFnOnce (Self Args : Type) where
   Output : Type
   call_once : Self → Args → Result Output
 
 /- Trait declaration: [traits::CFnMut]
-   Source: 'tests/src/traits.rs', lines 292:0-292:37 -/
+   Source: 'tests/src/traits.rs', lines 293:0-293:37 -/
 structure CFnMut (Self Args : Type) where
   CFnOnceInst : CFnOnce Self Args
   call_mut : Self → Args → Result (CFnOnceInst.Output × Self)
 
 /- Trait declaration: [traits::CFn]
-   Source: 'tests/src/traits.rs', lines 296:0-296:33 -/
+   Source: 'tests/src/traits.rs', lines 297:0-297:33 -/
 structure CFn (Self Args : Type) where
   CFnMutInst : CFnMut Self Args
   call : Self → Args → Result CFnMutInst.CFnOnceInst.Output
 
 /- Trait declaration: [traits::GetTrait]
-   Source: 'tests/src/traits.rs', lines 300:0-300:18 -/
+   Source: 'tests/src/traits.rs', lines 301:0-301:18 -/
 structure GetTrait (Self : Type) where
   W : Type
   get_w : Self → Result W
 
 /- [traits::test_get_trait]:
-   Source: 'tests/src/traits.rs', lines 305:0-305:49 -/
+   Source: 'tests/src/traits.rs', lines 306:0-306:49 -/
 def test_get_trait
   (T : Type) (GetTraitInst : GetTrait T) (x : T) : Result GetTraitInst.W :=
   GetTraitInst.get_w x
 
 /- Trait declaration: [traits::Trait]
-   Source: 'tests/src/traits.rs', lines 310:0-310:15 -/
+   Source: 'tests/src/traits.rs', lines 311:0-311:15 -/
 structure Trait (Self : Type) where
   LEN : Usize
 
 /- [traits::{(traits::Trait for @Array<T, N>)#14}::LEN]
-   Source: 'tests/src/traits.rs', lines 315:4-315:20 -/
+   Source: 'tests/src/traits.rs', lines 316:4-316:20 -/
 def TraitArray.LEN_body (T : Type) (N : Usize) : Result Usize := Result.ok N
 def TraitArray.LEN (T : Type) (N : Usize) : Usize :=
   eval_global (TraitArray.LEN_body T N)
 
 /- Trait implementation: [traits::{(traits::Trait for @Array<T, N>)#14}]
-   Source: 'tests/src/traits.rs', lines 314:0-314:40 -/
+   Source: 'tests/src/traits.rs', lines 315:0-315:40 -/
 def TraitArray (T : Type) (N : Usize) : Trait (Array T N) := {
   LEN := TraitArray.LEN T N
 }
 
 /- [traits::{(traits::Trait for traits::Wrapper<T>)#15}::LEN]
-   Source: 'tests/src/traits.rs', lines 319:4-319:20 -/
+   Source: 'tests/src/traits.rs', lines 320:4-320:20 -/
 def TraittraitsWrapper.LEN_body (T : Type) (TraitInst : Trait T)
   : Result Usize :=
   Result.ok 0#usize
@@ -494,19 +494,19 @@ def TraittraitsWrapper.LEN (T : Type) (TraitInst : Trait T) : Usize :=
   eval_global (TraittraitsWrapper.LEN_body T TraitInst)
 
 /- Trait implementation: [traits::{(traits::Trait for traits::Wrapper<T>)#15}]
-   Source: 'tests/src/traits.rs', lines 318:0-318:35 -/
+   Source: 'tests/src/traits.rs', lines 319:0-319:35 -/
 def TraittraitsWrapper (T : Type) (TraitInst : Trait T) : Trait (Wrapper T)
   := {
   LEN := TraittraitsWrapper.LEN T TraitInst
 }
 
 /- [traits::use_wrapper_len]:
-   Source: 'tests/src/traits.rs', lines 322:0-322:43 -/
+   Source: 'tests/src/traits.rs', lines 323:0-323:43 -/
 def use_wrapper_len (T : Type) (TraitInst : Trait T) : Result Usize :=
   Result.ok (TraittraitsWrapper T TraitInst).LEN
 
 /- [traits::Foo]
-   Source: 'tests/src/traits.rs', lines 326:0-326:20 -/
+   Source: 'tests/src/traits.rs', lines 327:0-327:20 -/
 structure Foo (T U : Type) where
   x : T
   y : U
@@ -519,7 +519,7 @@ inductive core.result.Result (T E : Type) :=
 | Err : E → core.result.Result T E
 
 /- [traits::{traits::Foo<T, U>#16}::FOO]
-   Source: 'tests/src/traits.rs', lines 332:4-332:33 -/
+   Source: 'tests/src/traits.rs', lines 333:4-333:33 -/
 def Foo.FOO_body (T U : Type) (TraitInst : Trait T)
   : Result (core.result.Result T I32) :=
   Result.ok (core.result.Result.Err 0#i32)
@@ -527,13 +527,13 @@ def Foo.FOO (T U : Type) (TraitInst : Trait T) : core.result.Result T I32 :=
   eval_global (Foo.FOO_body T U TraitInst)
 
 /- [traits::use_foo1]:
-   Source: 'tests/src/traits.rs', lines 335:0-335:48 -/
+   Source: 'tests/src/traits.rs', lines 336:0-336:48 -/
 def use_foo1
   (T U : Type) (TraitInst : Trait T) : Result (core.result.Result T I32) :=
   Result.ok (Foo.FOO T U TraitInst)
 
 /- [traits::use_foo2]:
-   Source: 'tests/src/traits.rs', lines 339:0-339:48 -/
+   Source: 'tests/src/traits.rs', lines 340:0-340:48 -/
 def use_foo2
   (T U : Type) (TraitInst : Trait U) : Result (core.result.Result U I32) :=
   Result.ok (Foo.FOO U T TraitInst)

--- a/tests/src/arrays.rs
+++ b/tests/src/arrays.rs
@@ -1,3 +1,6 @@
+//@ [coq] aeneas-args=-use-fuel
+//@ [fstar] aeneas-args=-decreases-clauses -template-clauses
+//@ [fstar] aeneas-args=-split-files
 //! Exercise the translation of arrays, with features supported by Eurydice
 
 pub enum AB {

--- a/tests/src/bitwise.rs
+++ b/tests/src/bitwise.rs
@@ -1,3 +1,4 @@
+//@ aeneas-args=-test-trans-units
 //! Exercise the bitwise operations
 
 pub fn shift_u32(a: u32) -> u32 {

--- a/tests/src/constants.rs
+++ b/tests/src/constants.rs
@@ -1,3 +1,5 @@
+//@ charon-args=--no-code-duplication
+//@ aeneas-args=-test-trans-units
 //! Tests with constants
 
 // Integers

--- a/tests/src/demo.rs
+++ b/tests/src/demo.rs
@@ -1,3 +1,4 @@
+//@ [coq,fstar] aeneas-args=-use-fuel
 #![allow(clippy::needless_lifetimes)]
 
 /* Simple functions */

--- a/tests/src/external.rs
+++ b/tests/src/external.rs
@@ -1,3 +1,6 @@
+//@ charon-args=--no-code-duplication
+//@ aeneas-args=-state -split-files
+//@ aeneas-args=-test-trans-units
 //! This module uses external types and functions
 
 use std::cell::Cell;

--- a/tests/src/hashmap.rs
+++ b/tests/src/hashmap.rs
@@ -1,3 +1,11 @@
+//@ [coq] aeneas-args=-use-fuel
+//@ aeneas-args=-split-files
+//@ [fstar] aeneas-args=-decreases-clauses -template-clauses
+//@ [lean] aeneas-args=-no-gen-lib-entry
+// ^ the `-no-gen-lib-entry` is because we add a custom import in the Hashmap.lean file: we do not
+// want to overwrite it.
+// TODO: reactivate -test-trans-units
+
 //! A hashmap implementation.
 //!
 //! Current limitations:

--- a/tests/src/hashmap_main.rs
+++ b/tests/src/hashmap_main.rs
@@ -1,3 +1,9 @@
+//@ charon-args=--opaque=hashmap_utils
+//@ aeneas-args=-state -split-files
+//@ [coq] aeneas-args=-use-fuel
+//@ [fstar] aeneas-args=-decreases-clauses -template-clauses
+// Possible to add `--no-code-duplication` if we use the optimized MIR
+// TODO: reactivate -test-trans-units
 mod hashmap;
 mod hashmap_utils;
 

--- a/tests/src/hashmap_utils.rs
+++ b/tests/src/hashmap_utils.rs
@@ -1,3 +1,4 @@
+//@ skip
 use crate::hashmap::*;
 
 /// Serialize a hash map - we don't have traits, so we fix the type of the

--- a/tests/src/loops.rs
+++ b/tests/src/loops.rs
@@ -1,3 +1,6 @@
+//@ [coq] aeneas-args=-use-fuel
+//@ [fstar] aeneas-args=-decreases-clauses -template-clauses
+//@ [fstar] aeneas-args=-split-files
 use std::vec::Vec;
 
 /// No borrows

--- a/tests/src/nested_borrows.rs
+++ b/tests/src/nested_borrows.rs
@@ -1,3 +1,5 @@
+//@ skip
+//@ charon-args=--no-code-duplication
 //! This module contains functions with nested borrows in their signatures.
 
 pub fn id_mut_mut<'a, 'b, T>(x: &'a mut &'b mut T) -> &'a mut &'b mut T {

--- a/tests/src/no_nested_borrows.rs
+++ b/tests/src/no_nested_borrows.rs
@@ -1,3 +1,5 @@
+//@ charon-args=--no-code-duplication
+//@ aeneas-args=-test-trans-units
 //! This module doesn't contain **functions which use nested borrows in their
 //! signatures**, and doesn't contain functions with loops.
 

--- a/tests/src/paper.rs
+++ b/tests/src/paper.rs
@@ -1,3 +1,5 @@
+//@ charon-args=--no-code-duplication
+//@ aeneas-args=-test-trans-units
 //! The examples from the ICFP submission, all in one place.
 
 // 2.1

--- a/tests/src/polonius_list.rs
+++ b/tests/src/polonius_list.rs
@@ -1,3 +1,5 @@
+//@ charon-args=--polonius
+//@ aeneas-args=-test-trans-units
 #![allow(dead_code)]
 
 pub enum List<T> {

--- a/tests/src/traits.rs
+++ b/tests/src/traits.rs
@@ -1,3 +1,4 @@
+//@ [fstar] aeneas-args=-decreases-clauses -template-clauses
 pub trait BoolTrait {
     // Required method
     fn get_bool(&self) -> bool;

--- a/tests/test_runner/dune
+++ b/tests/test_runner/dune
@@ -1,4 +1,10 @@
 (executable
  (public_name test_runner)
  (libraries core_unix.sys_unix unix)
+ (preprocess
+  (pps ppx_deriving.show ppx_deriving.ord ppx_sexp_conv))
  (name run_test))
+
+(env
+ (dev
+  (flags :standard -warn-error -5@8-11-14-32-33-20-21-26-27-39)))

--- a/tests/test_runner/dune
+++ b/tests/test_runner/dune
@@ -1,6 +1,6 @@
 (executable
  (public_name test_runner)
- (libraries core_unix.sys_unix unix)
+ (libraries core_unix.sys_unix re unix)
  (preprocess
   (pps ppx_deriving.show ppx_deriving.ord ppx_sexp_conv))
  (name run_test))

--- a/tests/test_runner/run_test.ml
+++ b/tests/test_runner/run_test.ml
@@ -5,22 +5,38 @@ type runner_env = {
   llbc_dir : string;
 }
 
-(* The data for a specific test to run aeneas on *)
-type aeneas_test_case = {
-  name : string;
-  backend : string;
-  subdir : string;
-  extra_aeneas_options : string list;
-}
+module Backend = struct
+  type t = Coq | Lean | FStar | HOL4 [@@deriving ord, sexp]
+
+  (* TODO: reactivate HOL4 once traits are parameterized by their associated types *)
+  let all = [ Coq; Lean; FStar ]
+
+  let of_string = function
+    | "coq" -> Coq
+    | "lean" -> Lean
+    | "fstar" -> FStar
+    | "hol4" -> HOL4
+    | backend -> failwith ("Unknown backend: `" ^ backend ^ "`")
+
+  let to_string = function
+    | Coq -> "coq"
+    | Lean -> "lean"
+    | FStar -> "fstar"
+    | HOL4 -> "hol4"
+end
+
+module BackendMap = Map.Make (Backend)
 
 type input_kind = SingleFile | Crate
 
-(* The data for a specific test to generate llbc for *)
-type charon_test_case = {
-  kind : input_kind;
+(* The data for a specific test input *)
+type test_case = {
   name : string;
   path : string;
-  extra_charon_options : string list;
+  input_kind : input_kind;
+  charon_options : string list;
+  aeneas_options : string list BackendMap.t;
+  subdir : string BackendMap.t;
 }
 
 let concat_path = List.fold_left Filename.concat ""
@@ -43,21 +59,26 @@ let run_command args =
   ()
 
 (* Run Aeneas on a specific input with the given options *)
-let run_aeneas (env : runner_env) (case : aeneas_test_case) =
-  let input_file = concat_path [ env.llbc_dir; case.name ] ^ ".llbc" in
-  let dest_dir = concat_path [ "tests"; case.backend; case.subdir ] in
+let run_aeneas (env : runner_env) (case : test_case) (backend : Backend.t) =
+  (* FIXME: remove this special case *)
+  let test_name = if case.name = "betree" then "betree_main" else case.name in
+  let input_file = concat_path [ env.llbc_dir; test_name ] ^ ".llbc" in
+  let subdir = BackendMap.find backend case.subdir in
+  let aeneas_options = BackendMap.find backend case.aeneas_options in
+  let backend_str = Backend.to_string backend in
+  let dest_dir = concat_path [ "tests"; backend_str; subdir ] in
   let args =
     [|
-      env.aeneas_path; input_file; "-dest"; dest_dir; "-backend"; case.backend;
+      env.aeneas_path; input_file; "-dest"; dest_dir; "-backend"; backend_str;
     |]
   in
-  let args = Array.append args (Array.of_list case.extra_aeneas_options) in
+  let args = Array.append args (Array.of_list aeneas_options) in
   (* Run Aeneas *)
   run_command args
 
 (* Run Charon on a specific input with the given options *)
-let run_charon (env : runner_env) (case : charon_test_case) =
-  match case.kind with
+let run_charon (env : runner_env) (case : test_case) =
+  match case.input_kind with
   | SingleFile ->
       let args =
         [|
@@ -71,16 +92,14 @@ let run_charon (env : runner_env) (case : charon_test_case) =
           env.llbc_dir;
         |]
       in
-      let args = Array.append args (Array.of_list case.extra_charon_options) in
+      let args = Array.append args (Array.of_list case.charon_options) in
       (* Run Charon on the rust file *)
       run_command args
   | Crate -> (
       match Sys.getenv_opt "IN_CI" with
       | None ->
           let args = [| env.charon_path; "--dest"; env.llbc_dir |] in
-          let args =
-            Array.append args (Array.of_list case.extra_charon_options)
-          in
+          let args = Array.append args (Array.of_list case.charon_options) in
           (* Run Charon inside the crate *)
           let old_pwd = Unix.getcwd () in
           Unix.chdir case.path;
@@ -96,12 +115,13 @@ let run_charon (env : runner_env) (case : charon_test_case) =
 
 (* File-specific options *)
 let aeneas_options_for_test backend test_name =
+  let backend = Backend.to_string backend in
   (* TODO: reactivate -test-trans-units for hashmap and hashmap_main *)
   let use_fuel =
     match (backend, test_name) with
     | ( "coq",
-        ( "arrays" | "betree_main" | "demo" | "hashmap" | "hashmap_main"
-        | "loops" ) ) ->
+        ("arrays" | "betree" | "demo" | "hashmap" | "hashmap_main" | "loops") )
+      ->
         true
     | "fstar", "demo" -> true
     | _ -> false
@@ -112,8 +132,7 @@ let aeneas_options_for_test backend test_name =
     backend = "fstar"
     &&
     match test_name with
-    | "arrays" | "betree_main" | "hashmap" | "hashmap_main" | "loops" | "traits"
-      ->
+    | "arrays" | "betree" | "hashmap" | "hashmap_main" | "loops" | "traits" ->
         true
     | _ -> false
   in
@@ -125,7 +144,7 @@ let aeneas_options_for_test backend test_name =
 
   let extra_options =
     match (backend, test_name) with
-    | _, "betree_main" ->
+    | _, "betree" ->
         [
           "-backward-no-state-update";
           "-test-trans-units";
@@ -172,11 +191,12 @@ let charon_options_for_test test_name =
 (* The subdirectory in which to store the outputs. *)
 (* This reproduces the file layout that was set by the old Makefile. FIXME: cleanup *)
 let test_subdir backend test_name =
+  let backend = Backend.to_string backend in
   match (backend, test_name) with
   | "lean", "demo" -> "Demo"
   | "lean", _ -> "."
   | _, ("arrays" | "demo" | "hashmap" | "traits") -> test_name
-  | _, "betree_main" -> "betree"
+  | _, "betree" -> "betree"
   | _, "hashmap_main" -> "hashmap_on_disk"
   | "hol4", _ -> "misc-" ^ test_name
   | ( _,
@@ -185,49 +205,49 @@ let test_subdir backend test_name =
       "misc"
   | _ -> test_name
 
+let build_test (path : string) : test_case =
+  let name = Filename.remove_extension (Filename.basename path) in
+  let input_kind =
+    if Sys_unix.is_file_exn path then SingleFile
+    else if Sys_unix.is_directory_exn path then Crate
+    else failwith ("`" ^ path ^ "` is not a file or a directory.")
+  in
+  let charon_options = charon_options_for_test name in
+  let subdir =
+    List.fold_left
+      (fun map backend ->
+        let subdir = test_subdir backend name in
+        BackendMap.add backend subdir map)
+      BackendMap.empty Backend.all
+  in
+  let aeneas_options =
+    List.fold_left
+      (fun map backend ->
+        let opts = aeneas_options_for_test backend name in
+        BackendMap.add backend opts map)
+      BackendMap.empty Backend.all
+  in
+  { path; name; input_kind; charon_options; subdir; aeneas_options }
+
 let () =
   match Array.to_list Sys.argv with
   (* Ad-hoc argument passing for now. *)
   | _exe_path :: charon_path :: aeneas_path :: llbc_dir :: test_path
     :: aeneas_options ->
       let runner_env = { charon_path; aeneas_path; llbc_dir } in
-      let test_name = Filename.remove_extension (Filename.basename test_path) in
-
-      let charon_kind =
-        if Sys_unix.is_file_exn test_path then SingleFile
-        else if Sys_unix.is_directory_exn test_path then Crate
-        else failwith ("`" ^ test_path ^ "` is not a file or a directory.")
-      in
-      let extra_charon_options = charon_options_for_test test_name in
-      let charon_case =
+      let test_case = build_test test_path in
+      let test_case =
         {
-          path = test_path;
-          name = test_name;
-          kind = charon_kind;
-          extra_charon_options;
+          test_case with
+          aeneas_options =
+            BackendMap.map (List.append aeneas_options) test_case.aeneas_options;
         }
       in
-      (* Generate the llbc file *)
-      run_charon runner_env charon_case;
 
-      (* FIXME: remove this special case *)
-      let test_name =
-        if test_name = "betree" then "betree_main" else test_name
-      in
-      (* TODO: reactivate HOL4 once traits are parameterized by their associated types *)
-      let backends = [ "coq"; "lean"; "fstar" ] in
+      (* Generate the llbc file *)
+      run_charon runner_env test_case;
+      (* Process the llbc file for the each backend *)
       List.iter
-        (fun backend ->
-          let subdir = test_subdir backend test_name in
-          let extra_aeneas_options =
-            List.append
-              (aeneas_options_for_test backend test_name)
-              aeneas_options
-          in
-          let aeneas_case =
-            { name = test_name; backend; subdir; extra_aeneas_options }
-          in
-          (* Process the llbc file for the current backend *)
-          run_aeneas runner_env aeneas_case)
-        backends
+        (fun backend -> run_aeneas runner_env test_case backend)
+        Backend.all
   | _ -> failwith "Incorrect options passed to test runner"


### PR DESCRIPTION
It is now possible to specify charon and aeneas options directly in the rust source file, like in the charon test suite.

Fixes #182 