### PR TITLE
Update the Makefile to filter more files when running tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -154,6 +154,8 @@ verify:
 INPUTS_LIST = $(wildcard $(INPUTS_DIR)/*)
 # Remove the committed output files
 INPUTS_LIST := $(filter-out %.out,$(INPUTS_LIST))
+# Remove some temporary files which are inserted by, for instance, Emacs
+INPUTS_LIST := $(filter-out %~,$(INPUTS_LIST))
 # Remove the directory prefix, replace with `test-`
 INPUTS_LIST := $(subst $(INPUTS_DIR)/,test-,$(INPUTS_LIST))
 


### PR DESCRIPTION
This fixes an issue which arises when running `make test` and there are some files like `test.rs~` in the test directory (the test runner used to run on those files, which is not something we want).