### PR TITLE
feat: `PropHasImp` can have `Sort u` as premisses

### DIFF
--- a/backends/lean/Base/Arith/Int.lean
+++ b/backends/lean/Base/Arith/Int.lean
@@ -22,7 +22,7 @@ class HasIntProp (a : Sort u) where
   prop : ∀ x:a, prop_ty x
 
 /- Proposition with implications: if we find P we can introduce Q in the context -/
-class PropHasImp (x : Prop) where
+class PropHasImp (x : Sort u) where
   concl : Prop
   prop : x → concl
 


### PR DESCRIPTION
This makes it possible to have `InBounds ... : Type 1` for example as `x`.