### PR TITLE
Implement a micro-pass to simplify the use of the array/slice index functions and the aggregated ADTs

### DIFF
--- a/compiler/Extract.ml
+++ b/compiler/Extract.ml
@@ -589,6 +589,14 @@ and extract_function_call (span : Meta.span) (ctx : extraction_ctx)
         | FromLlbc (FunId (FAssumed aid), _) ->
             Some
               (Assumed.AssumedFunIdMap.find aid ctx.builtin_sigs).explicit_info
+        | Pure (UpdateAtIndex Array) ->
+            Some
+              {
+                explicit_types = [ Implicit ];
+                explicit_const_generics = [ Implicit ];
+              }
+        | Pure (UpdateAtIndex Slice) ->
+            Some { explicit_types = [ Implicit ]; explicit_const_generics = [] }
         | Pure _ -> None
       in
       (* Filter the generics.

--- a/compiler/ExtractBase.ml
+++ b/compiler/ExtractBase.ml
@@ -1190,16 +1190,36 @@ let assumed_pure_functions () : (pure_assumed_fun_id * string) list =
         (Assert, "massert");
         (FuelDecrease, "decrease");
         (FuelEqZero, "is_zero");
+        (UpdateAtIndex Slice, "slice_update_usize");
+        (UpdateAtIndex Array, "array_update_usize");
       ]
   | Coq ->
       (* We don't provide [FuelDecrease] and [FuelEqZero] on purpose *)
-      [ (Return, "return_"); (Fail, "fail_"); (Assert, "massert") ]
+      [
+        (Return, "return_");
+        (Fail, "fail_");
+        (Assert, "massert");
+        (UpdateAtIndex Slice, "slice_update_usize");
+        (UpdateAtIndex Array, "array_update_usize");
+      ]
   | Lean ->
       (* We don't provide [FuelDecrease] and [FuelEqZero] on purpose *)
-      [ (Return, "return"); (Fail, "fail_"); (Assert, "massert") ]
+      [
+        (Return, "return");
+        (Fail, "fail_");
+        (Assert, "massert");
+        (UpdateAtIndex Slice, "Slice.update_usize");
+        (UpdateAtIndex Array, "Array.update_usize");
+      ]
   | HOL4 ->
       (* We don't provide [FuelDecrease] and [FuelEqZero] on purpose *)
-      [ (Return, "return"); (Fail, "fail"); (Assert, "massert") ]
+      [
+        (Return, "return");
+        (Fail, "fail");
+        (Assert, "massert");
+        (UpdateAtIndex Slice, "slice_update_usize");
+        (UpdateAtIndex Array, "array_update_usize");
+      ]
 
 let names_map_init () : names_map_init =
   {

--- a/compiler/Logging.ml
+++ b/compiler/Logging.ml
@@ -30,6 +30,10 @@ let symbolic_to_pure_log = L.get_logger "MainLogger.SymbolicToPure"
 (** Logger for PureMicroPasses *)
 let pure_micro_passes_log = L.get_logger "MainLogger.PureMicroPasses"
 
+(** Logger for PureMicroPasses.simplify_aggregates_unchanged_fields *)
+let simplify_aggregates_unchanged_fields_log =
+  L.get_logger "MainLogger.PureMicroPasses.simplify_aggregates_unchanged_fields"
+
 (** Logger for ExtractBase *)
 let extract_log = L.get_logger "MainLogger.ExtractBase"
 

--- a/compiler/Main.ml
+++ b/compiler/Main.ml
@@ -37,6 +37,7 @@ let _ =
   pure_utils_log#set_level EL.Info;
   symbolic_to_pure_log#set_level EL.Info;
   pure_micro_passes_log#set_level EL.Info;
+  simplify_aggregates_unchanged_fields_log#set_level EL.Info;
   extract_log#set_level EL.Info;
   builtin_log#set_level EL.Info;
   translate_log#set_level EL.Info;

--- a/compiler/PrintPure.ml
+++ b/compiler/PrintPure.ml
@@ -503,6 +503,11 @@ let pure_assumed_fun_id_to_string (fid : pure_assumed_fun_id) : string =
   | Assert -> "assert"
   | FuelDecrease -> "fuel_decrease"
   | FuelEqZero -> "fuel_eq_zero"
+  | UpdateAtIndex array_or_slice -> begin
+      match array_or_slice with
+      | Array -> "array_update"
+      | Slice -> "slice_update"
+    end
 
 let regular_fun_id_to_string (env : fmt_env) (fun_id : fun_id) : string =
   match fun_id with

--- a/compiler/PrintPure.ml
+++ b/compiler/PrintPure.ml
@@ -540,9 +540,9 @@ let fun_or_op_id_to_string (env : fmt_env) (fun_id : fun_or_op_id) : string =
       binop_to_string binop ^ "<" ^ integer_type_to_string int_ty ^ ">"
 
 (** [inside]: controls the introduction of parentheses *)
-let rec texpression_to_string ?(spandata : Meta.span option = None)
-    (env : fmt_env) (inside : bool) (indent : string) (indent_incr : string)
-    (e : texpression) : string =
+let rec texpression_to_string ?(span : Meta.span option = None) (env : fmt_env)
+    (inside : bool) (indent : string) (indent_incr : string) (e : texpression) :
+    string =
   match e.e with
   | Var var_id -> var_id_to_string env var_id
   | CVar cg_id -> const_generic_var_id_to_string env cg_id
@@ -551,65 +551,29 @@ let rec texpression_to_string ?(spandata : Meta.span option = None)
       (* Recursively destruct the app, to have a pair (app, arguments list) *)
       let app, args = destruct_apps e in
       (* Convert to string *)
-      app_to_string ~span:spandata env inside indent indent_incr app args
+      app_to_string ~span env inside indent indent_incr app args
   | Lambda _ ->
       let xl, e = destruct_lambdas e in
-      let e = lambda_to_string ~span:spandata env indent indent_incr xl e in
+      let e = lambda_to_string ~span env indent indent_incr xl e in
       if inside then "(" ^ e ^ ")" else e
   | Qualif _ ->
       (* Qualifier without arguments *)
-      app_to_string ~span:spandata env inside indent indent_incr e []
+      app_to_string ~span env inside indent indent_incr e []
   | Let (monadic, lv, re, e) ->
-      let e =
-        let_to_string ~span:spandata env indent indent_incr monadic lv re e
-      in
+      let e = let_to_string ~span env indent indent_incr monadic lv re e in
       if inside then "(" ^ e ^ ")" else e
   | Switch (scrutinee, body) ->
-      let e =
-        switch_to_string ~span:spandata env indent indent_incr scrutinee body
-      in
+      let e = switch_to_string ~span env indent indent_incr scrutinee body in
       if inside then "(" ^ e ^ ")" else e
   | Loop loop ->
-      let e = loop_to_string ~span:spandata env indent indent_incr loop in
+      let e = loop_to_string ~span env indent indent_incr loop in
       if inside then "(" ^ e ^ ")" else e
-  | StructUpdate supd -> (
-      let s =
-        match supd.init with
-        | None -> ""
-        | Some vid -> " " ^ var_id_to_string env vid ^ " with"
-      in
-      let indent1 = indent ^ indent_incr in
-      let indent2 = indent1 ^ indent_incr in
-      (* The id should be a custom type decl id or an array *)
-      match supd.struct_id with
-      | TAdtId aid ->
-          let field_names = Option.get (adt_field_names env aid None) in
-          let fields =
-            List.map
-              (fun (fid, fe) ->
-                let field = FieldId.nth field_names fid in
-                let fe =
-                  texpression_to_string ~spandata env false indent2 indent_incr
-                    fe
-                in
-                "\n" ^ indent1 ^ field ^ " := " ^ fe ^ ";")
-              supd.updates
-          in
-          let bl = if fields = [] then "" else "\n" ^ indent in
-          "{" ^ s ^ String.concat "" fields ^ bl ^ "}"
-      | TAssumed TArray ->
-          let fields =
-            List.map
-              (fun (_, fe) ->
-                texpression_to_string ~spandata env false indent2 indent_incr fe)
-              supd.updates
-          in
-          "[ " ^ String.concat ", " fields ^ " ]"
-      | _ -> craise_opt_span __FILE__ __LINE__ spandata "Unexpected")
-  | Meta (span, e) -> (
-      let span_s = espan_to_string ~spandata env span in
-      let e = texpression_to_string ~spandata env inside indent indent_incr e in
-      match span with
+  | StructUpdate supd ->
+      struct_update_to_string ~span env indent indent_incr supd
+  | Meta (span', e) -> (
+      let span_s = espan_to_string ~span env span' in
+      let e = texpression_to_string ~span env inside indent indent_incr e in
+      match span' with
       | Assignment _ | SymbolicAssignments _ | SymbolicPlaces _ | Tag _ ->
           let e = span_s ^ "\n" ^ indent ^ e in
           if inside then "(" ^ e ^ ")" else e
@@ -652,8 +616,7 @@ and app_to_string ?(span : Meta.span option = None) (env : fmt_env)
     | _ ->
         (* "Regular" expression case *)
         let inside = args <> [] || (args = [] && inside) in
-        ( texpression_to_string ~spandata:span env inside indent indent_incr app,
-          [] )
+        (texpression_to_string ~span env inside indent indent_incr app, [])
   in
   (* Convert the arguments.
    * The arguments are expressions, so indentation might get weird... (though
@@ -661,7 +624,7 @@ and app_to_string ?(span : Meta.span option = None) (env : fmt_env)
   let arg_to_string =
     let inside = true in
     let indent1 = indent ^ indent_incr in
-    texpression_to_string ~spandata:span env inside indent1 indent_incr
+    texpression_to_string ~span env inside indent1 indent_incr
   in
   let args = List.map arg_to_string args in
   let all_args = List.append generics args in
@@ -676,7 +639,7 @@ and lambda_to_string ?(span : Meta.span option = None) (env : fmt_env)
     (indent : string) (indent_incr : string) (xl : typed_pattern list)
     (e : texpression) : string =
   let xl = List.map (typed_pattern_to_string ~span env) xl in
-  let e = texpression_to_string ~spandata:span env false indent indent_incr e in
+  let e = texpression_to_string ~span env false indent indent_incr e in
   "λ " ^ String.concat " " xl ^ ". " ^ e
 
 and let_to_string ?(span : Meta.span option = None) (env : fmt_env)
@@ -684,12 +647,8 @@ and let_to_string ?(span : Meta.span option = None) (env : fmt_env)
     (lv : typed_pattern) (re : texpression) (e : texpression) : string =
   let indent1 = indent ^ indent_incr in
   let inside = false in
-  let re =
-    texpression_to_string ~spandata:span env inside indent1 indent_incr re
-  in
-  let e =
-    texpression_to_string ~spandata:span env inside indent indent_incr e
-  in
+  let re = texpression_to_string ~span env inside indent1 indent_incr re in
+  let e = texpression_to_string ~span env inside indent indent_incr e in
   let lv = typed_pattern_to_string ~span env lv in
   if monadic then lv ^ " <-- " ^ re ^ ";\n" ^ indent ^ e
   else "let " ^ lv ^ " = " ^ re ^ " in\n" ^ indent ^ e
@@ -702,11 +661,9 @@ and switch_to_string ?(span : Meta.span option = None) (env : fmt_env)
    * in most situations it will be a value or a function call, so it should be
    * ok*)
   let scrut =
-    texpression_to_string ~spandata:span env true indent1 indent_incr scrutinee
+    texpression_to_string ~span env true indent1 indent_incr scrutinee
   in
-  let e_to_string =
-    texpression_to_string ~spandata:span env false indent1 indent_incr
-  in
+  let e_to_string = texpression_to_string ~span env false indent1 indent_incr in
   match body with
   | If (e_true, e_false) ->
       let e_true = e_to_string e_true in
@@ -721,6 +678,41 @@ and switch_to_string ?(span : Meta.span option = None) (env : fmt_env)
       let branches = List.map branch_to_string branches in
       "match " ^ scrut ^ " with\n" ^ String.concat "\n" branches
 
+and struct_update_to_string ?(span : Meta.span option = None) (env : fmt_env)
+    (indent : string) (indent_incr : string) (supd : struct_update) : string =
+  let s =
+    match supd.init with
+    | None -> ""
+    | Some vid -> " " ^ var_id_to_string env vid ^ " with"
+  in
+  let indent1 = indent ^ indent_incr in
+  let indent2 = indent1 ^ indent_incr in
+  (* The id should be a custom type decl id or an array *)
+  match supd.struct_id with
+  | TAdtId aid ->
+      let field_names = Option.get (adt_field_names env aid None) in
+      let fields =
+        List.map
+          (fun (fid, fe) ->
+            let field = FieldId.nth field_names fid in
+            let fe =
+              texpression_to_string ~span env false indent2 indent_incr fe
+            in
+            "\n" ^ indent1 ^ field ^ " := " ^ fe ^ ";")
+          supd.updates
+      in
+      let bl = if fields = [] then "" else "\n" ^ indent in
+      "{" ^ s ^ String.concat "" fields ^ bl ^ "}"
+  | TAssumed TArray ->
+      let fields =
+        List.map
+          (fun (_, fe) ->
+            texpression_to_string ~span env false indent2 indent_incr fe)
+          supd.updates
+      in
+      "[ " ^ String.concat ", " fields ^ " ]"
+  | _ -> craise_opt_span __FILE__ __LINE__ span "Unexpected"
+
 and loop_to_string ?(span : Meta.span option = None) (env : fmt_env)
     (indent : string) (indent_incr : string) (loop : loop) : string =
   let indent1 = indent ^ indent_incr in
@@ -732,22 +724,20 @@ and loop_to_string ?(span : Meta.span option = None) (env : fmt_env)
   in
   let output_ty = "output_ty: " ^ ty_to_string env false loop.output_ty in
   let fun_end =
-    texpression_to_string ~spandata:span env false indent2 indent_incr
-      loop.fun_end
+    texpression_to_string ~span env false indent2 indent_incr loop.fun_end
   in
   let loop_body =
-    texpression_to_string ~spandata:span env false indent2 indent_incr
-      loop.loop_body
+    texpression_to_string ~span env false indent2 indent_incr loop.loop_body
   in
   "loop {\n" ^ indent1 ^ loop_inputs ^ "\n" ^ indent1 ^ output_ty ^ "\n"
   ^ indent1 ^ "fun_end: {\n" ^ indent2 ^ fun_end ^ "\n" ^ indent1 ^ "}\n"
   ^ indent1 ^ "loop_body: {\n" ^ indent2 ^ loop_body ^ "\n" ^ indent1 ^ "}\n"
   ^ indent ^ "}"
 
-and espan_to_string ?(spandata : Meta.span option = None) (env : fmt_env)
-    (span : espan) : string =
-  let span =
-    match span with
+and espan_to_string ?(span : Meta.span option = None) (env : fmt_env)
+    (espan : espan) : string =
+  let espan =
+    match espan with
     | Assignment (lp, rv, rp) ->
         let rp =
           match rp with
@@ -755,14 +745,14 @@ and espan_to_string ?(spandata : Meta.span option = None) (env : fmt_env)
           | Some rp -> " [@src=" ^ mplace_to_string env rp ^ "]"
         in
         "@assign(" ^ mplace_to_string env lp ^ " := "
-        ^ texpression_to_string ~spandata env false "" "" rv
+        ^ texpression_to_string ~span env false "" "" rv
         ^ rp ^ ")"
     | SymbolicAssignments info ->
         let infos =
           List.map
             (fun (var_id, rv) ->
               VarId.to_string var_id ^ " == "
-              ^ texpression_to_string ~spandata env false "" "" rv)
+              ^ texpression_to_string ~span env false "" "" rv)
             info
         in
         let infos = String.concat ", " infos in
@@ -779,7 +769,7 @@ and espan_to_string ?(spandata : Meta.span option = None) (env : fmt_env)
     | MPlace mp -> "@mplace=" ^ mplace_to_string env mp
     | Tag msg -> "@tag \"" ^ msg ^ "\""
   in
-  "@span[" ^ span ^ "]"
+  "@span[" ^ espan ^ "]"
 
 let fun_decl_to_string (env : fmt_env) (def : fun_decl) : string =
   let env = { env with generics = def.signature.generics } in
@@ -796,7 +786,7 @@ let fun_decl_to_string (env : fmt_env) (def : fun_decl) : string =
         else "  fun " ^ String.concat " " inputs ^ " ->\n" ^ indent
       in
       let body =
-        texpression_to_string ~spandata:(Some def.item_meta.span) env inside
-          indent indent body.body
+        texpression_to_string ~span:(Some def.item_meta.span) env inside indent
+          indent body.body
       in
       "let " ^ name ^ " :\n  " ^ signature ^ " =\n" ^ inputs ^ body

--- a/compiler/Pure.ml
+++ b/compiler/Pure.ml
@@ -54,6 +54,7 @@ type loc = Meta.loc [@@deriving show, ord]
 type file_name = Meta.file_name [@@deriving show, ord]
 type raw_span = Meta.raw_span [@@deriving show, ord]
 type span = Meta.span [@@deriving show, ord]
+type ref_kind = Types.ref_kind [@@deriving show, ord]
 
 (** The assumed types for the pure AST.
 
@@ -712,6 +713,8 @@ type unop =
   | Cast of literal_type * literal_type
 [@@deriving show, ord]
 
+type array_or_slice = Array | Slice [@@deriving show, ord]
+
 (** Identifiers of assumed functions that we use only in the pure translation *)
 type pure_assumed_fun_id =
   | Return  (** The monadic return *)
@@ -720,6 +723,14 @@ type pure_assumed_fun_id =
   | FuelDecrease
       (** Decrease fuel, provided it is non zero (used for F* ) - TODO: this is ugly *)
   | FuelEqZero  (** Test if some fuel is equal to 0 - TODO: ugly *)
+  | UpdateAtIndex of array_or_slice
+      (** Update an array or a slice at a given index.
+
+          Note that in LLBC we only use an index function: if we want to
+          modify an element in an array/slice, we create a mutable borrow
+          to this element, then use the borrow to perform the update. The
+          update functions are introduced in the pure code by a micro-pass.
+       *)
 [@@deriving show, ord]
 
 type fun_id_or_trait_method_ref =

--- a/compiler/Pure.ml
+++ b/compiler/Pure.ml
@@ -545,16 +545,18 @@ and type_decl = {
 type scalar_value = V.scalar_value [@@deriving show, ord]
 type literal = V.literal [@@deriving show, ord]
 type var_id = VarId.id [@@deriving show, ord]
+type field_proj_kind = E.field_proj_kind [@@deriving show, ord]
+type field_id = FieldId.id [@@deriving show, ord]
 
 (* TODO: we might want to redefine field_proj_kind here, to prevent field accesses
  * on enumerations.
  * Also: tuples...
  * Rmk: projections are actually only used as span-data.
  * *)
-type mprojection_elem = { pkind : E.field_proj_kind; field_id : FieldId.id }
-[@@deriving show]
+type mprojection_elem = { pkind : field_proj_kind; field_id : field_id }
+[@@deriving show, ord]
 
-type mprojection = mprojection_elem list [@@deriving show]
+type mprojection = mprojection_elem list [@@deriving show, ord]
 
 (** "Meta" place.
 
@@ -567,9 +569,9 @@ type mplace = {
   name : string option;
   projection : mprojection;
 }
-[@@deriving show]
+[@@deriving show, ord]
 
-type variant_id = VariantId.id [@@deriving show]
+type variant_id = VariantId.id [@@deriving show, ord]
 
 (** Because we introduce a lot of temporary variables, the list of variables
     is not fixed: we thus must carry all its information with the variable
@@ -583,7 +585,7 @@ type var = {
        *)
   ty : ty;
 }
-[@@deriving show]
+[@@deriving show, ord]
 
 (** Ancestor for {!iter_typed_pattern} visitor *)
 class ['self] iter_typed_pattern_base =
@@ -672,6 +674,7 @@ and adt_pattern = {
 and typed_pattern = { value : pattern; ty : ty }
 [@@deriving
   show,
+    ord,
     visitors
       {
         name = "iter_typed_pattern";
@@ -767,12 +770,13 @@ type fun_or_op_id =
 
 (** An identifier for an ADT constructor *)
 type adt_cons_id = { adt_id : type_id; variant_id : variant_id option }
-[@@deriving show]
+[@@deriving show, ord]
 
 (** Projection - For now we don't support projection of tuple fields
     (because not all the backends have syntax for this).
  *)
-type projection = { adt_id : type_id; field_id : FieldId.id } [@@deriving show]
+type projection = { adt_id : type_id; field_id : field_id }
+[@@deriving show, ord]
 
 type qualif_id =
   | FunOrOp of fun_or_op_id  (** A function or an operation *)
@@ -780,7 +784,7 @@ type qualif_id =
   | AdtCons of adt_cons_id  (** A function or ADT constructor identifier *)
   | Proj of projection  (** Field projector *)
   | TraitConst of trait_ref * string  (** A trait associated constant *)
-[@@deriving show]
+[@@deriving show, ord]
 
 (** An instantiated qualifier.
 
@@ -788,9 +792,7 @@ type qualif_id =
     which explains why we have the [generics] field: a function or ADT
     constructor is always fully instantiated.
  *)
-type qualif = { id : qualif_id; generics : generic_args } [@@deriving show]
-
-type field_id = FieldId.id [@@deriving show, ord]
+type qualif = { id : qualif_id; generics : generic_args } [@@deriving show, ord]
 
 (** Ancestor for {!iter_expression} visitor *)
 class ['self] iter_expression_base =
@@ -1004,6 +1006,7 @@ and espan =
   | Tag of string  (** A tag - typically used for debugging *)
 [@@deriving
   show,
+    ord,
     visitors
       {
         name = "iter_expression";

--- a/compiler/PureMicroPasses.ml
+++ b/compiler/PureMicroPasses.ml
@@ -833,8 +833,9 @@ let simplify_let_bindings (_ctx : trans_ctx) (def : fun_decl) : fun_decl =
     leave the let-bindings where they are, and eliminated them in a subsequent
     pass (if they are useless).
  *)
-let inline_useless_var_reassignments (ctx : trans_ctx) ~(inline_named : bool)
-    ~(inline_const : bool) ~(inline_pure : bool) (def : fun_decl) : fun_decl =
+let inline_useless_var_reassignments ~(inline_named : bool)
+    ~(inline_const : bool) ~(inline_pure : bool) (ctx : trans_ctx)
+    (def : fun_decl) : fun_decl =
   let obj =
     object (self)
       inherit [_] map_expression as super
@@ -1604,6 +1605,103 @@ let eliminate_box_functions (_ctx : trans_ctx) (def : fun_decl) : fun_decl =
       let body = Some { body with body = obj#visit_texpression () body.body } in
       { def with body }
 
+(** This pass simplifies uses of array/slice index operations.
+
+    We perform the following transformations:
+    {[
+      let (_, back) = Array.index_mut_usize a i in
+      let a' = back x in
+      ...
+
+       ~~>
+
+      let a' = Array.update a i x in
+      ...
+
+      let (_, back) = Array.index_mut_usize a i in
+      back x
+
+       ~~>
+
+      Array.update a i x
+    ]}
+  *)
+let simplify_array_slice_update (_ctx : trans_ctx) (def : fun_decl) : fun_decl =
+  let span = def.item_meta.span in
+  let visitor =
+    object
+      inherit [_] map_expression as super
+
+      method! visit_Let env monadic pat e1 e2 =
+        let e1_app, e1_args = destruct_apps e1 in
+        match (pat.value, e1_app.e, e1_args) with
+        | ( (* let (_, back) = ... *)
+            PatAdt
+              {
+                variant_id = None;
+                field_values =
+                  [
+                    { value = PatDummy; _ }; { value = PatVar (back_var, _); _ };
+                  ];
+              },
+            (* ... = Array.index_mut_usize a i *)
+            Qualif
+              {
+                id =
+                  FunOrOp
+                    (Fun
+                      (FromLlbc
+                        ( FunId
+                            (FAssumed
+                              (Index
+                                {
+                                  is_array;
+                                  mutability = RMut;
+                                  is_range = false;
+                                })),
+                          None )));
+                generics = index_generics;
+              },
+            [ a; i ] ) ->
+            let is_call_to_back (app : texpression) =
+              match app.e with
+              | Var id -> id = back_var.id
+              | _ -> false
+            in
+            let mk_call_to_update (back_v : texpression) =
+              let array_or_slice = if is_array then Array else Slice in
+              let qualif =
+                Qualif
+                  {
+                    id = FunOrOp (Fun (Pure (UpdateAtIndex array_or_slice)));
+                    generics = index_generics;
+                  }
+              in
+              let qualif =
+                { e = qualif; ty = mk_arrows [ a.ty; i.ty; back_v.ty ] e2.ty }
+              in
+              mk_apps span qualif [ a; i; back_v ]
+            in
+            begin
+              match e2.e with
+              (* back x *)
+              | App (app, back_v) when is_call_to_back app ->
+                  (super#visit_texpression env (mk_call_to_update back_v)).e
+              (* let a' = back x in ... *)
+              | Let (monadic', pat', { e = App (app, back_v); _ }, e3)
+                when is_call_to_back app ->
+                  super#visit_expression env
+                    (Let (monadic', pat', mk_call_to_update back_v, e3))
+              | _ -> super#visit_Let env monadic pat e1 e2
+            end
+        | _ -> super#visit_Let env monadic pat e1 e2
+    end
+  in
+  let simplify (body : fun_body) : fun_body =
+    { body with body = visitor#visit_texpression () body.body }
+  in
+  { def with body = Option.map simplify def.body }
+
 (** Decompose let-bindings by introducing intermediate let-bindings.
 
     This is a utility function: see {!decompose_monadic_let_bindings} and
@@ -1814,147 +1912,99 @@ let unfold_monadic_let_bindings (_ctx : trans_ctx) (def : fun_decl) : fun_decl =
       (* Return *)
       { def with body = Some body }
 
+let end_passes :
+    (bool ref option * string * (trans_ctx -> fun_decl -> fun_decl)) list =
+  [
+    (* Convert the unit variables to [()] if they are used as right-values or
+     * [_] if they are used as left values. *)
+    (None, "unit_vars_to_unit", fun _ -> unit_vars_to_unit);
+    (* Introduce the special structure create/update expressions *)
+    (None, "intro_struct_updates", intro_struct_updates);
+    (* Simplify the let-bindings *)
+    (None, "simplify_let_bindings", simplify_let_bindings);
+    (* Inline the useless variable reassignments *)
+    ( None,
+      "inline_useless_var_assignments",
+      inline_useless_var_reassignments ~inline_named:true ~inline_const:true
+        ~inline_pure:true );
+    (* Eliminate the box functions - note that the "box" types were eliminated
+     * during the symbolic to pure phase: see the comments for [eliminate_box_functions] *)
+    (None, "eliminate_box_functions", eliminate_box_functions);
+    (* Filter the useless variables, assignments, function calls, etc. *)
+    (None, "filter_useless", filter_useless);
+    (* Simplify the lets immediately followed by a return.
+
+       Ex.:
+       {[
+         x <-- f y;
+         Return x
+
+           ~~>
+
+         f y
+       ]}
+    *)
+    (None, "simplify_let_then_ok", simplify_let_then_ok);
+    (* Simplify the aggregated ADTs.
+
+       Ex.:
+       {[
+         (* type struct = { f0 : nat; f1 : nat; f2 : nat } *)
+
+         Mkstruct x.f0 x.f1 x.f2                 ~~> x
+         { f0 := x.f0; f1 := x.f1; f2 := x.f2 }  ~~> x
+         { f0 := x.f0; f1 := x.f1; f2 := v }     ~~> { x with f2 = v }
+       ]}
+    *)
+    (None, "simplify_aggregates", simplify_aggregates);
+    (* Simplify the let-bindings - some simplifications may have been unlocked by
+       the pass above (for instance, the lambda simplification) *)
+    (None, "simplify_let_bindings", simplify_let_bindings);
+    (* Inline the useless vars again *)
+    ( None,
+      "inline_useless_var_reassignments",
+      inline_useless_var_reassignments ~inline_named:true ~inline_const:true
+        ~inline_pure:false );
+    (* Simplify the let-then return again (the lambda simplification may have
+       unlocked more simplifications here) *)
+    (None, "simplify_let_then_ok (pass 2)", simplify_let_then_ok);
+    (* Simplify the array/slice manipulations by introducing calls to [array_update]
+       [slice_update] *)
+    (None, "simplify_array_slice_update", simplify_array_slice_update);
+    (* Decompose the monadic let-bindings - used by Coq *)
+    ( Some Config.decompose_monadic_let_bindings,
+      "decompose_monadic_let_bindings",
+      decompose_monadic_let_bindings );
+    (* Decompose nested let-patterns *)
+    ( Some Config.decompose_nested_let_patterns,
+      "decompose_nested_let_patterns",
+      decompose_nested_let_patterns );
+    (* Unfold the monadic let-bindings *)
+    ( Some Config.unfold_monadic_let_bindings,
+      "unfold_monadic_let_bindings",
+      unfold_monadic_let_bindings );
+  ]
+
 (** Auxiliary function for {!apply_passes_to_def} *)
 let apply_end_passes_to_def (ctx : trans_ctx) (def : fun_decl) : fun_decl =
-  (* Convert the unit variables to [()] if they are used as right-values or
-   * [_] if they are used as left values. *)
-  let def = unit_vars_to_unit def in
-  log#ldebug
-    (lazy ("unit_vars_to_unit:\n\n" ^ fun_decl_to_string ctx def ^ "\n"));
+  List.fold_left
+    (fun def (option, pass_name, pass) ->
+      let apply =
+        match option with
+        | None -> true
+        | Some option -> !option
+      in
 
-  (* Introduce the special structure create/update expressions *)
-  let def = intro_struct_updates ctx def in
-  log#ldebug
-    (lazy ("intro_struct_updates:\n\n" ^ fun_decl_to_string ctx def ^ "\n"));
-
-  (* Simplify the let-bindings *)
-  let def = simplify_let_bindings ctx def in
-  log#ldebug
-    (lazy ("simplify_let_bindings:\n\n" ^ fun_decl_to_string ctx def ^ "\n"));
-
-  (* Inline the useless variable reassignments *)
-  let def =
-    inline_useless_var_reassignments ctx ~inline_named:true ~inline_const:true
-      ~inline_pure:true def
-  in
-  log#ldebug
-    (lazy
-      ("inline_useless_var_assignments:\n\n" ^ fun_decl_to_string ctx def ^ "\n"));
-
-  (* Eliminate the box functions - note that the "box" types were eliminated
-   * during the symbolic to pure phase: see the comments for [eliminate_box_functions] *)
-  let def = eliminate_box_functions ctx def in
-  log#ldebug
-    (lazy ("eliminate_box_functions:\n\n" ^ fun_decl_to_string ctx def ^ "\n"));
-
-  (* Filter the useless variables, assignments, function calls, etc. *)
-  let def = filter_useless ctx def in
-  log#ldebug (lazy ("filter_useless:\n\n" ^ fun_decl_to_string ctx def ^ "\n"));
-
-  (* Simplify the lets immediately followed by a return.
-
-     Ex.:
-     {[
-       x <-- f y;
-       Return x
-
-         ~~>
-
-       f y
-     ]}
-  *)
-  let def = simplify_let_then_ok ctx def in
-  log#ldebug
-    (lazy ("simplify_let_then_ok:\n\n" ^ fun_decl_to_string ctx def ^ "\n"));
-
-  (* Simplify the aggregated ADTs.
-
-     Ex.:
-     {[
-       (* type struct = { f0 : nat; f1 : nat; f2 : nat } *)
-
-       Mkstruct x.f0 x.f1 x.f2                 ~~> x
-       { f0 := x.f0; f1 := x.f1; f2 := x.f2 }  ~~> x
-       { f0 := x.f0; f1 := x.f1; f2 := v }     ~~> { x with f2 = v }
-     ]}
-  *)
-  let def = simplify_aggregates ctx def in
-  log#ldebug
-    (lazy ("simplify_aggregates:\n\n" ^ fun_decl_to_string ctx def ^ "\n"));
-
-  (* Simplify the let-bindings - some simplifications may have been unlocked by
-     the pass above (for instance, the lambda simplification) *)
-  let def = simplify_let_bindings ctx def in
-  log#ldebug
-    (lazy
-      ("simplify_let_bindings (pass 2):\n\n" ^ fun_decl_to_string ctx def ^ "\n"));
-
-  (* Inline the useless vars again *)
-  let def =
-    inline_useless_var_reassignments ctx ~inline_named:true ~inline_const:true
-      ~inline_pure:false def
-  in
-  log#ldebug
-    (lazy
-      ("inline_useless_var_assignments (pass 2):\n\n"
-     ^ fun_decl_to_string ctx def ^ "\n"));
-
-  (* Simplify the let-then return again (the lambda simplification may have
-     unlocked more simplifications here) *)
-  let def = simplify_let_then_ok ctx def in
-  log#ldebug
-    (lazy
-      ("simplify_let_then_ok (pass 2):\n\n" ^ fun_decl_to_string ctx def ^ "\n"));
-
-  (* Decompose the monadic let-bindings - used by Coq *)
-  let def =
-    if !Config.decompose_monadic_let_bindings then (
-      let def = decompose_monadic_let_bindings ctx def in
-      log#ldebug
-        (lazy
-          ("decompose_monadic_let_bindings:\n\n" ^ fun_decl_to_string ctx def
-         ^ "\n"));
-      def)
-    else (
-      log#ldebug
-        (lazy
-          "ignoring decompose_monadic_let_bindings due to the configuration\n");
-      def)
-  in
-
-  (* Decompose nested let-patterns *)
-  let def =
-    if !Config.decompose_nested_let_patterns then (
-      let def = decompose_nested_let_patterns ctx def in
-      log#ldebug
-        (lazy
-          ("decompose_nested_let_patterns:\n\n" ^ fun_decl_to_string ctx def
-         ^ "\n"));
-      def)
-    else (
-      log#ldebug
-        (lazy
-          "ignoring decompose_nested_let_patterns due to the configuration\n");
-      def)
-  in
-
-  (* Unfold the monadic let-bindings *)
-  let def =
-    if !Config.unfold_monadic_let_bindings then (
-      let def = unfold_monadic_let_bindings ctx def in
-      log#ldebug
-        (lazy
-          ("unfold_monadic_let_bindings:\n\n" ^ fun_decl_to_string ctx def
-         ^ "\n"));
-      def)
-    else (
-      log#ldebug
-        (lazy "ignoring unfold_monadic_let_bindings due to the configuration\n");
-      def)
-  in
-
-  (* We are done *)
-  def
+      if apply then (
+        let def = pass ctx def in
+        log#ldebug
+          (lazy (pass_name ^ ":\n\n" ^ fun_decl_to_string ctx def ^ "\n"));
+        def)
+      else (
+        log#ldebug
+          (lazy ("ignoring " ^ pass_name ^ " due to the configuration\n"));
+        def))
+    def end_passes
 
 (** Small utility for {!filter_loop_inputs} *)
 let filter_prefix (keep : bool list) (ls : 'a list) : 'a list =

--- a/compiler/SymbolicToPure.ml
+++ b/compiler/SymbolicToPure.ml
@@ -359,7 +359,7 @@ let pure_type_decl_to_string (ctx : bs_ctx) (def : type_decl) : string =
 
 let texpression_to_string (ctx : bs_ctx) (e : texpression) : string =
   let env = bs_ctx_to_pure_fmt_env ctx in
-  PrintPure.texpression_to_string ~spandata:(Some ctx.span) env false "" "  " e
+  PrintPure.texpression_to_string ~span:(Some ctx.span) env false "" "  " e
 
 let fun_id_to_string (ctx : bs_ctx) (id : A.fun_id) : string =
   let env = bs_ctx_to_fmt_env ctx in

--- a/compiler/ValuesUtils.ml
+++ b/compiler/ValuesUtils.ml
@@ -11,6 +11,12 @@ exception FoundSymbolicValue of symbolic_value
 let mk_unit_value : typed_value =
   { value = VAdt { variant_id = None; field_values = [] }; ty = mk_unit_ty }
 
+let mk_bool_value (b : bool) : typed_value =
+  { value = VLiteral (VBool b); ty = TLiteral TBool }
+
+let mk_true : typed_value = mk_bool_value true
+let mk_false : typed_value = mk_bool_value false
+
 let mk_typed_value (span : Meta.span) (ty : ty) (value : value) : typed_value =
   sanity_check __FILE__ __LINE__ (ty_is_ety ty) span;
   { value; ty }

--- a/tests/coq/arrays/Arrays.v
+++ b/tests/coq/arrays/Arrays.v
@@ -185,9 +185,7 @@ Definition update_update_array
   :=
   p <- array_index_mut_usize s i;
   let (a, index_mut_back) := p in
-  p1 <- array_index_mut_usize a j;
-  let (_, index_mut_back1) := p1 in
-  a1 <- index_mut_back1 0%u32;
+  a1 <- array_update_usize a j 0%u32;
   _ <- index_mut_back a1;
   Ok tt
 .
@@ -293,27 +291,20 @@ Definition index_all : result u32 :=
 (** [arrays::update_array]:
     Source: 'tests/src/arrays.rs', lines 187:0-189:1 *)
 Definition update_array (x : array u32 2%usize) : result unit :=
-  p <- array_index_mut_usize x 0%usize;
-  let (_, index_mut_back) := p in
-  _ <- index_mut_back 1%u32;
-  Ok tt
+  _ <- array_update_usize x 0%usize 1%u32; Ok tt
 .
 
 (** [arrays::update_array_mut_borrow]:
     Source: 'tests/src/arrays.rs', lines 190:0-192:1 *)
 Definition update_array_mut_borrow
   (x : array u32 2%usize) : result (array u32 2%usize) :=
-  p <- array_index_mut_usize x 0%usize;
-  let (_, index_mut_back) := p in
-  index_mut_back 1%u32
+  array_update_usize x 0%usize 1%u32
 .
 
 (** [arrays::update_mut_slice]:
     Source: 'tests/src/arrays.rs', lines 193:0-195:1 *)
 Definition update_mut_slice (x : slice u32) : result (slice u32) :=
-  p <- slice_index_mut_usize x 0%usize;
-  let (_, index_mut_back) := p in
-  index_mut_back 1%u32
+  slice_update_usize x 0%usize 1%u32
 .
 
 (** [arrays::update_all]:
@@ -329,8 +320,24 @@ Definition update_all : result unit :=
   Ok tt
 .
 
+(** [arrays::incr_array]:
+    Source: 'tests/src/arrays.rs', lines 205:0-207:1 *)
+Definition incr_array (x : array u32 2%usize) : result (array u32 2%usize) :=
+  i <- array_index_usize x 0%usize;
+  i1 <- u32_add i 1%u32;
+  array_update_usize x 0%usize i1
+.
+
+(** [arrays::incr_slice]:
+    Source: 'tests/src/arrays.rs', lines 209:0-211:1 *)
+Definition incr_slice (x : slice u32) : result (slice u32) :=
+  i <- slice_index_usize x 0%usize;
+  i1 <- u32_add i 1%u32;
+  slice_update_usize x 0%usize i1
+.
+
 (** [arrays::range_all]:
-    Source: 'tests/src/arrays.rs', lines 208:0-212:1 *)
+    Source: 'tests/src/arrays.rs', lines 216:0-220:1 *)
 Definition range_all : result unit :=
   p <-
     core_array_Array_index_mut (core_ops_index_IndexMutSliceTIInst
@@ -347,31 +354,31 @@ Definition range_all : result unit :=
 .
 
 (** [arrays::deref_array_borrow]:
-    Source: 'tests/src/arrays.rs', lines 217:0-220:1 *)
+    Source: 'tests/src/arrays.rs', lines 225:0-228:1 *)
 Definition deref_array_borrow (x : array u32 2%usize) : result u32 :=
   array_index_usize x 0%usize
 .
 
 (** [arrays::deref_array_mut_borrow]:
-    Source: 'tests/src/arrays.rs', lines 222:0-225:1 *)
+    Source: 'tests/src/arrays.rs', lines 230:0-233:1 *)
 Definition deref_array_mut_borrow
   (x : array u32 2%usize) : result (u32 * (array u32 2%usize)) :=
   i <- array_index_usize x 0%usize; Ok (i, x)
 .
 
 (** [arrays::take_array_t]:
-    Source: 'tests/src/arrays.rs', lines 230:0-230:34 *)
+    Source: 'tests/src/arrays.rs', lines 238:0-238:34 *)
 Definition take_array_t (a : array AB_t 2%usize) : result unit :=
   Ok tt.
 
 (** [arrays::non_copyable_array]:
-    Source: 'tests/src/arrays.rs', lines 232:0-240:1 *)
+    Source: 'tests/src/arrays.rs', lines 240:0-248:1 *)
 Definition non_copyable_array : result unit :=
   take_array_t (mk_array 2%usize [ AB_A; AB_B ])
 .
 
 (** [arrays::sum]: loop 0:
-    Source: 'tests/src/arrays.rs', lines 248:4-251:5 *)
+    Source: 'tests/src/arrays.rs', lines 256:4-259:5 *)
 Fixpoint sum_loop
   (n : nat) (s : slice u32) (sum1 : u32) (i : usize) : result u32 :=
   match n with
@@ -389,13 +396,13 @@ Fixpoint sum_loop
 .
 
 (** [arrays::sum]:
-    Source: 'tests/src/arrays.rs', lines 245:0-253:1 *)
+    Source: 'tests/src/arrays.rs', lines 253:0-261:1 *)
 Definition sum (n : nat) (s : slice u32) : result u32 :=
   sum_loop n s 0%u32 0%usize
 .
 
 (** [arrays::sum2]: loop 0:
-    Source: 'tests/src/arrays.rs', lines 259:4-262:5 *)
+    Source: 'tests/src/arrays.rs', lines 267:4-270:5 *)
 Fixpoint sum2_loop
   (n : nat) (s : slice u32) (s2 : slice u32) (sum1 : u32) (i : usize) :
   result u32
@@ -417,7 +424,7 @@ Fixpoint sum2_loop
 .
 
 (** [arrays::sum2]:
-    Source: 'tests/src/arrays.rs', lines 255:0-264:1 *)
+    Source: 'tests/src/arrays.rs', lines 263:0-272:1 *)
 Definition sum2 (n : nat) (s : slice u32) (s2 : slice u32) : result u32 :=
   let i := slice_len s in
   let i1 := slice_len s2 in
@@ -425,33 +432,29 @@ Definition sum2 (n : nat) (s : slice u32) (s2 : slice u32) : result u32 :=
 .
 
 (** [arrays::f0]:
-    Source: 'tests/src/arrays.rs', lines 266:0-269:1 *)
+    Source: 'tests/src/arrays.rs', lines 274:0-277:1 *)
 Definition f0 : result unit :=
   p <- array_to_slice_mut (mk_array 2%usize [ 1%u32; 2%u32 ]);
   let (s, to_slice_mut_back) := p in
-  p1 <- slice_index_mut_usize s 0%usize;
-  let (_, index_mut_back) := p1 in
-  s1 <- index_mut_back 1%u32;
+  s1 <- slice_update_usize s 0%usize 1%u32;
   _ <- to_slice_mut_back s1;
   Ok tt
 .
 
 (** [arrays::f1]:
-    Source: 'tests/src/arrays.rs', lines 271:0-274:1 *)
+    Source: 'tests/src/arrays.rs', lines 279:0-282:1 *)
 Definition f1 : result unit :=
-  p <- array_index_mut_usize (mk_array 2%usize [ 1%u32; 2%u32 ]) 0%usize;
-  let (_, index_mut_back) := p in
-  _ <- index_mut_back 1%u32;
+  _ <- array_update_usize (mk_array 2%usize [ 1%u32; 2%u32 ]) 0%usize 1%u32;
   Ok tt
 .
 
 (** [arrays::f2]:
-    Source: 'tests/src/arrays.rs', lines 276:0-276:20 *)
+    Source: 'tests/src/arrays.rs', lines 284:0-284:20 *)
 Definition f2 (i : u32) : result unit :=
   Ok tt.
 
 (** [arrays::f4]:
-    Source: 'tests/src/arrays.rs', lines 285:0-287:1 *)
+    Source: 'tests/src/arrays.rs', lines 293:0-295:1 *)
 Definition f4
   (x : array u32 32%usize) (y : usize) (z : usize) : result (slice u32) :=
   core_array_Array_index (core_ops_index_IndexSliceTIInst
@@ -460,7 +463,7 @@ Definition f4
 .
 
 (** [arrays::f3]:
-    Source: 'tests/src/arrays.rs', lines 278:0-283:1 *)
+    Source: 'tests/src/arrays.rs', lines 286:0-291:1 *)
 Definition f3 (n : nat) : result u32 :=
   i <- array_index_usize (mk_array 2%usize [ 1%u32; 2%u32 ]) 0%usize;
   _ <- f2 i;
@@ -471,18 +474,18 @@ Definition f3 (n : nat) : result u32 :=
 .
 
 (** [arrays::SZ]
-    Source: 'tests/src/arrays.rs', lines 289:0-289:25 *)
+    Source: 'tests/src/arrays.rs', lines 297:0-297:25 *)
 Definition sz_body : result usize := Ok 32%usize.
 Definition sz : usize := sz_body%global.
 
 (** [arrays::f5]:
-    Source: 'tests/src/arrays.rs', lines 292:0-294:1 *)
+    Source: 'tests/src/arrays.rs', lines 300:0-302:1 *)
 Definition f5 (x : array u32 32%usize) : result u32 :=
   array_index_usize x 0%usize
 .
 
 (** [arrays::ite]:
-    Source: 'tests/src/arrays.rs', lines 297:0-304:1 *)
+    Source: 'tests/src/arrays.rs', lines 305:0-312:1 *)
 Definition ite : result unit :=
   p <- array_to_slice_mut (mk_array 2%usize [ 0%u32; 0%u32 ]);
   let (s, to_slice_mut_back) := p in
@@ -498,7 +501,7 @@ Definition ite : result unit :=
 .
 
 (** [arrays::zero_slice]: loop 0:
-    Source: 'tests/src/arrays.rs', lines 309:4-312:5 *)
+    Source: 'tests/src/arrays.rs', lines 317:4-320:5 *)
 Fixpoint zero_slice_loop
   (n : nat) (a : slice u8) (i : usize) (len : usize) : result (slice u8) :=
   match n with
@@ -516,13 +519,13 @@ Fixpoint zero_slice_loop
 .
 
 (** [arrays::zero_slice]:
-    Source: 'tests/src/arrays.rs', lines 306:0-313:1 *)
+    Source: 'tests/src/arrays.rs', lines 314:0-321:1 *)
 Definition zero_slice (n : nat) (a : slice u8) : result (slice u8) :=
   let len := slice_len a in zero_slice_loop n a 0%usize len
 .
 
 (** [arrays::iter_mut_slice]: loop 0:
-    Source: 'tests/src/arrays.rs', lines 318:4-320:5 *)
+    Source: 'tests/src/arrays.rs', lines 326:4-328:5 *)
 Fixpoint iter_mut_slice_loop
   (n : nat) (len : usize) (i : usize) : result unit :=
   match n with
@@ -535,13 +538,13 @@ Fixpoint iter_mut_slice_loop
 .
 
 (** [arrays::iter_mut_slice]:
-    Source: 'tests/src/arrays.rs', lines 315:0-321:1 *)
+    Source: 'tests/src/arrays.rs', lines 323:0-329:1 *)
 Definition iter_mut_slice (n : nat) (a : slice u8) : result (slice u8) :=
   let len := slice_len a in _ <- iter_mut_slice_loop n len 0%usize; Ok a
 .
 
 (** [arrays::sum_mut_slice]: loop 0:
-    Source: 'tests/src/arrays.rs', lines 326:4-329:5 *)
+    Source: 'tests/src/arrays.rs', lines 334:4-337:5 *)
 Fixpoint sum_mut_slice_loop
   (n : nat) (a : slice u32) (i : usize) (s : u32) : result u32 :=
   match n with
@@ -559,7 +562,7 @@ Fixpoint sum_mut_slice_loop
 .
 
 (** [arrays::sum_mut_slice]:
-    Source: 'tests/src/arrays.rs', lines 323:0-331:1 *)
+    Source: 'tests/src/arrays.rs', lines 331:0-339:1 *)
 Definition sum_mut_slice
   (n : nat) (a : slice u32) : result (u32 * (slice u32)) :=
   i <- sum_mut_slice_loop n a 0%usize 0%u32; Ok (i, a)

--- a/tests/coq/hashmap/Hashmap_Funs.v
+++ b/tests/coq/hashmap/Hashmap_Funs.v
@@ -264,7 +264,7 @@ Definition hashMap_try_resize
     Ok
       {|
         hashMap_num_entries := self.(hashMap_num_entries);
-        hashMap_max_load_factor := (i, i1);
+        hashMap_max_load_factor := self.(hashMap_max_load_factor);
         hashMap_max_load := ntable1.(hashMap_max_load);
         hashMap_saturated := self.(hashMap_saturated);
         hashMap_slots := ntable1.(hashMap_slots)
@@ -273,7 +273,7 @@ Definition hashMap_try_resize
     Ok
       {|
         hashMap_num_entries := self.(hashMap_num_entries);
-        hashMap_max_load_factor := (i, i1);
+        hashMap_max_load_factor := self.(hashMap_max_load_factor);
         hashMap_max_load := self.(hashMap_max_load);
         hashMap_saturated := true;
         hashMap_slots := self.(hashMap_slots)
@@ -462,7 +462,7 @@ Fixpoint hashMap_remove_from_list_loop
     | AList_Cons ckey t tl =>
       if ckey s= key
       then
-        let (mv_ls, _) := core_mem_replace (AList_Cons ckey t tl) AList_Nil in
+        let (mv_ls, _) := core_mem_replace ls AList_Nil in
         match mv_ls with
         | AList_Cons _ cvalue tl1 => Ok (Some cvalue, tl1)
         | AList_Nil => Fail_ Failure
@@ -514,7 +514,7 @@ Definition hashMap_remove
   | Some x1 =>
     i1 <- usize_sub self.(hashMap_num_entries) 1%usize;
     v <- index_mut_back a1;
-    Ok (Some x1,
+    Ok (x,
       {|
         hashMap_num_entries := i1;
         hashMap_max_load_factor := self.(hashMap_max_load_factor);

--- a/tests/coq/misc/NoNestedBorrows.v
+++ b/tests/coq/misc/NoNestedBorrows.v
@@ -386,7 +386,7 @@ Definition id_mut_pair2
   {T1 : Type} {T2 : Type} (p : (T1 * T2)) :
   result ((T1 * T2) * ((T1 * T2) -> result (T1 * T2)))
   :=
-  let (t, t1) := p in Ok ((t, t1), Ok)
+  let (t, t1) := p in Ok (p, Ok)
 .
 
 (** [no_nested_borrows::id_mut_pair3]:
@@ -404,7 +404,7 @@ Definition id_mut_pair4
   {T1 : Type} {T2 : Type} (p : (T1 * T2)) :
   result ((T1 * T2) * (T1 -> result T1) * (T2 -> result T2))
   :=
-  let (t, t1) := p in Ok ((t, t1), Ok, Ok)
+  let (t, t1) := p in Ok (p, Ok, Ok)
 .
 
 (** [no_nested_borrows::StructWithTuple]
@@ -597,5 +597,43 @@ Definition not_u32 (x : u32) : result u32 :=
     Source: 'tests/src/no_nested_borrows.rs', lines 528:0-530:1 *)
 Definition not_i32 (x : i32) : result i32 :=
   Ok (scalar_not x).
+
+(** [no_nested_borrows::ExpandSimpliy::Wrapper]
+    Source: 'tests/src/no_nested_borrows.rs', lines 534:4-534:32 *)
+Definition ExpandSimpliy_Wrapper_t (T : Type) : Type := T * T.
+
+(** [no_nested_borrows::ExpandSimpliy::check_expand_simplify_symb1]:
+    Source: 'tests/src/no_nested_borrows.rs', lines 536:4-542:5 *)
+Definition expandSimpliy_check_expand_simplify_symb1
+  (x : ExpandSimpliy_Wrapper_t bool) : result (ExpandSimpliy_Wrapper_t bool) :=
+  let (b, b1) := x in if b then Ok x else Ok x
+.
+
+(** [no_nested_borrows::ExpandSimpliy::Wrapper2]
+    Source: 'tests/src/no_nested_borrows.rs', lines 544:4-547:5 *)
+Record ExpandSimpliy_Wrapper2_t :=
+mkExpandSimpliy_Wrapper2_t {
+  expandSimpliy_Wrapper2_b : bool; expandSimpliy_Wrapper2_x : u32;
+}
+.
+
+(** [no_nested_borrows::ExpandSimpliy::check_expand_simplify_symb2]:
+    Source: 'tests/src/no_nested_borrows.rs', lines 549:4-555:5 *)
+Definition expandSimpliy_check_expand_simplify_symb2
+  (x : ExpandSimpliy_Wrapper2_t) : result ExpandSimpliy_Wrapper2_t :=
+  if x.(expandSimpliy_Wrapper2_b)
+  then
+    Ok
+      {|
+        expandSimpliy_Wrapper2_b := true;
+        expandSimpliy_Wrapper2_x := x.(expandSimpliy_Wrapper2_x)
+      |}
+  else
+    Ok
+      {|
+        expandSimpliy_Wrapper2_b := false;
+        expandSimpliy_Wrapper2_x := x.(expandSimpliy_Wrapper2_x)
+      |}
+.
 
 End NoNestedBorrows.

--- a/tests/coq/misc/PoloniusList.v
+++ b/tests/coq/misc/PoloniusList.v
@@ -27,7 +27,7 @@ Fixpoint get_list_at_x
   match ls with
   | List_Cons hd tl =>
     if hd s= x
-    then Ok (List_Cons hd tl, Ok)
+    then Ok (ls, Ok)
     else (
       p <- get_list_at_x tl x;
       let (l, get_list_at_x_back) := p in

--- a/tests/fstar/arrays/Arrays.Clauses.Template.fst
+++ b/tests/fstar/arrays/Arrays.Clauses.Template.fst
@@ -7,31 +7,31 @@ open Arrays.Types
 #set-options "--z3rlimit 50 --fuel 1 --ifuel 1"
 
 (** [arrays::sum]: decreases clause
-    Source: 'tests/src/arrays.rs', lines 248:4-251:5 *)
+    Source: 'tests/src/arrays.rs', lines 256:4-259:5 *)
 unfold
 let sum_loop_decreases (s : slice u32) (sum1 : u32) (i : usize) : nat =
   admit ()
 
 (** [arrays::sum2]: decreases clause
-    Source: 'tests/src/arrays.rs', lines 259:4-262:5 *)
+    Source: 'tests/src/arrays.rs', lines 267:4-270:5 *)
 unfold
 let sum2_loop_decreases (s : slice u32) (s2 : slice u32) (sum1 : u32)
   (i : usize) : nat =
   admit ()
 
 (** [arrays::zero_slice]: decreases clause
-    Source: 'tests/src/arrays.rs', lines 309:4-312:5 *)
+    Source: 'tests/src/arrays.rs', lines 317:4-320:5 *)
 unfold
 let zero_slice_loop_decreases (a : slice u8) (i : usize) (len : usize) : nat =
   admit ()
 
 (** [arrays::iter_mut_slice]: decreases clause
-    Source: 'tests/src/arrays.rs', lines 318:4-320:5 *)
+    Source: 'tests/src/arrays.rs', lines 326:4-328:5 *)
 unfold
 let iter_mut_slice_loop_decreases (len : usize) (i : usize) : nat = admit ()
 
 (** [arrays::sum_mut_slice]: decreases clause
-    Source: 'tests/src/arrays.rs', lines 326:4-329:5 *)
+    Source: 'tests/src/arrays.rs', lines 334:4-337:5 *)
 unfold
 let sum_mut_slice_loop_decreases (a : slice u32) (i : usize) (s : u32) : nat =
   admit ()

--- a/tests/fstar/arrays/Arrays.Funs.fst
+++ b/tests/fstar/arrays/Arrays.Funs.fst
@@ -149,8 +149,7 @@ let index_index_array
 let update_update_array
   (s : array (array u32 32) 32) (i : usize) (j : usize) : result unit =
   let* (a, index_mut_back) = array_index_mut_usize s i in
-  let* (_, index_mut_back1) = array_index_mut_usize a j in
-  let* a1 = index_mut_back1 0 in
+  let* a1 = array_update_usize a j 0 in
   let* _ = index_mut_back a1 in
   Ok ()
 
@@ -242,19 +241,17 @@ let index_all : result u32 =
 (** [arrays::update_array]:
     Source: 'tests/src/arrays.rs', lines 187:0-189:1 *)
 let update_array (x : array u32 2) : result unit =
-  let* (_, index_mut_back) = array_index_mut_usize x 0 in
-  let* _ = index_mut_back 1 in
-  Ok ()
+  let* _ = array_update_usize x 0 1 in Ok ()
 
 (** [arrays::update_array_mut_borrow]:
     Source: 'tests/src/arrays.rs', lines 190:0-192:1 *)
 let update_array_mut_borrow (x : array u32 2) : result (array u32 2) =
-  let* (_, index_mut_back) = array_index_mut_usize x 0 in index_mut_back 1
+  array_update_usize x 0 1
 
 (** [arrays::update_mut_slice]:
     Source: 'tests/src/arrays.rs', lines 193:0-195:1 *)
 let update_mut_slice (x : slice u32) : result (slice u32) =
-  let* (_, index_mut_back) = slice_index_mut_usize x 0 in index_mut_back 1
+  slice_update_usize x 0 1
 
 (** [arrays::update_all]:
     Source: 'tests/src/arrays.rs', lines 197:0-203:1 *)
@@ -267,8 +264,22 @@ let update_all : result unit =
   let* _ = to_slice_mut_back s1 in
   Ok ()
 
+(** [arrays::incr_array]:
+    Source: 'tests/src/arrays.rs', lines 205:0-207:1 *)
+let incr_array (x : array u32 2) : result (array u32 2) =
+  let* i = array_index_usize x 0 in
+  let* i1 = u32_add i 1 in
+  array_update_usize x 0 i1
+
+(** [arrays::incr_slice]:
+    Source: 'tests/src/arrays.rs', lines 209:0-211:1 *)
+let incr_slice (x : slice u32) : result (slice u32) =
+  let* i = slice_index_usize x 0 in
+  let* i1 = u32_add i 1 in
+  slice_update_usize x 0 i1
+
 (** [arrays::range_all]:
-    Source: 'tests/src/arrays.rs', lines 208:0-212:1 *)
+    Source: 'tests/src/arrays.rs', lines 216:0-220:1 *)
 let range_all : result unit =
   let* (s, index_mut_back) =
     core_array_Array_index_mut (core_ops_index_IndexMutSliceTIInst
@@ -279,27 +290,27 @@ let range_all : result unit =
   Ok ()
 
 (** [arrays::deref_array_borrow]:
-    Source: 'tests/src/arrays.rs', lines 217:0-220:1 *)
+    Source: 'tests/src/arrays.rs', lines 225:0-228:1 *)
 let deref_array_borrow (x : array u32 2) : result u32 =
   array_index_usize x 0
 
 (** [arrays::deref_array_mut_borrow]:
-    Source: 'tests/src/arrays.rs', lines 222:0-225:1 *)
+    Source: 'tests/src/arrays.rs', lines 230:0-233:1 *)
 let deref_array_mut_borrow (x : array u32 2) : result (u32 & (array u32 2)) =
   let* i = array_index_usize x 0 in Ok (i, x)
 
 (** [arrays::take_array_t]:
-    Source: 'tests/src/arrays.rs', lines 230:0-230:34 *)
+    Source: 'tests/src/arrays.rs', lines 238:0-238:34 *)
 let take_array_t (a : array aB_t 2) : result unit =
   Ok ()
 
 (** [arrays::non_copyable_array]:
-    Source: 'tests/src/arrays.rs', lines 232:0-240:1 *)
+    Source: 'tests/src/arrays.rs', lines 240:0-248:1 *)
 let non_copyable_array : result unit =
   take_array_t (mk_array 2 [ AB_A; AB_B ])
 
 (** [arrays::sum]: loop 0:
-    Source: 'tests/src/arrays.rs', lines 248:4-251:5 *)
+    Source: 'tests/src/arrays.rs', lines 256:4-259:5 *)
 let rec sum_loop
   (s : slice u32) (sum1 : u32) (i : usize) :
   Tot (result u32) (decreases (sum_loop_decreases s sum1 i))
