### PR TITLE
Filter out type aliases

### DIFF
--- a/charon-pin
+++ b/charon-pin
@@ -1,2 +1,2 @@
 # This is the commit from https://github.com/AeneasVerif/charon that should be used with this version of aeneas.
-3f3c013cbe726c2f3ae83e8a589eca47bce21a01
+335f6d7423c2c2a3863440bfd19507b5d2452aac

--- a/compiler/InterpreterExpansion.ml
+++ b/compiler/InterpreterExpansion.ml
@@ -648,9 +648,9 @@ let greedy_expand_symbolics_with_borrows (config : config) (span : Meta.span) :
                     1 variants (option [greedy_expand_symbolics_with_borrows] \
                     of [config]): "
                   ^ name_to_string ctx def.name)
-            | Opaque ->
+            | Alias _ | Opaque ->
                 craise __FILE__ __LINE__ span
-                  "Attempted to greedily expand an opaque type");
+                  "Attempted to greedily expand an alias or opaque type");
             (* Also, we need to check if the definition is recursive *)
             if ctx_type_decl_is_rec ctx def_id then
               craise __FILE__ __LINE__ span

--- a/compiler/PureMicroPasses.ml
+++ b/compiler/PureMicroPasses.ml
@@ -1202,7 +1202,7 @@ let simplify_aggregates (ctx : trans_ctx) (def : fun_decl) : fun_decl =
                 in
                 let fields =
                   match adt_decl.kind with
-                  | Enum _ | Opaque ->
+                  | Enum _ | Alias _ | Opaque ->
                       craise __FILE__ __LINE__ def.span "Unreachable"
                   | Struct fields -> fields
                 in

--- a/compiler/SymbolicToPure.ml
+++ b/compiler/SymbolicToPure.ml
@@ -564,6 +564,9 @@ let translate_type_decl_kind (span : Meta.span) (kind : T.type_decl_kind) :
   match kind with
   | T.Struct fields -> Struct (translate_fields span fields)
   | T.Enum variants -> Enum (translate_variants span variants)
+  | Alias _ ->
+      craise __FILE__ __LINE__ span
+        "type aliases should have been removed earlier"
   | T.Opaque -> Opaque
 
 (** Translate a type definition from LLBC

--- a/compiler/TypesAnalysis.ml
+++ b/compiler/TypesAnalysis.ml
@@ -272,7 +272,7 @@ let analyze_full_ty (updated : bool ref) (infos : type_infos)
   analyze expl_info_init ty_info ty
 
 let type_decl_is_opaque (d : type_decl) : bool =
-  match d.kind with Struct _ | Enum _ -> false | Opaque -> true
+  match d.kind with Opaque -> true | _ -> false
 
 let analyze_type_decl (updated : bool ref) (infos : type_infos)
     (def : type_decl) : type_infos =
@@ -289,6 +289,9 @@ let analyze_type_decl (updated : bool ref) (infos : type_infos)
             (List.map
                (fun v -> List.map (fun f -> f.field_ty) v.fields)
                variants)
+      | Alias _ ->
+          craise __FILE__ __LINE__ def.item_meta.span
+            "type aliases should have been removed earlier"
       | Opaque -> craise __FILE__ __LINE__ def.item_meta.span "unreachable"
     in
     (* Explore the types and accumulate information *)

--- a/flake.lock
+++ b/flake.lock
@@ -9,11 +9,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1717573223,
-        "narHash": "sha256-56arhtgTmdFFLV/BnO3GQC0FEiWdEmzM4CakeSulT+k=",
+        "lastModified": 1717573936,
+        "narHash": "sha256-PDfOISJ5hmlbM4j4jy8k0BTBYF6hPikM3ob4TbKCE/A=",
         "owner": "aeneasverif",
         "repo": "charon",
-        "rev": "3f3c013cbe726c2f3ae83e8a589eca47bce21a01",
+        "rev": "335f6d7423c2c2a3863440bfd19507b5d2452aac",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
This is the companion PR to https://github.com/AeneasVerif/charon/pull/216. It adds a pre-pass that forgets type aliases since aeneas has no use for them at a moment.