### PR TITLE
Update the generation of the backward functions so that they don't fail

### DIFF
--- a/backends/lean/Base/Primitives/Alloc.lean
+++ b/backends/lean/Base/Primitives/Alloc.lean
@@ -12,7 +12,7 @@ namespace boxed -- alloc.boxed
 namespace Box -- alloc.boxed.Box
 
 def deref {T : Type} (x : T) : Result T := ok x
-def deref_mut {T : Type} (x : T) : Result (T × (T → Result T)) := ok (x, λ x => ok x)
+def deref_mut {T : Type} (x : T) : Result (T × (T → T)) := ok (x, λ x => x)
 
 /-- Trait instance -/
 def coreopsDerefInst (Self : Type) :

--- a/backends/lean/Base/Primitives/Core.lean
+++ b/backends/lean/Base/Primitives/Core.lean
@@ -22,7 +22,7 @@ structure Index (Self Idx : Type) where
 /- Trait declaration: [core::ops::index::IndexMut] -/
 structure IndexMut (Self Idx : Type) where
   indexInst : Index Self Idx
-  index_mut : Self → Idx → Result (indexInst.Output × (indexInst.Output → Result Self))
+  index_mut : Self → Idx → Result (indexInst.Output × (indexInst.Output → Self))
 
 end index -- core.ops.index
 
@@ -34,7 +34,7 @@ structure Deref (Self : Type) where
 
 structure DerefMut (Self : Type) where
   derefInst : Deref Self
-  deref_mut : Self → Result (derefInst.Target × (Self → Result Self))
+  deref_mut : Self → Result (derefInst.Target × (Self → Self))
 
 end deref -- core.ops.deref
 

--- a/backends/lean/Base/Primitives/Vec.lean
+++ b/backends/lean/Base/Primitives/Vec.lean
@@ -121,18 +121,30 @@ theorem Vec.update_usize_spec {α : Type u} (v: Vec α) (i: Usize) (x : α)
   . simp_all [length]; scalar_tac
   . simp_all
 
+def Vec.update {α : Type u} (v: Vec α) (i: Usize) (x: α) : Vec α :=
+  ⟨ v.val.update i.toNat x, by have := v.property; simp [*] ⟩
+
+@[simp]
+theorem Vec.update_val_eq {α : Type u} (v: Vec α) (i: Usize) (x: α) :
+  (v.update i x).val = v.val.update i.toNat x := by
+  simp [update]
+
+@[scalar_tac v.update i x]
+theorem Vec.update_length {α : Type u} (v: Vec α) (i: Usize) (x: α) :
+  (v.update i x).length = v.length := by simp
+
 def Vec.index_mut_usize {α : Type u} (v: Vec α) (i: Usize) :
-  Result (α × (α → Result (Vec α))) :=
+  Result (α × (α → Vec α)) :=
   match Vec.index_usize v i with
   | ok x =>
-    ok (x, Vec.update_usize v i)
+    ok (x, Vec.update v i)
   | fail e => fail e
   | div => div
 
 @[pspec]
 theorem Vec.index_mut_usize_spec {α : Type u} [Inhabited α] (v: Vec α) (i: Usize)
   (hbound : i.val < v.length) :
-  ∃ x, v.index_mut_usize i = ok (x, v.update_usize i) ∧
+  ∃ x, v.index_mut_usize i = ok (x, v.update i) ∧
   x = v.val.index i.toNat
   := by
   simp only [index_mut_usize]
@@ -147,7 +159,7 @@ def Vec.index {T I : Type} (inst : core.slice.index.SliceIndex I (Slice T))
 /- [alloc::vec::Vec::index_mut]: forward function -/
 def Vec.index_mut {T I : Type} (inst : core.slice.index.SliceIndex I (Slice T))
   (self : Vec T) (i : I) :
-  Result (inst.Output × (inst.Output → Result (Vec T))) :=
+  Result (inst.Output × (inst.Output → Vec T)) :=
   sorry -- TODO
 
 /- Trait implementation: [alloc::vec::Vec] -/
@@ -210,8 +222,8 @@ def core.ops.deref.DerefVec {T : Type} : core.ops.deref.Deref (alloc.vec.Vec T) 
    Source: '/rustc/d59363ad0b6391b7fc5bbb02c9ccf9300eef3753/library/alloc/src/vec/mod.rs', lines 2632:4-2632:39
    Name pattern: alloc::vec::{core::ops::deref::DerefMut<alloc::vec::Vec<@T, @A>>}::deref_mut -/
 def alloc.vec.DerefMutVec.deref_mut {T : Type} (v :  alloc.vec.Vec T) :
