### PR TITLE
chore(lean): minimize imports in `Base/Arith`

### DIFF
--- a/backends/lean/Base/Arith/Base.lean
+++ b/backends/lean/Base/Arith/Base.lean
@@ -1,5 +1,5 @@
-import Lean
-import Mathlib.Tactic.Linarith -- Introduces a lot of useful lemmas
+import Mathlib.Algebra.Order.Ring.Int
+import Mathlib.Data.Nat.Cast.Order.Ring
 
 namespace Arith
 

--- a/backends/lean/Base/Arith/Init.lean
+++ b/backends/lean/Base/Arith/Init.lean
@@ -1,5 +1,4 @@
 import Base.Extensions
-import Aesop
 open Lean
 
 /-!

--- a/backends/lean/Base/Arith/Int.lean
+++ b/backends/lean/Base/Arith/Int.lean
@@ -1,13 +1,8 @@
 /- This file contains tactics to solve arithmetic goals -/
 
-import Lean
-import Lean.Meta.Tactic.Simp
-import Init.Data.List.Basic
-import Mathlib.Tactic.Ring.RingNF
-import Base.Utils
-import Base.Arith.Base
 import Base.Arith.Init
-import Base.Saturate
+import Base.Saturate.Tactic
+import Mathlib.Util.CountHeartbeats
 
 namespace Arith
 

--- a/backends/lean/Base/Arith/ScalarNF.lean
+++ b/backends/lean/Base/Arith/ScalarNF.lean
@@ -1,4 +1,5 @@
 import Base.Arith.Scalar
+import Mathlib.Tactic.Ring.RingNF
 
 namespace Arith
 

--- a/backends/lean/Base/Diverge/Base.lean
+++ b/backends/lean/Base/Diverge/Base.lean
@@ -1,5 +1,6 @@
 import Lean
 import Lean.Meta.Tactic.Simp
+import Mathlib.Tactic.Zify
 import Init.Data.List.Basic
 import Base.Primitives.Base
 import Base.Arith.Base

--- a/backends/lean/Base/Extensions.lean
+++ b/backends/lean/Base/Extensions.lean
@@ -1,9 +1,5 @@
-import Lean
 import Base.Utils
-import Base.Primitives.Base
-
-import Lean.Meta.DiscrTree
-import Lean.Meta.Tactic.Simp
+import Lean.Elab.Tactic.Rewrites
 
 /-! Various state extensions used in the library -/
 namespace Extensions


### PR DESCRIPTION
This is a methodology employed by the Mathlib community to improve the build performance of Mathlib.

The idea is to exploit the ImportGraph library which has a command `#min_imports` and `#redundant_imports` to figure out what imports to trim down.

See: https://reservoir.lean-lang.org/@leanprover-community/importGraph for the docs.

This is the result of this process for `Base/Arith`.

@sonmarcho If you are happy with the idea, I can minimize the rest of the library. This will be helpful with the documentation PR to minimize the build times as well (as we won't build unnecessary Mathlib modules in Nix).