### PR TITLE
Update charon pin to local commit when developing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,16 +81,11 @@ build-bin-dir: build-bin build-lib build-runner
 doc:
 	cd compiler && dune build @doc
 
-# Fetches the latest commit from charon and updates `flake.lock` accordingly.
+# Updates `flake.lock` and `charon-pin` with the latest commit from Charon. If
+# we're using a symlink, this takes the commit from our local charon.
 .PHONY: update-charon-pin
 update-charon-pin:
-	nix flake lock --update-input charon
-	$(MAKE) charon-pin
-
-# Keep the commit revision in `./charon-pin` as well so that non-nix users can
-# know which commit to use.
-./charon-pin: flake.lock
-	./scripts/update-charon-pin.sh >> ./charon-pin
+	./scripts/update-charon-pin.sh
 
 # Checks that `./charon` contains a clone of charon at the required commit.
 # Also checks that `./charon/bin/charon` exists.

--- a/scripts/update-charon-pin.sh
+++ b/scripts/update-charon-pin.sh
@@ -3,5 +3,16 @@ if ! which jq 2> /dev/null 1>&2; then
     echo 'Error: command `jq` not found; please install it.'
     exit 1
 fi
+
+if [ -L charon ]; then
+    echo '`./charon` is a symlink; we using the commit there for our new pin.'
+    COMMIT="$(git -C charon rev-parse HEAD)"
+    nix flake lock --override-input charon "github:aeneasverif/charon/$COMMIT"
+else
+    echo 'Pinning the latest commit from Charon `main`'
+    nix flake lock --update-input charon
+fi
+
+# Keep the commit revision in `./charon-pin` as well so that non-nix users can know which commit to use.
 echo '# This is the commit from https://github.com/AeneasVerif/charon that should be used with this version of aeneas.' > ./charon-pin
 jq -r .nodes.charon.locked.rev flake.lock >> ./charon-pin


### PR DESCRIPTION
This makes `make update-charon-pin` use the local charon commit when `./charon` is a symlink (instead of using charon main).