@@ -314,12 +325,12 @@ let rec sum_loop
   else Ok sum1
 
 (** [arrays::sum]:
-    Source: 'tests/src/arrays.rs', lines 245:0-253:1 *)
+    Source: 'tests/src/arrays.rs', lines 253:0-261:1 *)
 let sum (s : slice u32) : result u32 =
   sum_loop s 0 0
 
 (** [arrays::sum2]: loop 0:
-    Source: 'tests/src/arrays.rs', lines 259:4-262:5 *)
+    Source: 'tests/src/arrays.rs', lines 267:4-270:5 *)
 let rec sum2_loop
   (s : slice u32) (s2 : slice u32) (sum1 : u32) (i : usize) :
   Tot (result u32) (decreases (sum2_loop_decreases s s2 sum1 i))
@@ -336,42 +347,39 @@ let rec sum2_loop
   else Ok sum1
 
 (** [arrays::sum2]:
-    Source: 'tests/src/arrays.rs', lines 255:0-264:1 *)
+    Source: 'tests/src/arrays.rs', lines 263:0-272:1 *)
 let sum2 (s : slice u32) (s2 : slice u32) : result u32 =
   let i = slice_len s in
   let i1 = slice_len s2 in
   if i = i1 then sum2_loop s s2 0 0 else Fail Failure
 
 (** [arrays::f0]:
-    Source: 'tests/src/arrays.rs', lines 266:0-269:1 *)
+    Source: 'tests/src/arrays.rs', lines 274:0-277:1 *)
 let f0 : result unit =
   let* (s, to_slice_mut_back) = array_to_slice_mut (mk_array 2 [ 1; 2 ]) in
