### PR TITLE
Clarify the use of `region_id_set`

### DIFF
--- a/src/interp/Interpreter.ml
+++ b/src/interp/Interpreter.ml
@@ -209,7 +209,9 @@ let initialize_symbolic_context_for_fun (ctx : decls_ctx) (fdef : fun_decl) :
       eval_ctx * typed_avalue list =
     (* Project over the values - we use *loan* projectors, as explained above *)
     let avalues =
-      List.map (mk_aproj_loans_value_from_symbolic_value abs.regions) input_svs
+      List.map
+        (mk_aproj_loans_value_from_symbolic_value abs.regions.owned)
+        input_svs
     in
     (ctx, avalues)
   in
@@ -308,8 +310,8 @@ let evaluate_function_symbolic_synthesize_backward_from_return (config : config)
       let compute_abs_avalues (abs : abs) (ctx : eval_ctx) :
           eval_ctx * typed_avalue list =
         let ctx, avalue =
-          apply_proj_borrows_on_input_value config span ctx abs.regions
-            abs.ancestors_regions ret_value ret_rty
+          apply_proj_borrows_on_input_value config span ctx abs.regions.owned
+            abs.regions.ancestors ret_value ret_rty
         in
         (ctx, [ avalue ])
       in

--- a/src/interp/InterpreterBorrowsCore.ml
+++ b/src/interp/InterpreterBorrowsCore.ml
@@ -738,7 +738,7 @@ let lookup_intersecting_aproj_borrows_opt (span : Meta.span)
   let check_add_proj_borrows (is_shared : bool) abs sv' proj_ty =
     if
       proj_borrows_intersects_proj_loans span
