### PR TITLE
Deduplicate item maps in the various environments

### DIFF
--- a/charon-pin
+++ b/charon-pin
@@ -1,2 +1,2 @@
 # This is the commit from https://github.com/AeneasVerif/charon that should be used with this version of aeneas.
-548d3b70fdb175bdbbe0157050464afab326ee06
+0be4542d4223d6900ff3b907fa93da1261280dff

--- a/flake.lock
+++ b/flake.lock
@@ -9,11 +9,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1735554195,
-        "narHash": "sha256-16P01XkjnV7RPY/Ot37CmkwNIvrxGPC9vrhOEpzPdqI=",
+        "lastModified": 1735555565,
+        "narHash": "sha256-kYy+/Uqf4HQdFyzIN3k4FbkelqiDN8AknRWpjiB7j5k=",
         "owner": "aeneasverif",
         "repo": "charon",
-        "rev": "548d3b70fdb175bdbbe0157050464afab326ee06",
+        "rev": "0be4542d4223d6900ff3b907fa93da1261280dff",
         "type": "github"
       },
       "original": {

--- a/src/Main.ml
+++ b/src/Main.ml
@@ -59,33 +59,15 @@ Usage: %s [OPTIONS] FILE
 
 let matches_name (c : crate) (name : Types.name)
     (m : 'a ExtractName.NameMatcherMap.t) : bool =
-  let open Charon.NameMatcher in
+  let mctx = Charon.NameMatcher.ctx_from_crate c in
   let open ExtractBuiltin in
-  let mctx : ctx =
-    {
-      type_decls = c.type_decls;
-      global_decls = c.global_decls;
-      fun_decls = c.fun_decls;
-      trait_decls = c.trait_decls;
-      trait_impls = c.trait_impls;
-    }
-  in
   NameMatcherMap.mem mctx name m
 
 let matches_name_with_generics (c : crate) (name : Types.name)
     (generics : Types.generic_args) (m : 'a ExtractName.NameMatcherMap.t) : bool
     =
-  let open Charon.NameMatcher in
+  let mctx = Charon.NameMatcher.ctx_from_crate c in
   let open ExtractBuiltin in
-  let mctx : ctx =
-    {
-      type_decls = c.type_decls;
-      global_decls = c.global_decls;
-      fun_decls = c.fun_decls;
-      trait_decls = c.trait_decls;
-      trait_impls = c.trait_impls;
-    }
-  in
   Option.is_some (NameMatcherMap.find_with_generics_opt mctx name generics m)
 
 let () =

--- a/src/Translate.ml
+++ b/src/Translate.ml
@@ -91,9 +91,6 @@ let translate_function_to_pure_aux (trans_ctx : trans_ctx)
       regions_hierarchies = trans_ctx.fun_ctx.regions_hierarchies;
     }
   in
-  let global_ctx =
-    { SymbolicToPure.llbc_global_decls = trans_ctx.global_ctx.global_decls }
-  in
 
   (* Compute the set of loops, and find better ids for them (starting at 0).
      Note that we only need to explore the forward function: the backward
@@ -146,9 +143,6 @@ let translate_function_to_pure_aux (trans_ctx : trans_ctx)
       fuel;
       type_ctx;
       fun_ctx;
-      global_ctx;
-      trait_decls_ctx = trans_ctx.trait_decls_ctx.trait_decls;
-      trait_impls_ctx = trans_ctx.trait_impls_ctx.trait_impls;
       fun_decl = fdef;
       forward_inputs = [];
       (* Initialized just below *)
@@ -310,7 +304,7 @@ let translate_crate_to_pure (crate : crate) :
            ^ " because of previous error\nName pattern: '" ^ name_pattern ^ "'"
             );
           None)
-      (TraitDeclId.Map.values trans_ctx.trait_decls_ctx.trait_decls)
+      (TraitDeclId.Map.values trans_ctx.crate.trait_decls)
   in
 
   (* Translate the trait implementations *)
@@ -328,7 +322,7 @@ let translate_crate_to_pure (crate : crate) :
            ^ " because of previous error\nName pattern: '" ^ name_pattern ^ "'"
             );
           None)
-      (TraitImplId.Map.values trans_ctx.trait_impls_ctx.trait_impls)
+      (TraitImplId.Map.values trans_ctx.crate.trait_impls)
   in
 
   (* Apply the micro-passes *)