-  let* (_, index_mut_back) = slice_index_mut_usize s 0 in
-  let* s1 = index_mut_back 1 in
+  let* s1 = slice_update_usize s 0 1 in
   let* _ = to_slice_mut_back s1 in
   Ok ()
 
 (** [arrays::f1]:
-    Source: 'tests/src/arrays.rs', lines 271:0-274:1 *)
+    Source: 'tests/src/arrays.rs', lines 279:0-282:1 *)
 let f1 : result unit =
-  let* (_, index_mut_back) = array_index_mut_usize (mk_array 2 [ 1; 2 ]) 0 in
-  let* _ = index_mut_back 1 in
-  Ok ()
+  let* _ = array_update_usize (mk_array 2 [ 1; 2 ]) 0 1 in Ok ()
 
 (** [arrays::f2]:
-    Source: 'tests/src/arrays.rs', lines 276:0-276:20 *)
+    Source: 'tests/src/arrays.rs', lines 284:0-284:20 *)
 let f2 (i : u32) : result unit =
   Ok ()
 
 (** [arrays::f4]:
-    Source: 'tests/src/arrays.rs', lines 285:0-287:1 *)
+    Source: 'tests/src/arrays.rs', lines 293:0-295:1 *)
 let f4 (x : array u32 32) (y : usize) (z : usize) : result (slice u32) =
   core_array_Array_index (core_ops_index_IndexSliceTIInst
     (core_slice_index_SliceIndexRangeUsizeSliceTInst u32)) x
     { start = y; end_ = z }
 
 (** [arrays::f3]:
-    Source: 'tests/src/arrays.rs', lines 278:0-283:1 *)
+    Source: 'tests/src/arrays.rs', lines 286:0-291:1 *)
 let f3 : result u32 =
   let* i = array_index_usize (mk_array 2 [ 1; 2 ]) 0 in
   let* _ = f2 i in