-        (abs.regions, sv', proj_ty)
+        (abs.regions.owned, sv', proj_ty)
         (regions, sv)
     then
       let x = (abs.abs_id, proj_ty) in
@@ -832,7 +832,7 @@ let update_intersecting_aproj_borrows (span : Meta.span)
   let check_proj_borrows is_shared abs sv' proj_ty =
     if
       proj_borrows_intersects_proj_loans span
-        (abs.regions, sv', proj_ty)
+        (abs.regions.owned, sv', proj_ty)
         (regions, sv)
     then (
       if is_shared then add_shared () else set_non_shared ();
@@ -994,7 +994,7 @@ let update_intersecting_aproj_loans (span : Meta.span)
               sanity_check __FILE__ __LINE__ (sv.sv_ty = sv'.sv_ty) span;
               if
                 projections_intersect span proj_ty proj_regions sv'.sv_ty
-                  abs.regions
+                  abs.regions.owned
               then update abs given_back
               else super#visit_aproj (Some abs) sproj)
             else super#visit_aproj (Some abs) sproj

--- a/src/interp/InterpreterExpansion.ml
+++ b/src/interp/InterpreterExpansion.ml
@@ -86,8 +86,8 @@ let apply_symbolic_expansion_to_target_avalues (config : config)
 
       method! visit_ASymbolic current_abs aproj =
         let current_abs = Option.get current_abs in
-        let proj_regions = current_abs.regions in
-        let ancestors_regions = current_abs.ancestors_regions in
+        let proj_regions = current_abs.regions.owned in
+        let ancestors_regions = current_abs.regions.ancestors in
         (* Explore in depth first - we won't update anything: we simply
          * want to check we don't have to expand inner symbolic value *)
         match (aproj, proj_kind) with
@@ -336,7 +336,7 @@ let expand_symbolic_value_shared_borrow (config : config) (span : Meta.span)
 
       method! visit_EAbs proj_regions abs =
         sanity_check __FILE__ __LINE__ (Option.is_none proj_regions) span;
-        let proj_regions = Some abs.regions in
+        let proj_regions = Some abs.regions.owned in
         super#visit_EAbs proj_regions abs
 
       method! visit_AProjSharedBorrow proj_regions asb =

--- a/src/interp/InterpreterLoopsMatchCtxs.ml
+++ b/src/interp/InterpreterLoopsMatchCtxs.ml
@@ -1995,12 +1995,16 @@ let match_ctx_with_target (config : config) (span : Meta.span)
 
       method! visit_region_id _ _ =
         craise_opt_span __FILE__ __LINE__ None
-          "Region ids should not be visited directly; the visitor should catch \
-           cases that contain region ids earlier."
+          "Internal error: region ids should not be visited directly; the \
+           visitor should catch cases that contain region ids earlier."
 
       method! visit_RVar _ var =
         match var with
-        | Free id -> RVar (Free (get_region_id id))
+        | Free id ->
+            (* If the bound region is free, then it is a region owned
+               by an abstraction, so we do the same as for the case
+               [abs_region_id]. *)
+            RVar (Free (get_region_id id))
         | Bound _ -> RVar var
 
       method! visit_region_id_set _ (ids : region_id_set) : region_id_set =

--- a/src/interp/InterpreterLoopsMatchCtxs.ml
+++ b/src/interp/InterpreterLoopsMatchCtxs.ml
@@ -546,8 +546,11 @@ module MakeJoinMatcher (S : MatchJoinState) : PrimMatcher = struct
           can_end = true;
           parents = AbstractionId.Set.empty;
           original_parents = [];
-          regions = RegionId.Set.singleton rid;
-          ancestors_regions = RegionId.Set.empty;
+          regions =
+            {
+              owned = RegionId.Set.singleton rid;
+              ancestors = RegionId.Set.empty;
+            };
           avalues;
         }
       in
@@ -661,8 +664,11 @@ module MakeJoinMatcher (S : MatchJoinState) : PrimMatcher = struct
             can_end = true;
             parents = AbstractionId.Set.empty;
             original_parents = [];
-            regions = RegionId.Set.singleton rid;
-            ancestors_regions = RegionId.Set.empty;
+            regions =
+              {
+                owned = RegionId.Set.singleton rid;
+                ancestors = RegionId.Set.empty;
+              };
             avalues;
           }
         in
@@ -714,8 +720,11 @@ module MakeJoinMatcher (S : MatchJoinState) : PrimMatcher = struct
           can_end = true;
           parents = AbstractionId.Set.empty;
           original_parents = [];
-          regions = RegionId.Set.singleton rid;
-          ancestors_regions = RegionId.Set.empty;
+          regions =
+            {
+              owned = RegionId.Set.singleton rid;
+              ancestors = RegionId.Set.empty;
+            };
           avalues;
         }
       in
@@ -1388,8 +1397,7 @@ let match_ctxs (span : Meta.span) (check_equiv : bool) (fixed_ids : ids_sets)
       can_end = can_end0;
       parents = parents0;
       original_parents = original_parents0;
-      regions = regions0;
-      ancestors_regions = ancestors_regions0;
+      regions = { owned = regions0; ancestors = ancestors_regions0 };
       avalues = avalues0;
     } =
       abs0
@@ -1401,8 +1409,7 @@ let match_ctxs (span : Meta.span) (check_equiv : bool) (fixed_ids : ids_sets)
       can_end = can_end1;
       parents = parents1;
       original_parents = original_parents1;
-      regions = regions1;
-      ancestors_regions = ancestors_regions1;
+      regions = { owned = regions1; ancestors = ancestors_regions1 };
       avalues = avalues1;
     } =
       abs1
@@ -2007,8 +2014,11 @@ let match_ctx_with_target (config : config) (span : Meta.span)
             RVar (Free (get_region_id id))
         | Bound _ -> RVar var
 
-      method! visit_region_id_set _ (ids : region_id_set) : region_id_set =
-        RegionId.Set.map get_region_id ids
+      method! visit_abs_regions _ regions =
+        let { owned; ancestors } = regions in
+        let owned = RegionId.Set.map get_region_id owned in
+        let ancestors = RegionId.Set.map get_region_id ancestors in
+        { owned; ancestors }
 
       (** We also need to change the abstraction kind *)
       method! visit_abs env abs =

--- a/src/interp/InterpreterUtils.ml
+++ b/src/interp/InterpreterUtils.ml
@@ -402,8 +402,9 @@ let compute_ids () =
         | Free id -> rids := RegionId.Set.add id !rids
         | Bound _ -> ()
 
-      method! visit_region_id_set _ (ids : region_id_set) : unit =
-        rids := RegionId.Set.union ids !rids
+      method! visit_abs_regions _ (regions : abs_regions) : unit =
+        let { owned; ancestors } = regions in
+        rids := RegionId.Set.union (RegionId.Set.union owned ancestors) !rids
 
       method! visit_symbolic_value env sv =
         sids := SymbolicValueId.Set.add sv.sv_id !sids;

--- a/src/interp/InterpreterUtils.ml
+++ b/src/interp/InterpreterUtils.ml
@@ -342,6 +342,9 @@ type ids_sets = {
   loan_ids : BorrowId.Set.t;  (** Only the loan ids *)
   dids : DummyVarId.Set.t;
   rids : RegionId.Set.t;
+      (** This should only contain **free** region ids (note that we have to be
+          careful because we use the same index type for bound regions and free
+          regions - see the implementation of [compute_ids] below) *)
   sids : SymbolicValueId.Set.t;
 }
 [@@deriving show]
@@ -514,7 +517,7 @@ let instantiate_fun_sig (span : Meta.span) (ctx : eval_ctx)
   let asubst (rg_id : RegionGroupId.id) : AbstractionId.id =
     RegionGroupId.Map.find rg_id asubst_map
   in
-  (* Refresh the region ids so that we can subsequently generate more fresh regions without clash *)
+  (* Generate fresh regions *)
   let rsubst =
     Substitute.fresh_regions_with_substs_from_vars sg.generics.regions
       fresh_region_id

--- a/src/interp/Invariants.ml
+++ b/src/interp/Invariants.ml
@@ -695,7 +695,7 @@ let check_typing_invariant (span : Meta.span) (ctx : eval_ctx) : unit =
                  * otherwise they should have been reduced to [_] *)
                 let abs = Option.get info in
                 sanity_check __FILE__ __LINE__
-                  (ty_has_regions_in_set abs.regions sv.sv_ty)
+                  (ty_has_regions_in_set abs.regions.owned sv.sv_ty)
                   span
             | AProjBorrows (sv, proj_ty) ->
                 let ty2 = Substitute.erase_regions sv.sv_ty in
@@ -704,7 +704,7 @@ let check_typing_invariant (span : Meta.span) (ctx : eval_ctx) : unit =
                  * otherwise they should have been reduced to [_] *)
                 let abs = Option.get info in
                 sanity_check __FILE__ __LINE__