@@ -535,7 +529,7 @@ let export_types_group (fmt : Format.formatter) (config : gen_config)
  *)
 let export_global (fmt : Format.formatter) (config : gen_config) (ctx : gen_ctx)
     (id : GlobalDeclId.id) : unit =
-  let global_decls = ctx.trans_ctx.global_ctx.global_decls in
+  let global_decls = ctx.trans_ctx.crate.global_decls in
   let global = GlobalDeclId.Map.find id global_decls in
   let trans =
     silent_unwrap_opt_span __FILE__ __LINE__ None

--- a/src/TranslateCore.ml
+++ b/src/TranslateCore.ml
@@ -22,89 +22,39 @@ let name_to_string (ctx : trans_ctx) =
 
 let match_name_find_opt (ctx : trans_ctx) (name : Types.name)
     (m : 'a NameMatcherMap.t) : 'a option =
-  let open Charon.NameMatcher in
+  let mctx = Charon.NameMatcher.ctx_from_crate ctx.crate in
   let open ExtractBuiltin in
-  let mctx : ctx =
-    {
-      type_decls = ctx.type_ctx.type_decls;
-      global_decls = ctx.global_ctx.global_decls;
-      fun_decls = ctx.fun_ctx.fun_decls;
-      trait_decls = ctx.trait_decls_ctx.trait_decls;
-      trait_impls = ctx.trait_impls_ctx.trait_impls;
-    }
-  in
   NameMatcherMap.find_opt mctx name m
 
 let match_name_with_generics_find_opt (ctx : trans_ctx) (name : Types.name)
     (generics : Types.generic_args) (m : 'a NameMatcherMap.t) : 'a option =
-  let open Charon.NameMatcher in
+  let mctx = Charon.NameMatcher.ctx_from_crate ctx.crate in
   let open ExtractBuiltin in
-  let mctx : ctx =
-    {
-      type_decls = ctx.type_ctx.type_decls;
-      global_decls = ctx.global_ctx.global_decls;
-      fun_decls = ctx.fun_ctx.fun_decls;
-      trait_decls = ctx.trait_decls_ctx.trait_decls;
-      trait_impls = ctx.trait_impls_ctx.trait_impls;
-    }
-  in
   NameMatcherMap.find_with_generics_opt mctx name generics m
 
 let name_to_simple_name (ctx : trans_ctx) (n : Types.name) : string list =
-  let mctx : Charon.NameMatcher.ctx =
-    {
-      type_decls = ctx.type_ctx.type_decls;
-      global_decls = ctx.global_ctx.global_decls;
-      fun_decls = ctx.fun_ctx.fun_decls;
-      trait_decls = ctx.trait_decls_ctx.trait_decls;
-      trait_impls = ctx.trait_impls_ctx.trait_impls;
-    }
-  in
+  let mctx = Charon.NameMatcher.ctx_from_crate ctx.crate in
   name_to_simple_name mctx n
 
 let trait_name_with_generics_to_simple_name (ctx : trans_ctx)
     ?(prefix : Types.name option = None) (n : Types.name)
     (p : Types.generic_params) (g : Types.generic_args) : string list =
-  let mctx : Charon.NameMatcher.ctx =
-    {
-      type_decls = ctx.type_ctx.type_decls;
-      global_decls = ctx.global_ctx.global_decls;
-      fun_decls = ctx.fun_ctx.fun_decls;
-      trait_decls = ctx.trait_decls_ctx.trait_decls;
-      trait_impls = ctx.trait_impls_ctx.trait_impls;
-    }
-  in
+  let mctx = Charon.NameMatcher.ctx_from_crate ctx.crate in
   name_with_generics_to_simple_name mctx ~prefix n p g
 
-let name_with_crate_to_pattern_string (ctx : LlbcAst.crate) (n : Types.name) :
+let name_with_crate_to_pattern_string (crate : LlbcAst.crate) (n : Types.name) :
     string =
-  let mctx : Charon.NameMatcher.ctx =
-    {
-      type_decls = ctx.type_decls;
-      global_decls = ctx.global_decls;
-      fun_decls = ctx.fun_decls;
-      trait_decls = ctx.trait_decls;
-      trait_impls = ctx.trait_impls;
-    }
-  in
+  let mctx = Charon.NameMatcher.ctx_from_crate crate in
   let c : Charon.NameMatcher.to_pat_config =
     { tgt = TkPattern; use_trait_decl_refs = match_with_trait_decl_refs }
   in
   let pat = Charon.NameMatcher.name_to_pattern mctx c n in
   Charon.NameMatcher.pattern_to_string { tgt = TkPattern } pat
 
-let name_with_generics_crate_to_pattern_string (ctx : LlbcAst.crate)
+let name_with_generics_crate_to_pattern_string (crate : LlbcAst.crate)
     (n : Types.name) (params : Types.generic_params) (args : Types.generic_args)
     : string =
-  let mctx : Charon.NameMatcher.ctx =
-    {
-      type_decls = ctx.type_decls;
-      global_decls = ctx.global_decls;
-      fun_decls = ctx.fun_decls;
-      trait_decls = ctx.trait_decls;
-      trait_impls = ctx.trait_impls;
-    }
-  in
+  let mctx = Charon.NameMatcher.ctx_from_crate crate in
   let c : Charon.NameMatcher.to_pat_config =
     { tgt = TkPattern; use_trait_decl_refs = match_with_trait_decl_refs }
   in
@@ -114,15 +64,7 @@ let name_with_generics_crate_to_pattern_string (ctx : LlbcAst.crate)
   Charon.NameMatcher.pattern_to_string { tgt = TkPattern } pat
 
 let name_to_pattern_string (ctx : trans_ctx) (n : Types.name) : string =
-  let mctx : Charon.NameMatcher.ctx =
-    {
-      type_decls = ctx.type_ctx.type_decls;
-      global_decls = ctx.global_ctx.global_decls;
-      fun_decls = ctx.fun_ctx.fun_decls;
-      trait_decls = ctx.trait_decls_ctx.trait_decls;
-      trait_impls = ctx.trait_impls_ctx.trait_impls;
-    }
-  in
+  let mctx = Charon.NameMatcher.ctx_from_crate ctx.crate in
   let c : Charon.NameMatcher.to_pat_config =
     { tgt = TkPattern; use_trait_decl_refs = match_with_trait_decl_refs }
   in
@@ -131,15 +73,7 @@ let name_to_pattern_string (ctx : trans_ctx) (n : Types.name) : string =
 
 let name_with_generics_to_pattern_string (ctx : trans_ctx) (n : Types.name)
     (params : Types.generic_params) (args : Types.generic_args) : string =
-  let mctx : Charon.NameMatcher.ctx =
-    {
-      type_decls = ctx.type_ctx.type_decls;
-      global_decls = ctx.global_ctx.global_decls;
-      fun_decls = ctx.fun_ctx.fun_decls;
-      trait_decls = ctx.trait_decls_ctx.trait_decls;
-      trait_impls = ctx.trait_impls_ctx.trait_impls;
-    }
-  in
+  let mctx = Charon.NameMatcher.ctx_from_crate ctx.crate in
   let c : Charon.NameMatcher.to_pat_config =
     { tgt = TkPattern; use_trait_decl_refs = match_with_trait_decl_refs }
   in

--- a/src/interp/Interpreter.ml
+++ b/src/interp/Interpreter.ml
@@ -15,27 +15,14 @@ module SA = SymbolicAst
 (** The local logger *)
 let log = Logging.interpreter_log
 
-let compute_contexts (m : crate) : decls_ctx =
-  let type_decls_list, _, _, _, _, _ = split_declarations m.declarations in
-  let type_decls = m.type_decls in
-  let fun_decls = m.fun_decls in
-  let global_decls = m.global_decls in
-  let trait_decls = m.trait_decls in
-  let trait_impls = m.trait_impls in
+let compute_contexts (crate : crate) : decls_ctx =
+  let type_decls_list, _, _, _, _, _ = split_declarations crate.declarations in
   let fmt_env : Print.fmt_env =
-    {
-      type_decls;
-      fun_decls;
-      global_decls;
-      trait_decls;
-      trait_impls;
-      generics = [];
-      locals = [];
-    }
+    Charon.PrintLlbcAst.Crate.crate_to_fmt_env crate
   in
   (* Split the declaration groups between the declaration kinds (types, functions, etc.) *)
   let type_decls_groups, _, _, _, _, mixed_groups =
-    split_declarations_to_group_maps m.declarations
+    split_declarations_to_group_maps crate.declarations
   in
   (* Check if there are mixed groups: if there are, we report an error
      and ignore those *)
@@ -43,7 +30,7 @@ let compute_contexts (m : crate) : decls_ctx =
      (* We detected mixed groups: print a nice error message *)
      let any_decl_id_to_string (id : any_decl_id) : string =
        let kind = any_decl_id_to_kind_name id in
-       let meta = LlbcAstUtils.crate_get_item_meta m id in
+       let meta = LlbcAstUtils.crate_get_item_meta crate id in
        let s =
          match meta with
          | None -> show_any_decl_id id
@@ -57,7 +44,7 @@ let compute_contexts (m : crate) : decls_ctx =
        let ids = g_declaration_group_to_list g in
        let decls = List.map any_decl_id_to_string ids in
        let local_requires =
-         LlbcAstUtils.find_local_transitive_dep m (AnyDeclIdSet.of_list ids)
+         LlbcAstUtils.find_local_transitive_dep crate (AnyDeclIdSet.of_list ids)
        in
        let local_requires = List.map span_to_string local_requires in
        let local_requires =
@@ -79,20 +66,22 @@ let compute_contexts (m : crate) : decls_ctx =
          type mutually recursive with a function, or a function mutually \
          recursive with a trait implementation):\n\n" ^ msgs));
 
+  let type_decls = crate.type_decls in
   let type_infos =
     TypesAnalysis.analyze_type_declarations type_decls type_decls_list
   in
   let type_ctx = { type_decls_groups; type_decls; type_infos } in
-  let fun_infos = FunsAnalysis.analyze_module m fun_decls !Config.use_state in
+
+  let fun_decls = crate.fun_decls in
+  let fun_infos =
+    FunsAnalysis.analyze_module crate fun_decls !Config.use_state
+  in
   let regions_hierarchies =
-    RegionsHierarchy.compute_regions_hierarchies type_decls fun_decls
-      global_decls trait_decls trait_impls
+    RegionsHierarchy.compute_regions_hierarchies crate
   in
   let fun_ctx = { fun_decls; fun_infos; regions_hierarchies } in
-  let global_ctx = { global_decls } in
-  let trait_decls_ctx = { trait_decls } in
-  let trait_impls_ctx = { trait_impls } in
-  { type_ctx; fun_ctx; global_ctx; trait_decls_ctx; trait_impls_ctx }
+
+  { crate; type_ctx; fun_ctx }
 
 (** Small helper.
 

--- a/src/interp/InterpreterLoopsJoinCtxs.ml
+++ b/src/interp/InterpreterLoopsJoinCtxs.ml
@@ -820,10 +820,8 @@ let join_ctxs (span : Meta.span) (loop_id : LoopId.id) (fixed_ids : ids_sets)
      * should be the same in the two contexts *)
     let {
       type_ctx;
+      crate;
       fun_ctx;
-      global_ctx;
-      trait_decls_ctx;
-      trait_impls_ctx;
       region_groups;
       type_vars;
       const_generic_vars;
@@ -836,10 +834,8 @@ let join_ctxs (span : Meta.span) (loop_id : LoopId.id) (fixed_ids : ids_sets)
     in
     let {
       type_ctx = _;
+      crate = _;
       fun_ctx = _;
-      global_ctx = _;
-      trait_decls_ctx = _;
-      trait_impls_ctx = _;
       region_groups = _;
       type_vars = _;
       const_generic_vars = _;
@@ -853,11 +849,9 @@ let join_ctxs (span : Meta.span) (loop_id : LoopId.id) (fixed_ids : ids_sets)
     let ended_regions = RegionId.Set.union ended_regions0 ended_regions1 in
     Ok
       {
+        crate;
         type_ctx;
         fun_ctx;
-        global_ctx;
-        trait_decls_ctx;
-        trait_impls_ctx;
         region_groups;
         type_vars;
         const_generic_vars;

--- a/src/interp/InterpreterStatements.ml
+++ b/src/interp/InterpreterStatements.ml
@@ -1542,9 +1542,7 @@ and eval_builtin_function_call_symbolic (config : config) (span : Meta.span)
        we have to recompute the regions hierarchy. *)
     let fun_name = Print.Expressions.builtin_fun_id_to_string fid in
     let inst_sig =
-      compute_regions_hierarchy_for_fun_call (Some span) ctx.type_ctx.type_decls
-        ctx.fun_ctx.fun_decls ctx.global_ctx.global_decls
-        ctx.trait_decls_ctx.trait_decls ctx.trait_impls_ctx.trait_impls fun_name
+      compute_regions_hierarchy_for_fun_call (Some span) ctx.crate fun_name
         ctx.type_vars ctx.const_generic_vars func.generics sg
     in
     log#ldebug

--- a/src/interp/InterpreterUtils.ml
+++ b/src/interp/InterpreterUtils.ml
@@ -488,11 +488,9 @@ let initialize_eval_ctx (span : Meta.span option) (ctx : decls_ctx)
          const_generic_vars)
   in
   {
+    crate = ctx.crate;
     type_ctx = ctx.type_ctx;
     fun_ctx = ctx.fun_ctx;
-    global_ctx = ctx.global_ctx;
-    trait_decls_ctx = ctx.trait_decls_ctx;
-    trait_impls_ctx = ctx.trait_impls_ctx;
     region_groups;
     type_vars;
     const_generic_vars;
@@ -570,13 +568,9 @@ let instantiate_fun_sig (span : Meta.span) (ctx : eval_ctx)
       instance, the region outlives constraints)
   *)
 let compute_regions_hierarchy_for_fun_call (span : Meta.span option)
-    (type_decls : type_decl TypeDeclId.Map.t)
-    (fun_decls : fun_decl FunDeclId.Map.t)
-    (global_decls : global_decl GlobalDeclId.Map.t)
-    (trait_decls : trait_decl TraitDeclId.Map.t)
-    (trait_impls : trait_impl TraitImplId.Map.t) (fun_name : string)
-    (type_vars : type_var list) (const_generic_vars : const_generic_var list)
-    (generic_args : generic_args) (sg : fun_sig) : inst_fun_sig =
+    (crate : crate) (fun_name : string) (type_vars : type_var list)
+    (const_generic_vars : const_generic_var list) (generic_args : generic_args)
+    (sg : fun_sig) : inst_fun_sig =
   (* We simply put everything into a "fake" signature, then call
      [compute_regions_hierarchy_for_sig].
 
@@ -704,8 +698,7 @@ let compute_regions_hierarchy_for_fun_call (span : Meta.span option)
       { is_unsafe; is_closure; closure_info; generics; inputs; output }
     in
     let regions_hierarchy =
-      RegionsHierarchy.compute_regions_hierarchy_for_sig span type_decls
-        fun_decls global_decls trait_decls trait_impls fun_name sg
+      RegionsHierarchy.compute_regions_hierarchy_for_sig span crate fun_name sg
     in
     (generics.trait_type_constraints, regions_hierarchy)
   in

--- a/src/llbc/AssociatedTypes.ml
+++ b/src/llbc/AssociatedTypes.ml
@@ -108,22 +108,14 @@ let rec trait_instance_id_is_local_clause (id : trait_instance_id) : bool =
 type norm_ctx = {
   span : Meta.span option;
   norm_trait_types : ty TraitTypeRefMap.t;
-  type_decls : type_decl TypeDeclId.Map.t;
-  fun_decls : fun_decl FunDeclId.Map.t;
-  global_decls : global_decl GlobalDeclId.Map.t;
-  trait_decls : trait_decl TraitDeclId.Map.t;
-  trait_impls : trait_impl TraitImplId.Map.t;
+  crate : crate;
   type_vars : type_var list;
   const_generic_vars : const_generic_var list;
 }
 
 let norm_ctx_to_fmt_env (ctx : norm_ctx) : Print.fmt_env =
   {
-    type_decls = ctx.type_decls;
-    fun_decls = ctx.fun_decls;
-    global_decls = ctx.global_decls;
-    trait_decls = ctx.trait_decls;
-    trait_impls = ctx.trait_impls;
+    crate = ctx.crate;
     generics =
       [
         {
@@ -171,7 +163,7 @@ let generic_params_to_string (ctx : norm_ctx) (x : generic_params) : string =
 let norm_ctx_lookup_trait_impl (ctx : norm_ctx) (impl_id : TraitImplId.id)
     (generics : generic_args) : trait_impl * subst =
   (* Lookup the implementation *)
-  let trait_impl = TraitImplId.Map.find impl_id ctx.trait_impls in
+  let trait_impl = TraitImplId.Map.find impl_id ctx.crate.trait_impls in
   (* The substitution *)
   let tr_self = UnknownTrait __FUNCTION__ in
   let subst = make_subst_from_generics trait_impl.generics generics tr_self in
@@ -424,12 +416,8 @@ let norm_ctx_normalize_trait_type_constraint (ctx : norm_ctx)
 let mk_norm_ctx (span : Meta.span option) (ctx : eval_ctx) : norm_ctx =
   {
     span;
+    crate = ctx.crate;
     norm_trait_types = ctx.norm_trait_types;
-    type_decls = ctx.type_ctx.type_decls;
-    fun_decls = ctx.fun_ctx.fun_decls;
-    global_decls = ctx.global_ctx.global_decls;
-    trait_decls = ctx.trait_decls_ctx.trait_decls;
-    trait_impls = ctx.trait_impls_ctx.trait_impls;
     type_vars = ctx.type_vars;
     const_generic_vars = ctx.const_generic_vars;
   }

--- a/src/llbc/FunsAnalysis.ml
+++ b/src/llbc/FunsAnalysis.ml
@@ -59,13 +59,7 @@ let analyze_module (m : crate) (funs_map : fun_decl FunDeclId.Map.t)
     let is_rec = ref false in
     let group_has_builtin_info = ref false in
     let name_matcher_ctx : Charon.NameMatcher.ctx =
-      {
-        type_decls = m.type_decls;
-        global_decls = m.global_decls;
-        fun_decls = m.fun_decls;
-        trait_decls = m.trait_decls;
-        trait_impls = m.trait_impls;
-      }
+      Charon.NameMatcher.ctx_from_crate m
     in
 
     (* We have some specialized knowledge of some library functions; we don't

--- a/src/llbc/LlbcAstUtils.ml
+++ b/src/llbc/LlbcAstUtils.ml
@@ -31,15 +31,7 @@ let lookup_fun_sig (fun_id : fun_id) (fun_decls : fun_decl FunDeclId.Map.t) :
 let crate_get_opaque_non_builtin_decls (k : crate) (filter_builtin : bool) :
     type_decl list * fun_decl list =
   let open ExtractBuiltin in
-  let ctx : Charon.NameMatcher.ctx =
-    {
-      type_decls = k.type_decls;
-      global_decls = k.global_decls;
-      fun_decls = k.fun_decls;
-      trait_decls = k.trait_decls;
-      trait_impls = k.trait_impls;
-    }
-  in
+  let ctx : Charon.NameMatcher.ctx = Charon.NameMatcher.ctx_from_crate k in
   let is_opaque_fun (d : fun_decl) : bool =
     d.body = None
     (* Something to pay attention to: we must ignore trait method *declarations*

--- a/src/llbc/Print.ml
+++ b/src/llbc/Print.ml
@@ -440,27 +440,9 @@ module Contexts = struct
     ^ "\n}"
 
   let decls_ctx_to_fmt_env (ctx : decls_ctx) : fmt_env =
-    let type_decls = ctx.type_ctx.type_decls in
-    let fun_decls = ctx.fun_ctx.fun_decls in
-    let global_decls = ctx.global_ctx.global_decls in
-    let trait_decls = ctx.trait_decls_ctx.trait_decls in
-    let trait_impls = ctx.trait_impls_ctx.trait_impls in
-    {
-      type_decls;
-      fun_decls;
-      global_decls;
-      trait_decls;
-      trait_impls;
-      generics = [];
-      locals = [];
-    }
+    Crate.crate_to_fmt_env ctx.crate
 
   let eval_ctx_to_fmt_env (ctx : eval_ctx) : fmt_env =
-    let type_decls = ctx.type_ctx.type_decls in
-    let fun_decls = ctx.fun_ctx.fun_decls in
-    let global_decls = ctx.global_ctx.global_decls in
-    let trait_decls = ctx.trait_decls_ctx.trait_decls in
-    let trait_impls = ctx.trait_impls_ctx.trait_impls in
     (* Below: it is always safe to omit fields - if an id can't be found at
        printing time, we print the id (in raw form) instead of the name it
        designates. *)
@@ -476,11 +458,7 @@ module Contexts = struct
     in
     let locals = env_to_locals ctx.env in
     {
-      type_decls;
-      fun_decls;
-      global_decls;
-      trait_decls;
-      trait_impls;
+      crate = ctx.crate;
       generics =
         [
           {

--- a/src/pure/PrintPure.ml
+++ b/src/pure/PrintPure.ml
@@ -10,11 +10,7 @@ open Errors
     at every stage we have the original LLBC definitions at hand.
  *)
 type fmt_env = {
-  type_decls : Types.type_decl TypeDeclId.Map.t;
-  fun_decls : LlbcAst.fun_decl FunDeclId.Map.t;
-  global_decls : LlbcAst.global_decl GlobalDeclId.Map.t;
-  trait_decls : LlbcAst.trait_decl TraitDeclId.Map.t;
-  trait_impls : LlbcAst.trait_impl TraitImplId.Map.t;
+  crate : LlbcAst.crate;
   generics : generic_params;
   vars : string VarId.Map.t;
 }
@@ -57,26 +53,10 @@ let var_id_to_string (env : fmt_env) (id : VarId.id) : string =
 let trait_clause_id_to_string = Print.Types.trait_clause_id_to_string
 
 let fmt_env_to_llbc_fmt_env (env : fmt_env) : Print.fmt_env =
-  {
-    type_decls = env.type_decls;
-    fun_decls = env.fun_decls;
-    global_decls = env.global_decls;
-    trait_decls = env.trait_decls;
-    trait_impls = env.trait_impls;
-    generics = [];
-    locals = [];
-  }
+  Charon.PrintLlbcAst.Crate.crate_to_fmt_env env.crate
 
 let decls_ctx_to_fmt_env (ctx : Contexts.decls_ctx) : fmt_env =
-  {
-    type_decls = ctx.type_ctx.type_decls;
-    fun_decls = ctx.fun_ctx.fun_decls;
-    global_decls = ctx.global_ctx.global_decls;
-    trait_decls = ctx.trait_decls_ctx.trait_decls;
-    trait_impls = ctx.trait_impls_ctx.trait_impls;
-    generics = empty_generic_params;
-    vars = VarId.Map.empty;
-  }
+  { crate = ctx.crate; generics = empty_generic_params; vars = VarId.Map.empty }
 
 let name_to_string (env : fmt_env) =
   Print.Types.name_to_string (fmt_env_to_llbc_fmt_env env)

--- a/tests/src/mutually-recursive-traits.lean.out
+++ b/tests/src/mutually-recursive-traits.lean.out
@@ -1,17 +1,17 @@
 [[92mInfo[39m ] Imported: tests/llbc/mutually_recursive_traits.llbc
-[[91mError[39m] In file Translate.ml, line 863:
+[[91mError[39m] In file Translate.ml, line 857:
 Mutually recursive trait declarations are not supported
 
 Uncaught exception:
   
   (Failure
-    "In file Translate.ml, line 863:\
+    "In file Translate.ml, line 857:\
    \nMutually recursive trait declarations are not supported")
 
 Raised at Aeneas__Errors.craise_opt_span in file "Errors.ml", line 72, characters 4-23
-Called from Aeneas__Translate.extract_definitions.export_decl_group in file "Translate.ml", line 863, characters 8-114
+Called from Aeneas__Translate.extract_definitions.export_decl_group in file "Translate.ml", line 857, characters 8-114
 Called from Stdlib__List.iter in file "list.ml", line 110, characters 12-15
-Called from Aeneas__Translate.extract_definitions in file "Translate.ml", line 892, characters 2-177
-Called from Aeneas__Translate.extract_file in file "Translate.ml", line 1024, characters 2-36
-Called from Aeneas__Translate.translate_crate in file "Translate.ml", line 1658, characters 5-42
-Called from Dune__exe__Main in file "Main.ml", line 511, characters 11-63
+Called from Aeneas__Translate.extract_definitions in file "Translate.ml", line 886, characters 2-177
+Called from Aeneas__Translate.extract_file in file "Translate.ml", line 1018, characters 2-36
+Called from Aeneas__Translate.translate_crate in file "Translate.ml", line 1652, characters 5-42
+Called from Dune__exe__Main in file "Main.ml", line 493, characters 11-63


### PR DESCRIPTION
This uses `crate` in several places where 5 separate maps of items were used previously. This also uses helper functions to create environments when they exist instead of creating them by hand.

This is the companion PR to https://github.com/AeneasVerif/charon/pull/509.