### PR TITLE
Make lean job succeed if skipped

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,11 +49,11 @@ jobs:
   lean:
     needs: [diff_lean_files]
     runs-on: [self-hosted, linux, nix]
-    if: needs.diff_lean_files.outputs.check_lean == 'true'
     steps:
       - uses: actions/checkout@v4
-      # Lean cannot run its tests in the nix sandbox because `elan` will download things
-      - run: nix develop --command bash -c "cd tests/lean && make"
+      - if: needs.diff_lean_files.outputs.check_lean == 'true'
+        # Lean cannot run its tests in the nix sandbox because `elan` will download things
+        run: nix develop --command bash -c "cd tests/lean && make"
 
   charon-pin-is-forward:
     runs-on: [self-hosted, linux, nix]


### PR DESCRIPTION
Right now we can't merge PRs when the lean job is skipped.