### PR TITLE
Fix the extracted name of some clone methods

### DIFF
--- a/src/extract/ExtractBuiltin.ml
+++ b/src/extract/ExtractBuiltin.ml
@@ -493,13 +493,16 @@ let mk_builtin_funs () : (pattern * bool list option * builtin_fun_info) list =
   (* Clone<bool> *)
   @ [
       mk_fun "core::clone::impls::{core::clone::Clone<bool>}::clone"
-        ~extract_name:(Some "core.clone.CloneBool.clone") ~can_fail:false ();
+        ~extract_name:(Some "core.clone.impls.CloneBool.clone") ~can_fail:false
+        ();
     ]
   (* Clone<INT> *)
   @ mk_scalar_fun
       (fun ty -> "core::clone::impls::{core::clone::Clone<" ^ ty ^ ">}::clone")
       (fun ty ->
-        "core.clone.Clone" ^ StringUtils.capitalize_first_letter ty ^ ".clone")
+        "core.clone.impls.Clone"
+        ^ StringUtils.capitalize_first_letter ty
+        ^ ".clone")
       ~can_fail:false ()
   (* Lean-only definitions *)
   @ mk_lean_only


### PR DESCRIPTION
This is related to https://github.com/AeneasVerif/aeneas/issues/375#issuecomment-2508735894
The following code:
```rust
#[derive(Clone)]
pub struct Record {
    age: u32,
    zip: u32,
    salary: u32,
}
```
extracted to:
```lean
... -- Omitting the struct

def ClonekanonRecord.clone (self : Record) : Result Record :=
  let i := core.clone.CloneU32.clone self.age
  let i1 := core.clone.CloneU32.clone self.zip
  let i2 := core.clone.CloneU32.clone self.salary
  Result.ok { age := i, zip := i1, salary := i2 }
```
while it was supposed to extract to:
```lean
def CloneissueRecord.clone (self : Record) : Result Record :=
  let i := core.clone.impls.CloneU32.clone self.age
  let i1 := core.clone.impls.CloneU32.clone self.zip
  let i2 := core.clone.impls.CloneU32.clone self.salary
  Result.ok { age := i, zip := i1, salary := i2 }
```