@@ -381,17 +389,17 @@ let f3 : result u32 =
   sum2 s s1
 
 (** [arrays::SZ]
-    Source: 'tests/src/arrays.rs', lines 289:0-289:25 *)
+    Source: 'tests/src/arrays.rs', lines 297:0-297:25 *)
 let sz_body : result usize = Ok 32
 let sz : usize = eval_global sz_body
 
 (** [arrays::f5]:
-    Source: 'tests/src/arrays.rs', lines 292:0-294:1 *)
+    Source: 'tests/src/arrays.rs', lines 300:0-302:1 *)
 let f5 (x : array u32 32) : result u32 =
   array_index_usize x 0
 
 (** [arrays::ite]:
-    Source: 'tests/src/arrays.rs', lines 297:0-304:1 *)
+    Source: 'tests/src/arrays.rs', lines 305:0-312:1 *)
 let ite : result unit =
   let* (s, to_slice_mut_back) = array_to_slice_mut (mk_array 2 [ 0; 0 ]) in
   let* (_, s1) = index_mut_slice_u32_0 s in
@@ -402,7 +410,7 @@ let ite : result unit =
   Ok ()
 
 (** [arrays::zero_slice]: loop 0:
-    Source: 'tests/src/arrays.rs', lines 309:4-312:5 *)
+    Source: 'tests/src/arrays.rs', lines 317:4-320:5 *)
 let rec zero_slice_loop
   (a : slice u8) (i : usize) (len : usize) :
   Tot (result (slice u8)) (decreases (zero_slice_loop_decreases a i len))