-   Result ((Slice T) × (Slice T → Result (alloc.vec.Vec T))) :=
-   ok (⟨ v.val, v.property ⟩, λ s => ok ⟨ s.val, s.property ⟩)
+   Result ((Slice T) × (Slice T → alloc.vec.Vec T)) :=
+   ok (⟨ v.val, v.property ⟩, λ s => ⟨ s.val, s.property ⟩)
 
 /- Trait implementation: [alloc::vec::{(core::ops::deref::DerefMut for alloc::vec::Vec<T, A>)#10}]
    Source: '/rustc/d59363ad0b6391b7fc5bbb02c9ccf9300eef3753/library/alloc/src/vec/mod.rs', lines 2630:0-2630:49

--- a/compiler/PrintPure.ml
+++ b/compiler/PrintPure.ml
@@ -498,15 +498,15 @@ let llbc_fun_id_to_string (env : fmt_env) (fid : A.fun_id) : string =
 
 let pure_assumed_fun_id_to_string (fid : pure_assumed_fun_id) : string =
   match fid with
-  | Return -> "return"
-  | Fail -> "fail"
-  | Assert -> "assert"
-  | FuelDecrease -> "fuel_decrease"
-  | FuelEqZero -> "fuel_eq_zero"
+  | Return -> "@return"
+  | Fail -> "@fail"
+  | Assert -> "@assert"
+  | FuelDecrease -> "@fuel_decrease"
+  | FuelEqZero -> "@fuel_eq_zero"
   | UpdateAtIndex array_or_slice -> begin
       match array_or_slice with
-      | Array -> "array_update"
-      | Slice -> "slice_update"
+      | Array -> "@ArrayUpdate"
+      | Slice -> "@SliceUpdate"
     end
 
 let regular_fun_id_to_string (env : fmt_env) (fun_id : fun_id) : string =

--- a/compiler/PureMicroPasses.ml
+++ b/compiler/PureMicroPasses.ml
@@ -1941,10 +1941,10 @@ let simplify_array_slice_update (_ctx : trans_ctx) (def : fun_decl) : fun_decl =
               | App (app, back_v) when is_call_to_back app ->
                   (super#visit_texpression env (mk_call_to_update back_v)).e
               (* let a' = back x in ... *)
-              | Let (monadic', pat', { e = App (app, back_v); _ }, e3)
+              | Let (_, pat', { e = App (app, back_v); _ }, e3)
                 when is_call_to_back app ->
                   super#visit_expression env
-                    (Let (monadic', pat', mk_call_to_update back_v, e3))
+                    (Let (true, pat', mk_call_to_update back_v, e3))
               | _ -> super#visit_Let env monadic pat e1 e2
             end
         | _ -> super#visit_Let env monadic pat e1 e2

--- a/tests/coq/misc/External_Funs.v
+++ b/tests/coq/misc/External_Funs.v
@@ -36,8 +36,7 @@ Definition incr
   let (st1, p1) := p in
   let (i, get_mut_back) := p1 in
   i1 <- u32_add i 1%u32;
-  p2 <- get_mut_back i1 st1;
-  let (_, rc1) := p2 in
+  let (_, rc1) := get_mut_back i1 st1 in
   Ok (st1, rc1)
 .
 

--- a/tests/coq/misc/External_FunsExternal.v
+++ b/tests/coq/misc/External_FunsExternal.v
@@ -17,7 +17,7 @@ Axiom core_cell_Cell_get :
 Axiom core_cell_Cell_get_mut :
   forall{T : Type},
         core_cell_Cell_t T -> state -> result (state * (T * (T -> state ->
-          result (state * (core_cell_Cell_t T)))))
+          state * (core_cell_Cell_t T))))
 .
 
 End External_FunsExternal.

--- a/tests/coq/misc/External_FunsExternal_Template.v
+++ b/tests/coq/misc/External_FunsExternal_Template.v
@@ -25,7 +25,7 @@ Axiom core_cell_Cell_get :
 Axiom core_cell_Cell_get_mut :
   forall{T : Type},
         core_cell_Cell_t T -> state -> result (state * (T * (T -> state ->
-          result (state * (core_cell_Cell_t T)))))
+          (state * (core_cell_Cell_t T)))))
 .
 
 (** [core::clone::Clone::clone_from]:

--- a/tests/coq/misc/Paper.v
+++ b/tests/coq/misc/Paper.v
@@ -25,10 +25,10 @@ Check (test_incr)%return.
 (** [paper::choose]:
     Source: 'tests/src/paper.rs', lines 18:0-24:1 *)
 Definition choose
-  {T : Type} (b : bool) (x : T) (y : T) : result (T * (T -> result (T * T))) :=
+  {T : Type} (b : bool) (x : T) (y : T) : result (T * (T -> (T * T))) :=
   if b
-  then let back := fun (ret : T) => Ok (ret, y) in Ok (x, back)
-  else let back := fun (ret : T) => Ok (x, ret) in Ok (y, back)
+  then let back := fun (ret : T) => (ret, y) in Ok (x, back)
+  else let back := fun (ret : T) => (x, ret) in Ok (y, back)
 .
 
 (** [paper::test_choose]:
@@ -38,12 +38,11 @@ Definition test_choose : result unit :=
   let (z, choose_back) := p in
   z1 <- i32_add z 1%i32;
   if z1 s= 1%i32
-  then (
-    p1 <- choose_back z1;
-    let (x, y) := p1 in
+  then
+    let (x, y) := choose_back z1 in
     if x s= 1%i32
     then if y s= 0%i32 then Ok tt else Fail_ Failure
-    else Fail_ Failure)
+    else Fail_ Failure
   else Fail_ Failure
 .
 
@@ -63,19 +62,17 @@ Arguments List_Nil { _ }.
 (** [paper::list_nth_mut]:
     Source: 'tests/src/paper.rs', lines 45:0-58:1 *)
 Fixpoint list_nth_mut
-  {T : Type} (l : List_t T) (i : u32) :
-  result (T * (T -> result (List_t T)))
-  :=
+  {T : Type} (l : List_t T) (i : u32) : result (T * (T -> List_t T)) :=
   match l with
   | List_Cons x tl =>
     if i s= 0%u32
-    then let back := fun (ret : T) => Ok (List_Cons ret tl) in Ok (x, back)
+    then let back := fun (ret : T) => List_Cons ret tl in Ok (x, back)
     else (
       i1 <- u32_sub i 1%u32;
       p <- list_nth_mut tl i1;
       let (t, list_nth_mut_back) := p in
       let back :=
-        fun (ret : T) => tl1 <- list_nth_mut_back ret; Ok (List_Cons x tl1) in
+        fun (ret : T) => let tl1 := list_nth_mut_back ret in List_Cons x tl1 in
       Ok (t, back))
   | List_Nil => Fail_ Failure
   end
@@ -98,7 +95,7 @@ Definition test_nth : result unit :=
   p <- list_nth_mut (List_Cons 1%i32 l1) 2%u32;
   let (x, list_nth_mut_back) := p in
   x1 <- i32_add x 1%i32;
-  l2 <- list_nth_mut_back x1;
+  let l2 := list_nth_mut_back x1 in
   i <- sum l2;
   if i s= 7%i32 then Ok tt else Fail_ Failure
 .
@@ -113,8 +110,7 @@ Definition call_choose (p : (u32 * u32)) : result u32 :=
   p1 <- choose true px py;
   let (pz, choose_back) := p1 in
   pz1 <- u32_add pz 1%u32;
-  p2 <- choose_back pz1;
-  let (px1, _) := p2 in
+  let (px1, _) := choose_back pz1 in
   Ok px1
 .
 

--- a/tests/coq/misc/PoloniusList.v
+++ b/tests/coq/misc/PoloniusList.v
@@ -22,20 +22,21 @@ Arguments List_Nil { _ }.
     Source: 'tests/src/polonius_list.rs', lines 16:0-30:1 *)
 Fixpoint get_list_at_x
   (ls : List_t u32) (x : u32) :
-  result ((List_t u32) * (List_t u32 -> result (List_t u32)))
+  result ((List_t u32) * (List_t u32 -> List_t u32))
   :=
   match ls with
   | List_Cons hd tl =>
     if hd s= x
-    then Ok (ls, Ok)
+    then let back := fun (ret : List_t u32) => ret in Ok (ls, back)
     else (
       p <- get_list_at_x tl x;
       let (l, get_list_at_x_back) := p in
       let back :=
         fun (ret : List_t u32) =>
-          tl1 <- get_list_at_x_back ret; Ok (List_Cons hd tl1) in
+          let tl1 := get_list_at_x_back ret in List_Cons hd tl1 in
       Ok (l, back))
-  | List_Nil => Ok (List_Nil, Ok)
+  | List_Nil =>
+    let back := fun (ret : List_t u32) => ret in Ok (List_Nil, back)
   end
 .
 

--- a/tests/fstar/demo/Demo.fst
+++ b/tests/fstar/demo/Demo.fst
@@ -8,12 +8,10 @@ open Primitives
 (** [demo::choose]:
     Source: 'tests/src/demo.rs', lines 7:0-13:1 *)
 let choose
-  (#t : Type0) (b : bool) (x : t) (y : t) :
-  result (t & (t -> result (t & t)))
-  =
+  (#t : Type0) (b : bool) (x : t) (y : t) : result (t & (t -> (t & t))) =
   if b
-  then let back = fun ret -> Ok (ret, y) in Ok (x, back)
-  else let back = fun ret -> Ok (x, ret) in Ok (y, back)
+  then let back = fun ret -> (ret, y) in Ok (x, back)
+  else let back = fun ret -> (x, ret) in Ok (y, back)
 
 (** [demo::mul2_add1]:
     Source: 'tests/src/demo.rs', lines 15:0-17:1 *)
@@ -77,7 +75,7 @@ let list_nth1 (#t : Type0) (n : nat) (l : cList_t t) (i : u32) : result t =
     Source: 'tests/src/demo.rs', lines 67:0-80:1 *)
 let rec list_nth_mut
   (#t : Type0) (n : nat) (l : cList_t t) (i : u32) :
-  result (t & (t -> result (cList_t t)))
+  result (t & (t -> cList_t t))
   =
   if is_zero n
   then Fail OutOfFuel
@@ -86,13 +84,12 @@ let rec list_nth_mut
     begin match l with
     | CList_CCons x tl ->
       if i = 0
-      then let back = fun ret -> Ok (CList_CCons ret tl) in Ok (x, back)
+      then let back = fun ret -> CList_CCons ret tl in Ok (x, back)
       else
         let* i1 = u32_sub i 1 in
         let* (x1, list_nth_mut_back) = list_nth_mut n1 tl i1 in
         let back =
-          fun ret -> let* tl1 = list_nth_mut_back ret in Ok (CList_CCons x tl1)
-          in
+          fun ret -> let tl1 = list_nth_mut_back ret in CList_CCons x tl1 in
         Ok (x1, back)
     | CList_CNil -> Fail Failure
     end
@@ -112,7 +109,7 @@ let rec i32_id (n : nat) (i : i32) : result i32 =
     Source: 'tests/src/demo.rs', lines 90:0-95:1 *)
 let rec list_tail
   (#t : Type0) (n : nat) (l : cList_t t) :
-  result ((cList_t t) & (cList_t t -> result (cList_t t)))
+  result ((cList_t t) & (cList_t t -> cList_t t))
   =
   if is_zero n
   then Fail OutOfFuel
@@ -121,10 +118,10 @@ let rec list_tail
     begin match l with
     | CList_CCons x tl ->
       let* (c, list_tail_back) = list_tail n1 tl in
-      let back =
-        fun ret -> let* tl1 = list_tail_back ret in Ok (CList_CCons x tl1) in
+      let back = fun ret -> let tl1 = list_tail_back ret in CList_CCons x tl1
+        in
       Ok (c, back)
-    | CList_CNil -> Ok (CList_CNil, Ok)
+    | CList_CNil -> let back = fun ret -> ret in Ok (CList_CNil, back)
     end
 
 (** Trait declaration: [demo::Counter]

--- a/tests/fstar/misc/External.Funs.fst
+++ b/tests/fstar/misc/External.Funs.fst
@@ -27,6 +27,6 @@ let incr
   =
   let* (st1, (i, get_mut_back)) = core_cell_Cell_get_mut rc st in
   let* i1 = u32_add i 1 in
-  let* (_, rc1) = get_mut_back i1 st1 in
+  let (_, rc1) = get_mut_back i1 st1 in
   Ok (st1, rc1)
 

--- a/tests/fstar/misc/External.FunsExternal.fsti
+++ b/tests/fstar/misc/External.FunsExternal.fsti
@@ -18,8 +18,8 @@ val core_cell_Cell_get
     Name pattern: core::cell::{core::cell::Cell<@T>}::get_mut *)
 val core_cell_Cell_get_mut
   (#t : Type0) :
-  core_cell_Cell_t t -> state -> result (state & (t & (t -> state -> result
-    (state & (core_cell_Cell_t t)))))
+  core_cell_Cell_t t -> state -> result (state & (t & (t -> state -> (state &
+    (core_cell_Cell_t t)))))
 
 (** [core::clone::Clone::clone_from]:
     Source: '/rustc/library/core/src/clone.rs', lines 174:4-174:43

--- a/tests/fstar/misc/Loops.Funs.fst
+++ b/tests/fstar/misc/Loops.Funs.fst
@@ -90,7 +90,7 @@ let rec clear_loop
       alloc_vec_Vec_index_mut (core_slice_index_SliceIndexUsizeSliceTInst u32)
         v i in
     let* i2 = usize_add i 1 in
-    let* v1 = index_mut_back 0 in
+    let v1 = index_mut_back 0 in
     clear_loop v1 i2
   else Ok v
 
@@ -119,17 +119,17 @@ let list_mem (x : u32) (ls : list_t u32) : result bool =
     Source: 'tests/src/loops.rs', lines 93:4-102:1 *)
 let rec list_nth_mut_loop_loop
   (#t : Type0) (ls : list_t t) (i : u32) :
-  Tot (result (t & (t -> result (list_t t))))
+  Tot (result (t & (t -> list_t t)))
   (decreases (list_nth_mut_loop_loop_decreases ls i))
   =
   begin match ls with
   | List_Cons x tl ->
     if i = 0
-    then let back = fun ret -> Ok (List_Cons ret tl) in Ok (x, back)
+    then let back = fun ret -> List_Cons ret tl in Ok (x, back)
     else
       let* i1 = u32_sub i 1 in
       let* (x1, back) = list_nth_mut_loop_loop tl i1 in
-      let back1 = fun ret -> let* tl1 = back ret in Ok (List_Cons x tl1) in
+      let back1 = fun ret -> let tl1 = back ret in List_Cons x tl1 in
       Ok (x1, back1)
   | List_Nil -> Fail Failure
   end
@@ -137,9 +137,7 @@ let rec list_nth_mut_loop_loop
 (** [loops::list_nth_mut_loop]:
     Source: 'tests/src/loops.rs', lines 92:0-102:1 *)
 let list_nth_mut_loop
-  (#t : Type0) (ls : list_t t) (i : u32) :
-  result (t & (t -> result (list_t t)))
-  =
+  (#t : Type0) (ls : list_t t) (i : u32) : result (t & (t -> list_t t)) =
   list_nth_mut_loop_loop ls i
 
 (** [loops::list_nth_shared_loop]: loop 0:
@@ -165,16 +163,16 @@ let list_nth_shared_loop (#t : Type0) (ls : list_t t) (i : u32) : result t =
     Source: 'tests/src/loops.rs', lines 119:4-131:1 *)
 let rec get_elem_mut_loop
   (x : usize) (ls : list_t usize) :
-  Tot (result (usize & (usize -> result (list_t usize))))
+  Tot (result (usize & (usize -> list_t usize)))
   (decreases (get_elem_mut_loop_decreases x ls))
   =
   begin match ls with
   | List_Cons y tl ->
     if y = x
-    then let back = fun ret -> Ok (List_Cons ret tl) in Ok (y, back)
+    then let back = fun ret -> List_Cons ret tl in Ok (y, back)
     else
       let* (i, back) = get_elem_mut_loop x tl in
-      let back1 = fun ret -> let* tl1 = back ret in Ok (List_Cons y tl1) in
+      let back1 = fun ret -> let tl1 = back ret in List_Cons y tl1 in
       Ok (i, back1)
   | List_Nil -> Fail Failure
   end
@@ -183,13 +181,13 @@ let rec get_elem_mut_loop
     Source: 'tests/src/loops.rs', lines 117:0-131:1 *)
 let get_elem_mut
   (slots : alloc_vec_Vec (list_t usize)) (x : usize) :
-  result (usize & (usize -> result (alloc_vec_Vec (list_t usize))))
+  result (usize & (usize -> alloc_vec_Vec (list_t usize)))
   =
   let* (ls, index_mut_back) =
     alloc_vec_Vec_index_mut (core_slice_index_SliceIndexUsizeSliceTInst (list_t
       usize)) slots 0 in
   let* (i, back) = get_elem_mut_loop x ls in
-  let back1 = fun ret -> let* l = back ret in index_mut_back l in
+  let back1 = fun ret -> let l = back ret in index_mut_back l in
   Ok (i, back1)
 
 (** [loops::get_elem_shared]: loop 0:
@@ -215,10 +213,8 @@ let get_elem_shared
 (** [loops::id_mut]:
     Source: 'tests/src/loops.rs', lines 149:0-151:1 *)
 let id_mut
-  (#t : Type0) (ls : list_t t) :
-  result ((list_t t) & (list_t t -> result (list_t t)))
-  =
-  Ok (ls, Ok)
+  (#t : Type0) (ls : list_t t) : result ((list_t t) & (list_t t -> list_t t)) =
+  let back = fun ret -> ret in Ok (ls, back)
 
 (** [loops::id_shared]:
     Source: 'tests/src/loops.rs', lines 153:0-155:1 *)
@@ -229,17 +225,17 @@ let id_shared (#t : Type0) (ls : list_t t) : result (list_t t) =
     Source: 'tests/src/loops.rs', lines 160:4-169:1 *)
 let rec list_nth_mut_loop_with_id_loop
   (#t : Type0) (i : u32) (ls : list_t t) :
-  Tot (result (t & (t -> result (list_t t))))
+  Tot (result (t & (t -> list_t t)))
   (decreases (list_nth_mut_loop_with_id_loop_decreases i ls))
   =
   begin match ls with
   | List_Cons x tl ->
     if i = 0
-    then let back = fun ret -> Ok (List_Cons ret tl) in Ok (x, back)
+    then let back = fun ret -> List_Cons ret tl in Ok (x, back)
     else
       let* i1 = u32_sub i 1 in
       let* (x1, back) = list_nth_mut_loop_with_id_loop i1 tl in
-      let back1 = fun ret -> let* tl1 = back ret in Ok (List_Cons x tl1) in
+      let back1 = fun ret -> let tl1 = back ret in List_Cons x tl1 in
       Ok (x1, back1)
   | List_Nil -> Fail Failure
   end
@@ -247,12 +243,10 @@ let rec list_nth_mut_loop_with_id_loop
 (** [loops::list_nth_mut_loop_with_id]:
     Source: 'tests/src/loops.rs', lines 158:0-169:1 *)
 let list_nth_mut_loop_with_id
-  (#t : Type0) (ls : list_t t) (i : u32) :
-  result (t & (t -> result (list_t t)))
-  =
+  (#t : Type0) (ls : list_t t) (i : u32) : result (t & (t -> list_t t)) =
   let* (ls1, id_mut_back) = id_mut ls in
   let* (x, back) = list_nth_mut_loop_with_id_loop i ls1 in
-  let back1 = fun ret -> let* l = back ret in id_mut_back l in
+  let back1 = fun ret -> let l = back ret in id_mut_back l in
   Ok (x, back1)
 
 (** [loops::list_nth_shared_loop_with_id]: loop 0:
@@ -279,7 +273,7 @@ let list_nth_shared_loop_with_id
     Source: 'tests/src/loops.rs', lines 194:8-194:24 *)
 let rec list_nth_mut_loop_pair_loop
   (#t : Type0) (ls0 : list_t t) (ls1 : list_t t) (i : u32) :
-  Tot (result ((t & t) & (t -> result (list_t t)) & (t -> result (list_t t))))
+  Tot (result ((t & t) & (t -> list_t t) & (t -> list_t t)))
   (decreases (list_nth_mut_loop_pair_loop_decreases ls0 ls1 i))
   =
   begin match ls0 with
@@ -288,16 +282,14 @@ let rec list_nth_mut_loop_pair_loop
     | List_Cons x1 tl1 ->
       if i = 0
       then
-        let back'a = fun ret -> Ok (List_Cons ret tl0) in
-        let back'b = fun ret -> Ok (List_Cons ret tl1) in
+        let back'a = fun ret -> List_Cons ret tl0 in
+        let back'b = fun ret -> List_Cons ret tl1 in
         Ok ((x0, x1), back'a, back'b)
       else
         let* i1 = u32_sub i 1 in
         let* (p, back'a, back'b) = list_nth_mut_loop_pair_loop tl0 tl1 i1 in
-        let back'a1 =
-          fun ret -> let* tl01 = back'a ret in Ok (List_Cons x0 tl01) in
-        let back'b1 =
-          fun ret -> let* tl11 = back'b ret in Ok (List_Cons x1 tl11) in
+        let back'a1 = fun ret -> let tl01 = back'a ret in List_Cons x0 tl01 in
+        let back'b1 = fun ret -> let tl11 = back'b ret in List_Cons x1 tl11 in
         Ok (p, back'a1, back'b1)
     | List_Nil -> Fail Failure
     end
@@ -308,7 +300,7 @@ let rec list_nth_mut_loop_pair_loop
     Source: 'tests/src/loops.rs', lines 188:0-209:1 *)
 let list_nth_mut_loop_pair
   (#t : Type0) (ls0 : list_t t) (ls1 : list_t t) (i : u32) :
-  result ((t & t) & (t -> result (list_t t)) & (t -> result (list_t t)))
+  result ((t & t) & (t -> list_t t) & (t -> list_t t))
   =
   list_nth_mut_loop_pair_loop ls0 ls1 i
 
@@ -341,7 +333,7 @@ let list_nth_shared_loop_pair
     Source: 'tests/src/loops.rs', lines 242:4-252:1 *)
 let rec list_nth_mut_loop_pair_merge_loop
   (#t : Type0) (ls0 : list_t t) (ls1 : list_t t) (i : u32) :
-  Tot (result ((t & t) & ((t & t) -> result ((list_t t) & (list_t t)))))
+  Tot (result ((t & t) & ((t & t) -> ((list_t t) & (list_t t)))))
   (decreases (list_nth_mut_loop_pair_merge_loop_decreases ls0 ls1 i))
   =
   begin match ls0 with
@@ -351,16 +343,16 @@ let rec list_nth_mut_loop_pair_merge_loop
       if i = 0
       then
         let back =
-          fun ret ->
-            let (x, x2) = ret in Ok (List_Cons x tl0, List_Cons x2 tl1) in
+          fun ret -> let (x, x2) = ret in (List_Cons x tl0, List_Cons x2 tl1)
+          in
         Ok ((x0, x1), back)
       else
         let* i1 = u32_sub i 1 in
         let* (p, back) = list_nth_mut_loop_pair_merge_loop tl0 tl1 i1 in
         let back1 =
           fun ret ->
-            let* (tl01, tl11) = back ret in
-            Ok (List_Cons x0 tl01, List_Cons x1 tl11) in
+            let (tl01, tl11) = back ret in
+            (List_Cons x0 tl01, List_Cons x1 tl11) in
         Ok (p, back1)
     | List_Nil -> Fail Failure
     end
@@ -371,7 +363,7 @@ let rec list_nth_mut_loop_pair_merge_loop
     Source: 'tests/src/loops.rs', lines 237:0-252:1 *)
 let list_nth_mut_loop_pair_merge
   (#t : Type0) (ls0 : list_t t) (ls1 : list_t t) (i : u32) :
-  result ((t & t) & ((t & t) -> result ((list_t t) & (list_t t))))
+  result ((t & t) & ((t & t) -> ((list_t t) & (list_t t))))
   =
   list_nth_mut_loop_pair_merge_loop ls0 ls1 i
 
@@ -406,7 +398,7 @@ let list_nth_shared_loop_pair_merge
     Source: 'tests/src/loops.rs', lines 278:4-288:1 *)
 let rec list_nth_mut_shared_loop_pair_loop
   (#t : Type0) (ls0 : list_t t) (ls1 : list_t t) (i : u32) :
-  Tot (result ((t & t) & (t -> result (list_t t))))
+  Tot (result ((t & t) & (t -> list_t t)))
   (decreases (list_nth_mut_shared_loop_pair_loop_decreases ls0 ls1 i))
   =
   begin match ls0 with
@@ -414,12 +406,11 @@ let rec list_nth_mut_shared_loop_pair_loop
     begin match ls1 with
     | List_Cons x1 tl1 ->
       if i = 0
-      then let back = fun ret -> Ok (List_Cons ret tl0) in Ok ((x0, x1), back)
+      then let back = fun ret -> List_Cons ret tl0 in Ok ((x0, x1), back)
       else
         let* i1 = u32_sub i 1 in
         let* (p, back) = list_nth_mut_shared_loop_pair_loop tl0 tl1 i1 in
-        let back1 = fun ret -> let* tl01 = back ret in Ok (List_Cons x0 tl01)
-          in
+        let back1 = fun ret -> let tl01 = back ret in List_Cons x0 tl01 in
         Ok (p, back1)
     | List_Nil -> Fail Failure
     end
@@ -430,7 +421,7 @@ let rec list_nth_mut_shared_loop_pair_loop
     Source: 'tests/src/loops.rs', lines 273:0-288:1 *)
 let list_nth_mut_shared_loop_pair
   (#t : Type0) (ls0 : list_t t) (ls1 : list_t t) (i : u32) :
-  result ((t & t) & (t -> result (list_t t)))
+  result ((t & t) & (t -> list_t t))
   =
   list_nth_mut_shared_loop_pair_loop ls0 ls1 i
 
@@ -438,7 +429,7 @@ let list_nth_mut_shared_loop_pair
     Source: 'tests/src/loops.rs', lines 297:4-307:1 *)
 let rec list_nth_mut_shared_loop_pair_merge_loop
   (#t : Type0) (ls0 : list_t t) (ls1 : list_t t) (i : u32) :
-  Tot (result ((t & t) & (t -> result (list_t t))))
+  Tot (result ((t & t) & (t -> list_t t)))
   (decreases (list_nth_mut_shared_loop_pair_merge_loop_decreases ls0 ls1 i))
   =
   begin match ls0 with
@@ -446,12 +437,11 @@ let rec list_nth_mut_shared_loop_pair_merge_loop
     begin match ls1 with
     | List_Cons x1 tl1 ->
       if i = 0
-      then let back = fun ret -> Ok (List_Cons ret tl0) in Ok ((x0, x1), back)
+      then let back = fun ret -> List_Cons ret tl0 in Ok ((x0, x1), back)
       else
         let* i1 = u32_sub i 1 in
         let* (p, back) = list_nth_mut_shared_loop_pair_merge_loop tl0 tl1 i1 in
-        let back1 = fun ret -> let* tl01 = back ret in Ok (List_Cons x0 tl01)
-          in
+        let back1 = fun ret -> let tl01 = back ret in List_Cons x0 tl01 in
         Ok (p, back1)
     | List_Nil -> Fail Failure
     end
@@ -462,7 +452,7 @@ let rec list_nth_mut_shared_loop_pair_merge_loop
     Source: 'tests/src/loops.rs', lines 292:0-307:1 *)
 let list_nth_mut_shared_loop_pair_merge
   (#t : Type0) (ls0 : list_t t) (ls1 : list_t t) (i : u32) :
-  result ((t & t) & (t -> result (list_t t)))
+  result ((t & t) & (t -> list_t t))
   =
   list_nth_mut_shared_loop_pair_merge_loop ls0 ls1 i
 
@@ -470,7 +460,7 @@ let list_nth_mut_shared_loop_pair_merge
     Source: 'tests/src/loops.rs', lines 316:4-326:1 *)
 let rec list_nth_shared_mut_loop_pair_loop
   (#t : Type0) (ls0 : list_t t) (ls1 : list_t t) (i : u32) :
-  Tot (result ((t & t) & (t -> result (list_t t))))
+  Tot (result ((t & t) & (t -> list_t t)))
   (decreases (list_nth_shared_mut_loop_pair_loop_decreases ls0 ls1 i))
   =
   begin match ls0 with
@@ -478,12 +468,11 @@ let rec list_nth_shared_mut_loop_pair_loop
     begin match ls1 with
     | List_Cons x1 tl1 ->
       if i = 0
-      then let back = fun ret -> Ok (List_Cons ret tl1) in Ok ((x0, x1), back)
+      then let back = fun ret -> List_Cons ret tl1 in Ok ((x0, x1), back)
       else
         let* i1 = u32_sub i 1 in
         let* (p, back) = list_nth_shared_mut_loop_pair_loop tl0 tl1 i1 in
-        let back1 = fun ret -> let* tl11 = back ret in Ok (List_Cons x1 tl11)
-          in
+        let back1 = fun ret -> let tl11 = back ret in List_Cons x1 tl11 in
         Ok (p, back1)
     | List_Nil -> Fail Failure
     end
@@ -494,7 +483,7 @@ let rec list_nth_shared_mut_loop_pair_loop
     Source: 'tests/src/loops.rs', lines 311:0-326:1 *)
 let list_nth_shared_mut_loop_pair
   (#t : Type0) (ls0 : list_t t) (ls1 : list_t t) (i : u32) :
-  result ((t & t) & (t -> result (list_t t)))
+  result ((t & t) & (t -> list_t t))
   =
   list_nth_shared_mut_loop_pair_loop ls0 ls1 i
 
@@ -502,7 +491,7 @@ let list_nth_shared_mut_loop_pair
     Source: 'tests/src/loops.rs', lines 335:4-345:1 *)
 let rec list_nth_shared_mut_loop_pair_merge_loop
   (#t : Type0) (ls0 : list_t t) (ls1 : list_t t) (i : u32) :
-  Tot (result ((t & t) & (t -> result (list_t t))))
+  Tot (result ((t & t) & (t -> list_t t)))
   (decreases (list_nth_shared_mut_loop_pair_merge_loop_decreases ls0 ls1 i))
   =
   begin match ls0 with
@@ -510,12 +499,11 @@ let rec list_nth_shared_mut_loop_pair_merge_loop
     begin match ls1 with
     | List_Cons x1 tl1 ->
       if i = 0
-      then let back = fun ret -> Ok (List_Cons ret tl1) in Ok ((x0, x1), back)
+      then let back = fun ret -> List_Cons ret tl1 in Ok ((x0, x1), back)
       else
         let* i1 = u32_sub i 1 in
         let* (p, back) = list_nth_shared_mut_loop_pair_merge_loop tl0 tl1 i1 in
-        let back1 = fun ret -> let* tl11 = back ret in Ok (List_Cons x1 tl11)
-          in
+        let back1 = fun ret -> let tl11 = back ret in List_Cons x1 tl11 in
         Ok (p, back1)
     | List_Nil -> Fail Failure
     end
@@ -526,7 +514,7 @@ let rec list_nth_shared_mut_loop_pair_merge_loop
     Source: 'tests/src/loops.rs', lines 330:0-345:1 *)
 let list_nth_shared_mut_loop_pair_merge
   (#t : Type0) (ls0 : list_t t) (ls1 : list_t t) (i : u32) :
-  result ((t & t) & (t -> result (list_t t)))
+  result ((t & t) & (t -> list_t t))
   =
   list_nth_shared_mut_loop_pair_merge_loop ls0 ls1 i
 

--- a/tests/fstar/misc/Paper.fst
+++ b/tests/fstar/misc/Paper.fst
@@ -21,12 +21,10 @@ let _ = assert_norm (test_incr = Ok ())
 (** [paper::choose]:
     Source: 'tests/src/paper.rs', lines 18:0-24:1 *)
 let choose
-  (#t : Type0) (b : bool) (x : t) (y : t) :
-  result (t & (t -> result (t & t)))
-  =
+  (#t : Type0) (b : bool) (x : t) (y : t) : result (t & (t -> (t & t))) =
   if b
-  then let back = fun ret -> Ok (ret, y) in Ok (x, back)
-  else let back = fun ret -> Ok (x, ret) in Ok (y, back)
+  then let back = fun ret -> (ret, y) in Ok (x, back)
+  else let back = fun ret -> (x, ret) in Ok (y, back)
 
 (** [paper::test_choose]:
     Source: 'tests/src/paper.rs', lines 26:0-34:1 *)
@@ -35,7 +33,7 @@ let test_choose : result unit =
   let* z1 = i32_add z 1 in
   if z1 = 1
   then
-    let* (x, y) = choose_back z1 in
+    let (x, y) = choose_back z1 in
     if x = 1 then if y = 0 then Ok () else Fail Failure else Fail Failure
   else Fail Failure
 
@@ -51,18 +49,16 @@ type list_t (t : Type0) =
 (** [paper::list_nth_mut]:
     Source: 'tests/src/paper.rs', lines 45:0-58:1 *)
 let rec list_nth_mut
-  (#t : Type0) (l : list_t t) (i : u32) :
-  result (t & (t -> result (list_t t)))
-  =
+  (#t : Type0) (l : list_t t) (i : u32) : result (t & (t -> list_t t)) =
   begin match l with
   | List_Cons x tl ->
     if i = 0
-    then let back = fun ret -> Ok (List_Cons ret tl) in Ok (x, back)
+    then let back = fun ret -> List_Cons ret tl in Ok (x, back)
     else
       let* i1 = u32_sub i 1 in
       let* (x1, list_nth_mut_back) = list_nth_mut tl i1 in
-      let back =
-        fun ret -> let* tl1 = list_nth_mut_back ret in Ok (List_Cons x tl1) in
+      let back = fun ret -> let tl1 = list_nth_mut_back ret in List_Cons x tl1
+        in
       Ok (x1, back)
   | List_Nil -> Fail Failure
   end
@@ -82,7 +78,7 @@ let test_nth : result unit =
   let l1 = List_Cons 2 l in
   let* (x, list_nth_mut_back) = list_nth_mut (List_Cons 1 l1) 2 in
   let* x1 = i32_add x 1 in
-  let* l2 = list_nth_mut_back x1 in
+  let l2 = list_nth_mut_back x1 in
   let* i = sum l2 in
   if i = 7 then Ok () else Fail Failure
 
@@ -95,6 +91,6 @@ let call_choose (p : (u32 & u32)) : result u32 =
   let (px, py) = p in
   let* (pz, choose_back) = choose true px py in
   let* pz1 = u32_add pz 1 in
-  let* (px1, _) = choose_back pz1 in
+  let (px1, _) = choose_back pz1 in
   Ok px1
 

--- a/tests/fstar/misc/PoloniusList.fst
+++ b/tests/fstar/misc/PoloniusList.fst
@@ -15,18 +15,17 @@ type list_t (t : Type0) =
     Source: 'tests/src/polonius_list.rs', lines 16:0-30:1 *)
 let rec get_list_at_x
   (ls : list_t u32) (x : u32) :
-  result ((list_t u32) & (list_t u32 -> result (list_t u32)))
+  result ((list_t u32) & (list_t u32 -> list_t u32))
   =
   begin match ls with
   | List_Cons hd tl ->
     if hd = x
-    then Ok (ls, Ok)
+    then let back = fun ret -> ret in Ok (ls, back)
     else
       let* (l, get_list_at_x_back) = get_list_at_x tl x in
       let back =
-        fun ret -> let* tl1 = get_list_at_x_back ret in Ok (List_Cons hd tl1)
-        in
+        fun ret -> let tl1 = get_list_at_x_back ret in List_Cons hd tl1 in
       Ok (l, back)
-  | List_Nil -> Ok (List_Nil, Ok)
+  | List_Nil -> let back = fun ret -> ret in Ok (List_Nil, back)
   end
 

--- a/tests/lean/Demo/Demo.lean
+++ b/tests/lean/Demo/Demo.lean
@@ -11,13 +11,11 @@ namespace demo
 /- [demo::choose]:
    Source: 'tests/src/demo.rs', lines 7:0-13:1 -/
 def choose
-  {T : Type} (b : Bool) (x : T) (y : T) :
-  Result (T × (T → Result (T × T)))
-  :=
+  {T : Type} (b : Bool) (x : T) (y : T) : Result (T × (T → (T × T))) :=
   if b
-  then let back := fun ret => Result.ok (ret, y)
+  then let back := fun ret => (ret, y)
        Result.ok (x, back)
-  else let back := fun ret => Result.ok (x, ret)
+  else let back := fun ret => (x, ret)
        Result.ok (y, back)
 
 /- [demo::mul2_add1]:
@@ -87,24 +85,18 @@ def list_nth1 {T : Type} (l : CList T) (i : U32) : Result T :=
 /- [demo::list_nth_mut]:
    Source: 'tests/src/demo.rs', lines 67:0-80:1 -/
 divergent def list_nth_mut
-  {T : Type} (l : CList T) (i : U32) :
-  Result (T × (T → Result (CList T)))
-  :=
+  {T : Type} (l : CList T) (i : U32) : Result (T × (T → CList T)) :=
   match l with
   | CList.CCons x tl =>
     if i = 0#u32
-    then
-      let back := fun ret => Result.ok (CList.CCons ret tl)
-      Result.ok (x, back)
+    then let back := fun ret => CList.CCons ret tl
+         Result.ok (x, back)
     else
       do
       let i1 ← i - 1#u32
       let (t, list_nth_mut_back) ← list_nth_mut tl i1
-      let back :=
-        fun ret =>
-          do
-          let tl1 ← list_nth_mut_back ret
-          Result.ok (CList.CCons x tl1)
+      let back := fun ret => let tl1 := list_nth_mut_back ret
+                             CList.CCons x tl1
       Result.ok (t, back)
   | CList.CNil => Result.fail .panic
 
@@ -121,20 +113,16 @@ divergent def i32_id (i : I32) : Result I32 :=
 /- [demo::list_tail]:
    Source: 'tests/src/demo.rs', lines 90:0-95:1 -/
 divergent def list_tail
-  {T : Type} (l : CList T) :
-  Result ((CList T) × (CList T → Result (CList T)))
-  :=
+  {T : Type} (l : CList T) : Result ((CList T) × (CList T → CList T)) :=
   match l with
   | CList.CCons t tl =>
     do
     let (c, list_tail_back) ← list_tail tl
-    let back :=
-      fun ret =>
-        do
-        let tl1 ← list_tail_back ret
-        Result.ok (CList.CCons t tl1)
+    let back := fun ret => let tl1 := list_tail_back ret
+                           CList.CCons t tl1
     Result.ok (c, back)
-  | CList.CNil => Result.ok (CList.CNil, Result.ok)
+  | CList.CNil => let back := fun ret => ret
+                  Result.ok (CList.CNil, back)
 
 /- Trait declaration: [demo::Counter]
    Source: 'tests/src/demo.rs', lines 99:0-101:1 -/

--- a/tests/lean/Demo/Properties.lean
+++ b/tests/lean/Demo/Properties.lean
@@ -65,7 +65,7 @@ decreasing_by simp_wf; scalar_tac
 
 theorem list_tail_spec {T : Type} [Inhabited T] (l : CList T) :
   ∃ back, list_tail l = ok (CList.CNil, back) ∧
-  ∀ tl', ∃ l', back tl' = ok l' ∧ l'.to_list = l.to_list ++ tl'.to_list := by
+  ∀ tl', ∃ l', back tl' = l' ∧ l'.to_list = l.to_list ++ tl'.to_list := by
   rw [list_tail]
   match l with
   | CNil =>
@@ -76,7 +76,6 @@ theorem list_tail_spec {T : Type} [Inhabited T] (l : CList T) :
     simp
     -- Proving the backward function
     intro tl'
-    progress
     simp_all
 
 end demo

--- a/tests/lean/External/Funs.lean
+++ b/tests/lean/External/Funs.lean
@@ -32,7 +32,7 @@ def incr
   do
   let (st1, (i, get_mut_back)) ← core.cell.Cell.get_mut rc st
   let i1 ← i + 1#u32
-  let (_, rc1) ← get_mut_back i1 st1
+  let (_, rc1) := get_mut_back i1 st1
   Result.ok (st1, rc1)
 
 end external

--- a/tests/lean/External/FunsExternal.lean
+++ b/tests/lean/External/FunsExternal.lean
@@ -12,5 +12,5 @@ def core.cell.Cell.get
 
 /- [core::cell::{core::cell::Cell<T>#11}::get_mut]: -/
 def core.cell.Cell.get_mut {T : Type} (c : core.cell.Cell T) (s : State) :
-  Result (State × (T × (T → State → Result (State × (core.cell.Cell T))))) :=
+  Result (State × (T × (T → State → State × (core.cell.Cell T)))) :=
   sorry

--- a/tests/lean/External/FunsExternal_Template.lean
+++ b/tests/lean/External/FunsExternal_Template.lean
@@ -21,6 +21,6 @@ axiom core.cell.Cell.get
    Name pattern: core::cell::{core::cell::Cell<@T>}::get_mut -/
 axiom core.cell.Cell.get_mut
   {T : Type} :
-  core.cell.Cell T → State → Result (State × (T × (T → State → Result
-    (State × (core.cell.Cell T)))))
+  core.cell.Cell T → State → Result (State × (T × (T → State → (State
+    × (core.cell.Cell T)))))
 

--- a/tests/lean/Hashmap/Funs.lean
+++ b/tests/lean/Hashmap/Funs.lean
@@ -77,7 +77,7 @@ divergent def HashMap.clear_loop
       alloc.vec.Vec.index_mut (core.slice.index.SliceIndexUsizeSliceTInst
         (AList T)) slots i
     let i2 ← i + 1#usize
-    let slots1 ← index_mut_back AList.Nil
+    let slots1 := index_mut_back AList.Nil
     HashMap.clear_loop slots1 i2
   else Result.ok slots
 
@@ -136,10 +136,9 @@ def HashMap.insert_no_resize
   then
     do
     let i1 ← self.num_entries + 1#usize
-    let v ← index_mut_back a1
+    let v := index_mut_back a1
     Result.ok { self with num_entries := i1, slots := v }
-  else do
-       let v ← index_mut_back a1
+  else let v := index_mut_back a1
        Result.ok { self with slots := v }
 
 /- [hashmap::{hashmap::HashMap<T>}::move_elements_from_list]: loop 0:
@@ -177,7 +176,7 @@ divergent def HashMap.move_elements_loop
     let (ls, a1) := core.mem.replace a AList.Nil
     let ntable1 ← HashMap.move_elements_from_list ntable ls
     let i2 ← i + 1#usize
-    let slots1 ← index_mut_back a1
+    let slots1 := index_mut_back a1
     HashMap.move_elements_loop ntable1 slots1 i2
   else Result.ok (ntable, slots)
 
@@ -286,23 +285,17 @@ def HashMap.get {T : Type} (self : HashMap T) (key : Usize) : Result T :=
 /- [hashmap::{hashmap::HashMap<T>}::get_mut_in_list]: loop 0:
    Source: 'tests/src/hashmap.rs', lines 257:8-265:5 -/
 divergent def HashMap.get_mut_in_list_loop
-  {T : Type} (ls : AList T) (key : Usize) :
-  Result (T × (T → Result (AList T)))
-  :=
+  {T : Type} (ls : AList T) (key : Usize) : Result (T × (T → AList T)) :=
   match ls with
   | AList.Cons ckey cvalue tl =>
     if ckey = key
-    then
-      let back := fun ret => Result.ok (AList.Cons ckey ret tl)
-      Result.ok (cvalue, back)
+    then let back := fun ret => AList.Cons ckey ret tl
+         Result.ok (cvalue, back)
     else
       do
       let (t, back) ← HashMap.get_mut_in_list_loop tl key
-      let back1 :=
-        fun ret =>
-          do
-          let tl1 ← back ret
-          Result.ok (AList.Cons ckey cvalue tl1)
+      let back1 := fun ret => let tl1 := back ret
+                              AList.Cons ckey cvalue tl1
       Result.ok (t, back1)
   | AList.Nil => Result.fail .panic
 
@@ -310,16 +303,14 @@ divergent def HashMap.get_mut_in_list_loop
    Source: 'tests/src/hashmap.rs', lines 256:4-265:5 -/
 @[reducible]
 def HashMap.get_mut_in_list
-  {T : Type} (ls : AList T) (key : Usize) :
-  Result (T × (T → Result (AList T)))
-  :=
+  {T : Type} (ls : AList T) (key : Usize) : Result (T × (T → AList T)) :=
   HashMap.get_mut_in_list_loop ls key
 
 /- [hashmap::{hashmap::HashMap<T>}::get_mut]:
    Source: 'tests/src/hashmap.rs', lines 268:4-272:5 -/
 def HashMap.get_mut
   {T : Type} (self : HashMap T) (key : Usize) :
-  Result (T × (T → Result (HashMap T)))
+  Result (T × (T → HashMap T))
   :=
   do
   let hash ← hash_key key
@@ -331,10 +322,9 @@ def HashMap.get_mut
   let (t, get_mut_in_list_back) ← HashMap.get_mut_in_list a key
   let back :=
     fun ret =>
-      do
-      let a1 ← get_mut_in_list_back ret
-      let v ← index_mut_back a1
-      Result.ok { self with slots := v }
+      let a1 := get_mut_in_list_back ret
+      let v := index_mut_back a1
+      { self with slots := v }
   Result.ok (t, back)
 
 /- [hashmap::{hashmap::HashMap<T>}::remove_from_list]: loop 0:
@@ -378,13 +368,12 @@ def HashMap.remove
   let (x, a1) ← HashMap.remove_from_list key a
   match x with
   | none =>
-    do
-    let v ← index_mut_back a1
+    let v := index_mut_back a1
     Result.ok (none, { self with slots := v })
   | some x1 =>
     do
     let i1 ← self.num_entries - 1#usize
-    let v ← index_mut_back a1
+    let v := index_mut_back a1
     Result.ok (x, { self with num_entries := i1, slots := v })
 
 /- [hashmap::insert_on_disk]:
@@ -410,7 +399,7 @@ def test1 : Result Unit :=
   then
     do
     let (_, get_mut_back) ← HashMap.get_mut hm4 1024#usize
-    let hm5 ← get_mut_back 56#u64
+    let hm5 := get_mut_back 56#u64
     let i1 ← HashMap.get hm5 1024#usize
     if i1 = 56#u64
     then

--- a/tests/lean/PoloniusList.lean
+++ b/tests/lean/PoloniusList.lean
@@ -17,22 +17,19 @@ inductive List (T : Type) :=
 /- [polonius_list::get_list_at_x]:
    Source: 'tests/src/polonius_list.rs', lines 16:0-30:1 -/
 divergent def get_list_at_x
-  (ls : List U32) (x : U32) :
-  Result ((List U32) × (List U32 → Result (List U32)))
-  :=
+  (ls : List U32) (x : U32) : Result ((List U32) × (List U32 → List U32)) :=
   match ls with
   | List.Cons hd tl =>
     if hd = x
-    then Result.ok (ls, Result.ok)
+    then let back := fun ret => ret
+         Result.ok (ls, back)
     else
       do
       let (l, get_list_at_x_back) ← get_list_at_x tl x
-      let back :=
-        fun ret =>
-          do
-          let tl1 ← get_list_at_x_back ret
-          Result.ok (List.Cons hd tl1)
+      let back := fun ret => let tl1 := get_list_at_x_back ret
+                             List.Cons hd tl1
       Result.ok (l, back)
-  | List.Nil => Result.ok (List.Nil, Result.ok)
+  | List.Nil => let back := fun ret => ret
+                Result.ok (List.Nil, back)
 
 end polonius_list

--- a/tests/lean/Tutorial/Exercises.lean
+++ b/tests/lean/Tutorial/Exercises.lean
@@ -563,7 +563,7 @@ divergent def zero_loop
       alloc.vec.Vec.index_mut
         (core.slice.index.SliceIndexUsizeSliceTInst U32) x i
     let i2 ← i + 1#usize
-    let x1 ← index_mut_back 0#u32
+    let x1 := index_mut_back 0#u32
     zero_loop x1 i2
   else Result.ok x
 
@@ -662,7 +662,7 @@ divergent def add_no_overflow_loop
         (core.slice.index.SliceIndexUsizeSliceTInst U32) x i
     let i4 ← i3 + i2
     let i5 ← i + 1#usize
-    let x1 ← index_mut_back i4
+    let x1 := index_mut_back i4
     add_no_overflow_loop x1 y i5
   else Result.ok x
 
@@ -763,7 +763,7 @@ divergent def add_with_carry_loop
       alloc.vec.Vec.index_mut
         (core.slice.index.SliceIndexUsizeSliceTInst U32) x i
     let i7 ← i + 1#usize
-    let x1 ← index_mut_back sum1
+    let x1 := index_mut_back sum1
     add_with_carry_loop x1 y c01 i7
   else Result.ok (c0, x)
 
@@ -848,7 +848,7 @@ divergent def add_loop
       alloc.vec.Vec.index_mut
         (core.slice.index.SliceIndexUsizeSliceTInst U32) x i
     let i5 ← i + 1#usize
-    let x1 ← index_mut_back sum1
+    let x1 := index_mut_back sum1
     add_loop x1 y max1 c01 i5
   else
     if c0 != 0#u8

--- a/tests/lean/Tutorial/Solutions.lean
+++ b/tests/lean/Tutorial/Solutions.lean
@@ -49,7 +49,7 @@ theorem list_nth_mut1_spec {T: Type} [Inhabited T] (l : CList T) (i : U32)
   (h : i.val < l.toList.length) :
   ∃ x back, list_nth_mut1 l i = ok (x, back) ∧
   x = l.toList.index i.toNat ∧
-  ∀ x', ∃ l', back x' = ok l' ∧ l'.toList = l.toList.update i.toNat x' := by
+  ∀ x', (back x').toList = l.toList.update i.toNat x' := by
   rw [list_nth_mut1, list_nth_mut1_loop]
   split
   . rename_i hd tl
@@ -70,7 +70,7 @@ theorem list_nth_mut1_spec {T: Type} [Inhabited T] (l : CList T) (i : U32)
         simp only [hUpdate]
     . simp at *
       progress as ⟨ i1, hi1 ⟩
-      progress as ⟨ tl1, back, htl1 ⟩
+      progress as ⟨ tl1, back, htl1, hback ⟩
       simp
       split_conjs
       . have hIndex := List.index_nzero_cons hd tl.toList i.toNat (by scalar_tac)
@@ -80,11 +80,9 @@ theorem list_nth_mut1_spec {T: Type} [Inhabited T] (l : CList T) (i : U32)
         simp only [hiEq]
       . -- Backward function
         intro x'
-        progress as ⟨ tl2, htl2 ⟩
-        simp
+        simp [hback]
         have hUpdate := List.update_nzero_cons hd tl.toList i.toNat x' (by scalar_tac)
         simp only [hUpdate]
-        simp only [htl2]
         have hiEq : i1.toNat = i.toNat - 1 := by scalar_tac
         simp only [hiEq]
   . simp_all
@@ -101,7 +99,7 @@ theorem list_nth_mut1_spec' {T: Type} [Inhabited T] (l : CList T) (i : U32)
   (h : i.val < l.toList.length) :
   ∃ x back, list_nth_mut1 l i = ok (x, back) ∧
   x = l.toList.index i.toNat ∧
-  ∀ x', ∃ l', back x' = ok l' ∧ l'.toList = l.toList.update i.toNat x' := by
+  ∀ x', (back x').toList = l.toList.update i.toNat x' := by
   rw [list_nth_mut1, list_nth_mut1_loop]
   split
   . split
@@ -118,7 +116,6 @@ theorem list_nth_mut1_spec' {T: Type} [Inhabited T] (l : CList T) (i : U32)
       . simp [*]
       . -- Backward function
         intro x'
-        progress as ⟨ tl2 ⟩
         simp [*]
   . simp_all
     scalar_tac
@@ -127,7 +124,7 @@ theorem list_nth_mut1_spec' {T: Type} [Inhabited T] (l : CList T) (i : U32)
 @[pspec]
 theorem list_tail_spec {T : Type} (l : CList T) :
   ∃ back, list_tail l = ok (CList.CNil, back) ∧
-  ∀ tl', ∃ l', back tl' = ok l' ∧ l'.toList = l.toList ++ tl'.toList := by
+  ∀ tl', (back tl').toList = l.toList ++ tl'.toList := by
   rw [list_tail, list_tail_loop]
   split
   . rename_i hd tl
@@ -137,11 +134,8 @@ theorem list_tail_spec {T : Type} (l : CList T) :
     simp
     -- Proving the post-condition about the backward function
     intro tl1
-    progress as ⟨ tl2, htl2 ⟩
     -- Simplify the `toList` and the equality
-    simp
-    -- Finish
-    simp only [htl2]
+    simp only [hBack]
   . -- Quite a few things automatically happen here
     simp
 
@@ -149,15 +143,13 @@ theorem list_tail_spec {T : Type} (l : CList T) :
 @[pspec]
 theorem list_tail_spec' {T : Type} (l : CList T) :
   ∃ back, list_tail l = ok (CList.CNil, back) ∧
-  ∀ tl', ∃ l', back tl' = ok l' ∧ l'.toList = l.toList ++ tl'.toList := by
+  ∀ tl', (back tl').toList = l.toList ++ tl'.toList := by
   rw [list_tail, list_tail_loop]
   split
   . simp
     progress as ⟨ back ⟩
     simp
     -- Proving the post-condition about the backward function
-    intro tl'
-    progress
     simp [*]
   . simp
 
@@ -169,8 +161,6 @@ theorem append_in_place_spec {T : Type} (l0 l1 : CList T) :
   rw [append_in_place]
   progress as ⟨ tl, back ⟩
   progress as ⟨ l2 ⟩
-  -- Nothing much to do here
-  simp [*]
 
 @[pspec]
 theorem reverse_loop_spec {T : Type} (l : CList T) (out : CList T) :
@@ -222,8 +212,7 @@ theorem zero_loop_spec
   split
   . progress as ⟨ _ ⟩
     progress as ⟨ i1 ⟩
-    progress as ⟨ x1 ⟩
-    progress as ⟨ x2, _, hSame, hZero ⟩
+    progress as ⟨ x1, _, hSame, hZero ⟩
     simp_all
     split_conjs
     . intro j h0
@@ -340,7 +329,6 @@ theorem add_no_overflow_loop_spec
       scalar_tac
     progress as ⟨ i' ⟩
     progress as ⟨ x1 ⟩
-    progress as ⟨ x2 ⟩
     . -- This precondition is not proven automatically
       intro j h0 h1
       simp_all
@@ -405,8 +393,7 @@ theorem add_with_carry_loop_spec
       progress as ⟨ c3 ⟩
       progress as ⟨ _ ⟩
       progress as ⟨ i1 ⟩
-      progress as ⟨ x1 ⟩
-      progress as ⟨ c4, x2 ⟩
+      progress as ⟨ c4, x1 ⟩
       -- Proving the post-condition
       simp_all [toInt]
       have hxUpdate := toInt_aux_update x.val i.toNat s2 (by scalar_tac)

--- a/tests/src/arrays.rs
+++ b/tests/src/arrays.rs
@@ -114,7 +114,7 @@ pub fn update_update_slice(s: &mut [&mut [u32]], i: usize, j: usize) {
 }
 */
 
-pub fn update_update_array(mut s: [[u32; 32]; 32], i: usize, j: usize) {
+pub fn update_update_array(mut s: &mut [[u32; 32]; 32], i: usize, j: usize) {
     s[i][j] = 0;
 }
 


### PR DESCRIPTION
The backward functions now don't use the error monad anymore. For instance, the `choose` function used to be extracted to:
```lean
def choose
  {T : Type} (b : Bool) (x : T) (y : T) :
  Result (T × (T → Result (T × T)))
  :=
  if b
  then let back := fun ret => Result.ok (ret, y)
       Result.ok (x, back)
  else let back := fun ret => Result.ok (x, ret)
       Result.ok (y, back)
```

Now it gets compiled to:
```lean
def choose
  {T : Type} (b : Bool) (x : T) (y : T) :
  Result (T × (T → T × T))
  :=
  if b
  then let back := fun ret =>(ret, y)
       Result.ok (x, back)
  else let back := fun ret => (x, ret)
       Result.ok (y, back)
```