### PR TITLE
Improve `scalar_tac` and `scalar_decr_tac`

### DIFF
--- a/backends/lean/Base.lean
+++ b/backends/lean/Base.lean
@@ -1,6 +1,7 @@
-import Base.Utils
-import Base.Primitives
-import Base.Diverge
 import Base.Arith
-import Base.Progress
+import Base.Diverge
 import Base.IList
+import Base.Primitives
+import Base.Progress
+import Base.Utils
+import Base.Termination

--- a/backends/lean/Base/Arith/Int.lean
+++ b/backends/lean/Base/Arith/Int.lean
@@ -303,7 +303,7 @@ def intTac (tacName : String) (splitGoalConjs : Bool) (extraPreprocess :  Tactic
     try do Tactic.Omega.omegaTactic {}
     catch _ =>
       let g ← Tactic.getMainGoal
-      throwError "{tacName} failed to prove the goal:\n{g}"
+      throwError "{tacName} failed to prove the goal below.\n\nNote that {tacName} is equivalent to:\n  {tacName}_preprocess; omega\n\nGoal: \n{g}"
 
 elab "int_tac" args:(" split_goal"?): tactic =>
   let split := args.raw.getArgs.size > 0

--- a/backends/lean/Base/Arith/Scalar.lean
+++ b/backends/lean/Base/Arith/Scalar.lean
@@ -44,17 +44,6 @@ def scalarTac (splitGoalConjs : Bool) : Tactic.TacticM Unit := do
 elab "scalar_tac" : tactic =>
   scalarTac false
 
--- For termination proofs
-syntax "scalar_decr_tac" : tactic
-macro_rules
-  | `(tactic| scalar_decr_tac) =>
-    `(tactic|
-      simp_wf;
-      -- TODO: don't use a macro (namespace problems)
-      (first | apply Arith.to_int_to_nat_lt
-             | apply Arith.to_int_sub_to_nat_lt) <;>
-      simp_all <;> scalar_tac)
-
 instance (ty : ScalarTy) : HasIntProp (Scalar ty) where
   -- prop_ty is inferred
   prop := λ x => And.intro x.hmin x.hmax

--- a/backends/lean/Base/Primitives/Vec.lean
+++ b/backends/lean/Base/Primitives/Vec.lean
@@ -48,10 +48,7 @@ abbrev Vec.len (α : Type u) (v : Vec α) : Usize :=
 theorem Vec.len_val {α : Type u} (v : Vec α) : (Vec.len α v).val = v.length :=
   by rfl
 
--- This shouldn't be used
-def Vec.push_fwd (α : Type u) (_ : Vec α) (_ : α) : Unit := ()
-
--- This is actually the backward function
+@[irreducible]
 def Vec.push (α : Type u) (v : Vec α) (x : α) : Result (Vec α)
   :=
   let nlen := List.length v.val + 1
@@ -68,7 +65,7 @@ def Vec.push (α : Type u) (v : Vec α) (x : α) : Result (Vec α)
 theorem Vec.push_spec {α : Type u} (v : Vec α) (x : α) (h : v.val.len < Usize.max) :
   ∃ v1, v.push α x = ok v1 ∧
   v1.val = v.val ++ [x] := by
-  simp [push]
+  rw [push]; simp
   split <;> simp_all [List.len_eq_length]
   scalar_tac
 

--- a/backends/lean/Base/Termination.lean
+++ b/backends/lean/Base/Termination.lean
@@ -1,0 +1,94 @@
+/- Some utilities to prove termination -/
+import Lean
+import Mathlib.Tactic.Core
+import Base.Utils
+import Base.Arith
+
+namespace Utils
+
+open Lean Lean.Elab Command Term Lean.Meta Tactic
+
+-- Inspired by the `clear` tactic
+def clearFvarIds (fvarIds : Array FVarId) : TacticM Unit := do
+  let fvarIds ← withMainContext <| sortFVarIds fvarIds
+  for fvarId in fvarIds.reverse do
+    withMainContext do
+      let mvarId ← (← getMainGoal).clear fvarId
+      replaceMainGoal [mvarId]
+
+/- Utility function for proofs of termination (i.e., inside `decreasing_by`).
+
+   Clean up the local context by removing all assumptions containing occurrences
+   of `invImage` (those are introduced automatically when doing proofs of
+   termination). We do so because we often need to simplify the context in the
+   proofs, and if we simplify those assumptions they tend to make the context
+   blow up.
+-/
+def removeInvImageAssumptions : TacticM Unit := do
+  withMainContext do
+  -- Get the local declarations
+  let ctx ← Lean.MonadLCtx.getLCtx
+  let decls ← ctx.getDecls
+  -- Retrieve the list of local declarations which contain `invertImage`
+  let containsInvertImage (decl : LocalDecl) : MetaM Bool := do
+    let expr := decl.toExpr
+    reduceVisit (
+      fun _ b e =>
+      pure (
+        b ||
+        match e with
+        | .const name _ => name == ``invImage
+        | _ => false)) false (← inferType expr)
+  let filtDecls ← liftM (decls.filterM containsInvertImage)
+  -- It can happen that other variables depend on the variables we want to clear:
+  -- filter them.
+  let allFVarsInTypes ← decls.foldlM (fun hs d => do
+    let hs ← getFVarIds (← inferType d.toExpr) hs
+    -- Explore the body if it is not opaque
+    match d.value? with
+    | none => pure hs
+    | some e => getFVarIds e hs
+    ) HashSet.empty
+  let fvarIds := filtDecls.map fun d => d.fvarId
+  let fvarIds := fvarIds.filter (fun id => ¬ allFVarsInTypes.contains id)
+  -- Clear them
+  clearFvarIds fvarIds.toArray
+
+elab "remove_invImage_assumptions" : tactic =>
+  removeInvImageAssumptions
+
+-- Auxiliary function
+def scalarDecrTac_apply_lemmas : TacticM Unit := do
+  withMainContext do
+  let goal ← getMainGoal
+  let rec applyFirst (names : List Name) : TacticM (List MVarId) :=
+    match names with
+    | [] => pure [goal]
+    | name :: names =>
+      -- Should use try ... catch or Lean.observing?
+      -- Generally speaking we should use Lean.observing? to restore the state,
+      -- but with tactics the try ... catch variant seems to work
+      try do
+        let th ← mkConstWithFreshMVarLevels name
+        goal.apply th
+      catch _ => do applyFirst names
+  let ngoals ← applyFirst [``Arith.to_int_to_nat_lt, ``Arith.to_int_sub_to_nat_lt]
+  setGoals ngoals
+
+elab "scalar_decr_tac_apply_lemmas" : tactic =>
+  scalarDecrTac_apply_lemmas
+
+-- For termination proofs
+syntax "scalar_decr_tac" : tactic
+macro_rules
+  | `(tactic| scalar_decr_tac) =>
+    `(tactic|
+      simp_wf <;>
+      -- Simplify the context - otherwise simp_all below will blow up
+      remove_invImage_assumptions <;>
+      -- Transform the goal a bit
+      scalar_decr_tac_apply_lemmas <;>
+      -- Finish
+      simp_all <;> scalar_tac)
+
+end Utils

--- a/backends/lean/Base/Utils.lean
+++ b/backends/lean/Base/Utils.lean
@@ -42,10 +42,6 @@ namespace List
 
 end List
 
--- TODO: move?
-@[simp]
-theorem neq_imp {α : Type u} {x y : α} (h : ¬ x = y) : ¬ y = x := by intro; simp_all
-
 namespace Lean
 
 namespace LocalContext

--- a/tests/lean/Hashmap/Properties.lean
+++ b/tests/lean/Hashmap/Properties.lean
@@ -168,9 +168,9 @@ def frame_load (hm nhm : HashMap α) : Prop :=
 -- This rewriting lemma is problematic below
 attribute [-simp] Bool.exists_bool
 
--- The proof below is a bit expensive, so we need to increase the maximum number
--- of heart beats
-set_option maxHeartbeats 1000000
+-- The proofs below are a bit expensive, so we need to increase the maximum number of heart beats
+set_option maxHeartbeats 2000000
+
 open AList
 
 @[pspec]
@@ -206,10 +206,7 @@ theorem allocate_slots_spec {α : Type} (slots : alloc.vec.Vec (AList α)) (n : 
     -- of times
     -- progress as ⟨ slots2 .. ⟩
     -- TODO: bug here as well
-    stop
-    have ⟨ slots2, hEq, _, _ ⟩ := allocate_slots_spec slots1 n1 (by assumption) (by assumption)
-    stop
-    rw [allocate_slots] at hEq; rw [hEq]; clear hEq
+    progress as ⟨ slots2 .. ⟩
     simp
     constructor
     . intro i h0 h1
@@ -219,6 +216,13 @@ theorem allocate_slots_spec {α : Type} (slots : alloc.vec.Vec (AList α)) (n : 
     simp [h]
     simp_all
     scalar_tac
+termination_by n.val.toNat
+decreasing_by
+  -- TODO: improve the scalar_decr_tac (the simp_all makes the context blow up)
+  -- The issue comes from the assertions which contain the invImage: we could filter them
+  -- before simplifying the context
+  simp_wf
+  apply Arith.to_int_to_nat_lt <;> scalar_tac
 
 theorem forall_nil_imp_flatten_len_zero (slots : List (List α))
   (Hnil : ∀ i, 0 ≤ i → i < slots.len → slots.index i = []) :
@@ -383,10 +387,6 @@ def mk_opaque {α : Sort u} (x : α) : { y : α // y = x}  :=
 
 -- For pretty printing (useful when copy-pasting goals)
 set_option pp.coercions false -- do not print coercions with ↑ (this doesn't parse)
-
--- The proof below is a bit expensive, so we need to increase the maximum number
--- of heart beats
-set_option maxHeartbeats 2000000
 
 @[pspec]
 theorem insert_no_resize_spec {α : Type} (hm : HashMap α) (key : Usize) (value : α)


### PR DESCRIPTION
There are some performance issues with `scalar_decr_tac`: it is quite expensive to use it in `decreasing_by` clauses, and as a consequence it is often better to use `induction` and get rid of the `termination_by` clauses. But at least it is now usable on big theorems and provides a baseline performance.