@@ -416,12 +424,12 @@ let rec zero_slice_loop
   else Ok a
 
 (** [arrays::zero_slice]:
-    Source: 'tests/src/arrays.rs', lines 306:0-313:1 *)
+    Source: 'tests/src/arrays.rs', lines 314:0-321:1 *)
 let zero_slice (a : slice u8) : result (slice u8) =
   let len = slice_len a in zero_slice_loop a 0 len
 
 (** [arrays::iter_mut_slice]: loop 0:
-    Source: 'tests/src/arrays.rs', lines 318:4-320:5 *)
+    Source: 'tests/src/arrays.rs', lines 326:4-328:5 *)
 let rec iter_mut_slice_loop
   (len : usize) (i : usize) :
   Tot (result unit) (decreases (iter_mut_slice_loop_decreases len i))
@@ -431,12 +439,12 @@ let rec iter_mut_slice_loop
   else Ok ()
 
 (** [arrays::iter_mut_slice]:
-    Source: 'tests/src/arrays.rs', lines 315:0-321:1 *)
+    Source: 'tests/src/arrays.rs', lines 323:0-329:1 *)
 let iter_mut_slice (a : slice u8) : result (slice u8) =
   let len = slice_len a in let* _ = iter_mut_slice_loop len 0 in Ok a
 
 (** [arrays::sum_mut_slice]: loop 0:
-    Source: 'tests/src/arrays.rs', lines 326:4-329:5 *)
+    Source: 'tests/src/arrays.rs', lines 334:4-337:5 *)
 let rec sum_mut_slice_loop
   (a : slice u32) (i : usize) (s : u32) :
   Tot (result u32) (decreases (sum_mut_slice_loop_decreases a i s))