-                  (ty_has_regions_in_set abs.regions proj_ty)
+                  (ty_has_regions_in_set abs.regions.owned proj_ty)
                   span
             | AEndedProjLoans (_msv, given_back_ls) ->
                 List.iter
@@ -806,14 +806,14 @@ let check_symbolic_values (span : Meta.span) (ctx : eval_ctx) : unit =
         match asb with
         | AsbBorrow _ -> ()
         | AsbProjReborrows (sv, proj_ty) ->
-            add_aproj_borrows sv abs.abs_id abs.regions proj_ty true
+            add_aproj_borrows sv abs.abs_id abs.regions.owned proj_ty true
 
       method! visit_aproj abs aproj =
         (let abs = Option.get abs in
          match aproj with
-         | AProjLoans (sv, _) -> add_aproj_loans sv abs.abs_id abs.regions
+         | AProjLoans (sv, _) -> add_aproj_loans sv abs.abs_id abs.regions.owned
          | AProjBorrows (sv, proj_ty) ->
-             add_aproj_borrows sv abs.abs_id abs.regions proj_ty false
+             add_aproj_borrows sv abs.abs_id abs.regions.owned proj_ty false
          | AEndedProjLoans _ | AEndedProjBorrows _ | AIgnoredProjBorrows -> ());
         super#visit_aproj abs aproj
     end

--- a/src/llbc/Print.ml
+++ b/src/llbc/Print.ml
@@ -314,7 +314,7 @@ module Values = struct
     ^ kind ^ "{parents="
     ^ AbstractionId.Set.to_string None abs.parents
     ^ "}" ^ "{regions="
-    ^ RegionId.Set.to_string None abs.regions
+    ^ RegionId.Set.to_string None abs.regions.owned
     ^ "}" ^ can_end ^ " {\n" ^ avs ^ "\n" ^ indent ^ "}"
 
   let inst_fun_sig_to_string (env : fmt_env) (sg : LlbcAst.inst_fun_sig) :

--- a/src/llbc/Substitute.ml
+++ b/src/llbc/Substitute.ml
@@ -99,8 +99,11 @@ let subst_ids_visitor (subst : id_subst) =
         "Region ids should not be visited directly; the visitor should catch \
          cases that contain region ids earlier."
 
-    method! visit_region_id_set _ (ids : region_id_set) : region_id_set =
-      RegionId.Set.map subst.r_subst ids
+    method! visit_abs_regions _ regions =
+      let { owned; ancestors } = regions in
+      let owned = RegionId.Set.map subst.r_subst owned in
+      let ancestors = RegionId.Set.map subst.r_subst ancestors in
+      { owned; ancestors }
 
     method! visit_RVar _ var =
       match var with

--- a/src/llbc/Values.ml
+++ b/src/llbc/Values.ml
@@ -831,15 +831,19 @@ type abs = {
           when generating the backward function for 'a, we have to make sure we
           don't need to end the return region for 'b (if it is the case, it means
           the function doesn't borrow check).
-       *)
+      *)
   parents : abstraction_id_set;  (** The parent abstractions *)
   original_parents : abstraction_id list;
       (** The original list of parents, ordered. This is used for synthesis. TODO: remove? *)
-  regions : region_id_set;  (** Regions owned by this abstraction *)
-  ancestors_regions : region_id_set;
+  regions : abs_regions;
+  avalues : typed_avalue list;  (** The values in this abstraction *)
+}
+
+and abs_regions = {
+  owned : region_id_set;  (** Regions owned by the abstraction *)
+  ancestors : region_id_set;
       (** Union of the regions owned by this abstraction's ancestors (not
           including the regions of this abstraction itself) *)
-  avalues : typed_avalue list;  (** The values in this abstraction *)
 }
 [@@deriving
   show,


### PR DESCRIPTION
There might be confusions when using the `visit_region_id` and `visit_region_id_set` visitors. In order to prevent future mistakes, I made sure the visitors which might read region ids do not directly use `visit_region_id_set`.