### PR TITLE
Nit: Correctly indent abort-on-error option description

### DIFF
--- a/compiler/Main.ml
+++ b/compiler/Main.ml
@@ -120,7 +120,7 @@ let () =
       ("-print-llbc", Arg.Set print_llbc, " Print the imported LLBC");
       ( "-abort-on-error",
         Arg.Set fail_hard,
-        "Abort on the first encountered error" );
+        " Abort on the first encountered error" );
       ( "-tuple-nested-proj",
         Arg.Set use_nested_tuple_projectors,
         " Use nested projectors for tuples (e.g., (0, 1).snd.fst instead of \


### PR DESCRIPTION
As described. Allows for a cleaner output of `aeneas -help`