@@ -451,7 +459,7 @@ let rec sum_mut_slice_loop
   else Ok s
 
 (** [arrays::sum_mut_slice]:
-    Source: 'tests/src/arrays.rs', lines 323:0-331:1 *)
+    Source: 'tests/src/arrays.rs', lines 331:0-339:1 *)
 let sum_mut_slice (a : slice u32) : result (u32 & (slice u32)) =
   let* i = sum_mut_slice_loop a 0 0 in Ok (i, a)
 

--- a/tests/fstar/misc/NoNestedBorrows.fst
+++ b/tests/fstar/misc/NoNestedBorrows.fst
@@ -330,7 +330,7 @@ let id_mut_pair2
   (#t1 : Type0) (#t2 : Type0) (p : (t1 & t2)) :
   result ((t1 & t2) & ((t1 & t2) -> result (t1 & t2)))
   =
-  let (x, x1) = p in Ok ((x, x1), Ok)
+  let (x, x1) = p in Ok (p, Ok)
 
 (** [no_nested_borrows::id_mut_pair3]:
     Source: 'tests/src/no_nested_borrows.rs', lines 355:0-357:1 *)
@@ -346,7 +346,7 @@ let id_mut_pair4
   (#t1 : Type0) (#t2 : Type0) (p : (t1 & t2)) :
   result ((t1 & t2) & (t1 -> result t1) & (t2 -> result t2))
   =
-  let (x, x1) = p in Ok ((x, x1), Ok, Ok)
+  let (x, x1) = p in Ok (p, Ok, Ok)
 
 (** [no_nested_borrows::StructWithTuple]
     Source: 'tests/src/no_nested_borrows.rs', lines 366:0-368:1 *)
@@ -503,4 +503,24 @@ let not_u32 (x : u32) : result u32 =
     Source: 'tests/src/no_nested_borrows.rs', lines 528:0-530:1 *)
 let not_i32 (x : i32) : result i32 =
   Ok (i32_not x)
+
+(** [no_nested_borrows::ExpandSimpliy::Wrapper]
+    Source: 'tests/src/no_nested_borrows.rs', lines 534:4-534:32 *)
+type expandSimpliy_Wrapper_t (t : Type0) = t * t
+
+(** [no_nested_borrows::ExpandSimpliy::check_expand_simplify_symb1]:
+    Source: 'tests/src/no_nested_borrows.rs', lines 536:4-542:5 *)
+let expandSimpliy_check_expand_simplify_symb1
+  (x : expandSimpliy_Wrapper_t bool) : result (expandSimpliy_Wrapper_t bool) =
+  let (b, b1) = x in if b then Ok x else Ok x
+
+(** [no_nested_borrows::ExpandSimpliy::Wrapper2]
+    Source: 'tests/src/no_nested_borrows.rs', lines 544:4-547:5 *)
+type expandSimpliy_Wrapper2_t = { b : bool; x : u32; }
+
+(** [no_nested_borrows::ExpandSimpliy::check_expand_simplify_symb2]:
+    Source: 'tests/src/no_nested_borrows.rs', lines 549:4-555:5 *)
+let expandSimpliy_check_expand_simplify_symb2
+  (x : expandSimpliy_Wrapper2_t) : result expandSimpliy_Wrapper2_t =
+  if x.b then Ok x else Ok x
 

--- a/tests/fstar/misc/PoloniusList.fst
+++ b/tests/fstar/misc/PoloniusList.fst
@@ -20,7 +20,7 @@ let rec get_list_at_x
   begin match ls with
   | List_Cons hd tl ->
     if hd = x
-    then Ok (List_Cons hd tl, Ok)
+    then Ok (ls, Ok)
     else
       let* (l, get_list_at_x_back) = get_list_at_x tl x in
       let back =

--- a/tests/lean/Arrays.lean
+++ b/tests/lean/Arrays.lean
@@ -171,8 +171,7 @@ def update_update_array
   :=
   do
   let (a, index_mut_back) ← Array.index_mut_usize s i
-  let (_, index_mut_back1) ← Array.index_mut_usize a j
-  let a1 ← index_mut_back1 0#u32
+  let a1 ← Array.update_usize a j 0#u32
   let _ ← index_mut_back a1
   Result.ok ()
 
@@ -273,24 +272,19 @@ def index_all : Result U32 :=
    Source: 'tests/src/arrays.rs', lines 187:0-189:1 -/
 def update_array (x : Array U32 2#usize) : Result Unit :=
   do
-  let (_, index_mut_back) ← Array.index_mut_usize x 0#usize
-  let _ ← index_mut_back 1#u32
+  let _ ← Array.update_usize x 0#usize 1#u32
   Result.ok ()
 
 /- [arrays::update_array_mut_borrow]:
    Source: 'tests/src/arrays.rs', lines 190:0-192:1 -/
 def update_array_mut_borrow
   (x : Array U32 2#usize) : Result (Array U32 2#usize) :=
-  do
-  let (_, index_mut_back) ← Array.index_mut_usize x 0#usize
-  index_mut_back 1#u32
+  Array.update_usize x 0#usize 1#u32
 
 /- [arrays::update_mut_slice]:
    Source: 'tests/src/arrays.rs', lines 193:0-195:1 -/
 def update_mut_slice (x : Slice U32) : Result (Slice U32) :=
-  do
-  let (_, index_mut_back) ← Slice.index_mut_usize x 0#usize
-  index_mut_back 1#u32
+  Slice.update_usize x 0#usize 1#u32
 
 /- [arrays::update_all]:
    Source: 'tests/src/arrays.rs', lines 197:0-203:1 -/
@@ -304,8 +298,24 @@ def update_all : Result Unit :=
   let _ ← to_slice_mut_back s1
   Result.ok ()
 
+/- [arrays::incr_array]:
+   Source: 'tests/src/arrays.rs', lines 205:0-207:1 -/
+def incr_array (x : Array U32 2#usize) : Result (Array U32 2#usize) :=
+  do
+  let i ← Array.index_usize x 0#usize
+  let i1 ← i + 1#u32
+  Array.update_usize x 0#usize i1
+
+/- [arrays::incr_slice]:
+   Source: 'tests/src/arrays.rs', lines 209:0-211:1 -/
+def incr_slice (x : Slice U32) : Result (Slice U32) :=
+  do
+  let i ← Slice.index_usize x 0#usize
+  let i1 ← i + 1#u32
+  Slice.update_usize x 0#usize i1
+
 /- [arrays::range_all]:
-   Source: 'tests/src/arrays.rs', lines 208:0-212:1 -/
+   Source: 'tests/src/arrays.rs', lines 216:0-220:1 -/
 def range_all : Result Unit :=
   do
   let (s, index_mut_back) ←
@@ -318,12 +328,12 @@ def range_all : Result Unit :=
   Result.ok ()
 
 /- [arrays::deref_array_borrow]:
-   Source: 'tests/src/arrays.rs', lines 217:0-220:1 -/
+   Source: 'tests/src/arrays.rs', lines 225:0-228:1 -/
 def deref_array_borrow (x : Array U32 2#usize) : Result U32 :=
   Array.index_usize x 0#usize
 
 /- [arrays::deref_array_mut_borrow]:
-   Source: 'tests/src/arrays.rs', lines 222:0-225:1 -/
+   Source: 'tests/src/arrays.rs', lines 230:0-233:1 -/
 def deref_array_mut_borrow
   (x : Array U32 2#usize) : Result (U32 × (Array U32 2#usize)) :=
   do
@@ -331,17 +341,17 @@ def deref_array_mut_borrow
   Result.ok (i, x)
 
 /- [arrays::take_array_t]:
-   Source: 'tests/src/arrays.rs', lines 230:0-230:34 -/
+   Source: 'tests/src/arrays.rs', lines 238:0-238:34 -/
 def take_array_t (a : Array AB 2#usize) : Result Unit :=
   Result.ok ()
 
 /- [arrays::non_copyable_array]:
-   Source: 'tests/src/arrays.rs', lines 232:0-240:1 -/
+   Source: 'tests/src/arrays.rs', lines 240:0-248:1 -/
 def non_copyable_array : Result Unit :=
   take_array_t (Array.make 2#usize [ AB.A, AB.B ])
 
 /- [arrays::sum]: loop 0:
-   Source: 'tests/src/arrays.rs', lines 248:4-251:5 -/
+   Source: 'tests/src/arrays.rs', lines 256:4-259:5 -/
 divergent def sum_loop (s : Slice U32) (sum1 : U32) (i : Usize) : Result U32 :=
   let i1 := Slice.len s
   if i < i1
@@ -354,12 +364,12 @@ divergent def sum_loop (s : Slice U32) (sum1 : U32) (i : Usize) : Result U32 :=
   else Result.ok sum1
 
 /- [arrays::sum]:
-   Source: 'tests/src/arrays.rs', lines 245:0-253:1 -/
+   Source: 'tests/src/arrays.rs', lines 253:0-261:1 -/
 def sum (s : Slice U32) : Result U32 :=
   sum_loop s 0#u32 0#usize
 
 /- [arrays::sum2]: loop 0:
-   Source: 'tests/src/arrays.rs', lines 259:4-262:5 -/
+   Source: 'tests/src/arrays.rs', lines 267:4-270:5 -/
 divergent def sum2_loop
   (s : Slice U32) (s2 : Slice U32) (sum1 : U32) (i : Usize) : Result U32 :=
   let i1 := Slice.len s
@@ -375,7 +385,7 @@ divergent def sum2_loop
   else Result.ok sum1
 
 /- [arrays::sum2]:
-   Source: 'tests/src/arrays.rs', lines 255:0-264:1 -/
+   Source: 'tests/src/arrays.rs', lines 263:0-272:1 -/
 def sum2 (s : Slice U32) (s2 : Slice U32) : Result U32 :=
   let i := Slice.len s
   let i1 := Slice.len s2
@@ -384,39 +394,37 @@ def sum2 (s : Slice U32) (s2 : Slice U32) : Result U32 :=
   else Result.fail .panic
 
 /- [arrays::f0]:
-   Source: 'tests/src/arrays.rs', lines 266:0-269:1 -/
+   Source: 'tests/src/arrays.rs', lines 274:0-277:1 -/
 def f0 : Result Unit :=
   do
   let (s, to_slice_mut_back) ←
     Array.to_slice_mut (Array.make 2#usize [ 1#u32, 2#u32 ])
-  let (_, index_mut_back) ← Slice.index_mut_usize s 0#usize
-  let s1 ← index_mut_back 1#u32
+  let s1 ← Slice.update_usize s 0#usize 1#u32
   let _ ← to_slice_mut_back s1
   Result.ok ()
 
 /- [arrays::f1]:
-   Source: 'tests/src/arrays.rs', lines 271:0-274:1 -/
+   Source: 'tests/src/arrays.rs', lines 279:0-282:1 -/
 def f1 : Result Unit :=
   do
-  let (_, index_mut_back) ←
-    Array.index_mut_usize (Array.make 2#usize [ 1#u32, 2#u32 ]) 0#usize
-  let _ ← index_mut_back 1#u32
+  let _ ←
+    Array.update_usize (Array.make 2#usize [ 1#u32, 2#u32 ]) 0#usize 1#u32
   Result.ok ()
 
 /- [arrays::f2]:
-   Source: 'tests/src/arrays.rs', lines 276:0-276:20 -/
+   Source: 'tests/src/arrays.rs', lines 284:0-284:20 -/
 def f2 (i : U32) : Result Unit :=
   Result.ok ()
 
 /- [arrays::f4]:
-   Source: 'tests/src/arrays.rs', lines 285:0-287:1 -/
+   Source: 'tests/src/arrays.rs', lines 293:0-295:1 -/
 def f4 (x : Array U32 32#usize) (y : Usize) (z : Usize) : Result (Slice U32) :=
   core.array.Array.index (core.ops.index.IndexSliceTIInst
     (core.slice.index.SliceIndexRangeUsizeSliceTInst U32)) x
     { start := y, end_ := z }
 
 /- [arrays::f3]:
-   Source: 'tests/src/arrays.rs', lines 278:0-283:1 -/
+   Source: 'tests/src/arrays.rs', lines 286:0-291:1 -/
 def f3 : Result U32 :=
   do
   let i ← Array.index_usize (Array.make 2#usize [ 1#u32, 2#u32 ]) 0#usize
@@ -427,17 +435,17 @@ def f3 : Result U32 :=
   sum2 s s1
 
 /- [arrays::SZ]
-   Source: 'tests/src/arrays.rs', lines 289:0-289:25 -/
+   Source: 'tests/src/arrays.rs', lines 297:0-297:25 -/
 def SZ_body : Result Usize := Result.ok 32#usize
 def SZ : Usize := eval_global SZ_body
 
 /- [arrays::f5]:
-   Source: 'tests/src/arrays.rs', lines 292:0-294:1 -/
+   Source: 'tests/src/arrays.rs', lines 300:0-302:1 -/
 def f5 (x : Array U32 32#usize) : Result U32 :=
   Array.index_usize x 0#usize
 
 /- [arrays::ite]:
-   Source: 'tests/src/arrays.rs', lines 297:0-304:1 -/
+   Source: 'tests/src/arrays.rs', lines 305:0-312:1 -/
 def ite : Result Unit :=
   do
   let (s, to_slice_mut_back) ←
@@ -451,7 +459,7 @@ def ite : Result Unit :=
   Result.ok ()
 
 /- [arrays::zero_slice]: loop 0:
-   Source: 'tests/src/arrays.rs', lines 309:4-312:5 -/
+   Source: 'tests/src/arrays.rs', lines 317:4-320:5 -/
 divergent def zero_slice_loop
   (a : Slice U8) (i : Usize) (len : Usize) : Result (Slice U8) :=
   if i < len
@@ -464,13 +472,13 @@ divergent def zero_slice_loop
   else Result.ok a
 
 /- [arrays::zero_slice]:
-   Source: 'tests/src/arrays.rs', lines 306:0-313:1 -/
+   Source: 'tests/src/arrays.rs', lines 314:0-321:1 -/
 def zero_slice (a : Slice U8) : Result (Slice U8) :=
   let len := Slice.len a
   zero_slice_loop a 0#usize len
 
 /- [arrays::iter_mut_slice]: loop 0:
-   Source: 'tests/src/arrays.rs', lines 318:4-320:5 -/
+   Source: 'tests/src/arrays.rs', lines 326:4-328:5 -/
 divergent def iter_mut_slice_loop (len : Usize) (i : Usize) : Result Unit :=
   if i < len
   then do
@@ -479,7 +487,7 @@ divergent def iter_mut_slice_loop (len : Usize) (i : Usize) : Result Unit :=
   else Result.ok ()
 
 /- [arrays::iter_mut_slice]:
-   Source: 'tests/src/arrays.rs', lines 315:0-321:1 -/
+   Source: 'tests/src/arrays.rs', lines 323:0-329:1 -/
 def iter_mut_slice (a : Slice U8) : Result (Slice U8) :=
   do
   let len := Slice.len a
@@ -487,7 +495,7 @@ def iter_mut_slice (a : Slice U8) : Result (Slice U8) :=
   Result.ok a
 
 /- [arrays::sum_mut_slice]: loop 0:
-   Source: 'tests/src/arrays.rs', lines 326:4-329:5 -/
+   Source: 'tests/src/arrays.rs', lines 334:4-337:5 -/
 divergent def sum_mut_slice_loop
   (a : Slice U32) (i : Usize) (s : U32) : Result U32 :=
   let i1 := Slice.len a
@@ -501,7 +509,7 @@ divergent def sum_mut_slice_loop
   else Result.ok s
 
 /- [arrays::sum_mut_slice]:
-   Source: 'tests/src/arrays.rs', lines 323:0-331:1 -/
+   Source: 'tests/src/arrays.rs', lines 331:0-339:1 -/
 def sum_mut_slice (a : Slice U32) : Result (U32 × (Slice U32)) :=
   do
   let i ← sum_mut_slice_loop a 0#usize 0#u32

--- a/tests/lean/Bst/Funs.lean
+++ b/tests/lean/Bst/Funs.lean
@@ -55,7 +55,7 @@ divergent def TreeSet.insert_loop
         TreeSet.insert_loop OrdInst value current_node.right
       Result.ok (b, some (Node.mk current_node.value current_node.left
         current_tree1))
-    | Ordering.Equal => Result.ok (false, some current_node)
+    | Ordering.Equal => Result.ok (false, current_tree)
     | Ordering.Greater =>
       do
       let (b, current_tree1) ←

--- a/tests/lean/Hashmap/Properties.lean
+++ b/tests/lean/Hashmap/Properties.lean
@@ -943,10 +943,8 @@ theorem insert_spec {α} (hm : HashMap α) (key : Usize) (value : α)
   split
   . split
     . simp_all (config := {maxDischargeDepth := 1})
-      tauto
     . progress as ⟨ hm2 ⟩
       simp_all (config := {maxDischargeDepth := 1})
-      tauto
   . simp_all (config := {maxDischargeDepth := 1})
 
 @[pspec]

--- a/tests/lean/NoNestedBorrows.lean
+++ b/tests/lean/NoNestedBorrows.lean
@@ -408,7 +408,7 @@ def id_mut_pair2
   Result ((T1 × T2) × ((T1 × T2) → Result (T1 × T2)))
   :=
   let (t, t1) := p
-  Result.ok ((t, t1), Result.ok)
+  Result.ok (p, Result.ok)
 
 /- [no_nested_borrows::id_mut_pair3]:
    Source: 'tests/src/no_nested_borrows.rs', lines 355:0-357:1 -/
@@ -425,7 +425,7 @@ def id_mut_pair4
   Result ((T1 × T2) × (T1 → Result T1) × (T2 → Result T2))
   :=
   let (t, t1) := p
-  Result.ok ((t, t1), Result.ok, Result.ok)
+  Result.ok (p, Result.ok, Result.ok)
 
 /- [no_nested_borrows::StructWithTuple]
    Source: 'tests/src/no_nested_borrows.rs', lines 366:0-368:1 -/
@@ -605,5 +605,32 @@ def not_u32 (x : U32) : Result U32 :=
    Source: 'tests/src/no_nested_borrows.rs', lines 528:0-530:1 -/
 def not_i32 (x : I32) : Result I32 :=
   Result.ok (￢ x)
+
+/- [no_nested_borrows::ExpandSimpliy::Wrapper]
+   Source: 'tests/src/no_nested_borrows.rs', lines 534:4-534:32 -/
+def ExpandSimpliy.Wrapper (T : Type) := T × T
+
+/- [no_nested_borrows::ExpandSimpliy::check_expand_simplify_symb1]:
+   Source: 'tests/src/no_nested_borrows.rs', lines 536:4-542:5 -/
+def ExpandSimpliy.check_expand_simplify_symb1
+  (x : ExpandSimpliy.Wrapper Bool) : Result (ExpandSimpliy.Wrapper Bool) :=
+  let (b, b1) := x
+  if b
+  then Result.ok x
+  else Result.ok x
+
+/- [no_nested_borrows::ExpandSimpliy::Wrapper2]
+   Source: 'tests/src/no_nested_borrows.rs', lines 544:4-547:5 -/
+structure ExpandSimpliy.Wrapper2 where
+  b : Bool
+  x : U32
+
+/- [no_nested_borrows::ExpandSimpliy::check_expand_simplify_symb2]:
+   Source: 'tests/src/no_nested_borrows.rs', lines 549:4-555:5 -/
+def ExpandSimpliy.check_expand_simplify_symb2
+  (x : ExpandSimpliy.Wrapper2) : Result ExpandSimpliy.Wrapper2 :=
+  if x.b
+  then Result.ok x
+  else Result.ok x
 
 end no_nested_borrows

--- a/tests/lean/PoloniusList.lean
+++ b/tests/lean/PoloniusList.lean
@@ -23,7 +23,7 @@ divergent def get_list_at_x
   match ls with
   | List.Cons hd tl =>
     if hd = x
-    then Result.ok (List.Cons hd tl, Result.ok)
+    then Result.ok (ls, Result.ok)
     else
       do
       let (l, get_list_at_x_back) ← get_list_at_x tl x

--- a/tests/src/arrays.rs
+++ b/tests/src/arrays.rs
@@ -202,6 +202,14 @@ pub fn update_all() {
     update_mut_slice(&mut x);
 }
 
+pub fn incr_array(mut x: &mut [u32; 2]) {
+    x[0] += 1
+}
+
+pub fn incr_slice(mut x: &mut [u32]) {
+    x[0] += 1
+}
+
 // Nano-tests, with ranges
 // -----------------------
 

--- a/tests/src/mutually-recursive-traits.lean.out
+++ b/tests/src/mutually-recursive-traits.lean.out
@@ -14,4 +14,4 @@ Called from Stdlib__List.iter in file "list.ml", line 110, characters 12-15
 Called from Aeneas__Translate.extract_definitions in file "Translate.ml", line 874, characters 2-52
 Called from Aeneas__Translate.extract_file in file "Translate.ml", line 1001, characters 2-36
 Called from Aeneas__Translate.translate_crate in file "Translate.ml", line 1571, characters 5-42
-Called from Dune__exe__Main in file "Main.ml", line 317, characters 14-66
+Called from Dune__exe__Main in file "Main.ml", line 318, characters 14-66

--- a/tests/src/no_nested_borrows.rs
+++ b/tests/src/no_nested_borrows.rs
@@ -528,3 +528,29 @@ pub fn not_u32(x: u32) -> u32 {
 pub fn not_i32(x: i32) -> i32 {
     !x
 }
+
+// Testing the simplification of the ADT aggregates in the presence of symbolic expansions
+mod ExpandSimpliy {
+    pub struct Wrapper<T>(T, T);
+
+    pub fn check_expand_simplify_symb1(x: Wrapper<bool>) -> Wrapper<bool> {
+        if x.0 {
+            x
+        } else {
+            x
+        }
+    }
+
+    pub struct Wrapper2 {
+        b: bool,
+        x: u32,
+    }
+
+    pub fn check_expand_simplify_symb2(x: Wrapper2) -> Wrapper2 {
+        if x.b {
+            x
+        } else {
+            x
+        }
+    }
+}


### PR DESCRIPTION
# Arrays
Today, whenever we update an element in an array or a slice (e.g., `x[0] = 1`) we first create a mutable borrow to the element of the array, then use this borrow to update the element (e.g., `let tmp = &mut x[0]; *tmp = 1`). The output code looks like this:
```ocaml
let (_, back) = Array.index_mut a i in
let a' = back v in
...
```

I implemented a micro-pass so that the output code is actually:
```ocaml
let a' = Array.update a i v in
...
```

# Aggregated ADTs
Because of the way the symbolic execution works, we also often see patterns of the following shape in the generated code:
```lean
if x.field then { x with field = true }
else { x with field = false }
```
This PR implements a micro-pass to simplify this to:
```lean
if x.field then x
else x
```

This is very cosmetic but makes the generated code a lot cleaner and understandable in some cases.