### PR TITLE
Bind methods in pure

### DIFF
--- a/src/extract/ExtractBase.ml
+++ b/src/extract/ExtractBase.ml
@@ -113,8 +113,18 @@ let decl_is_not_last_from_group (kind : decl_kind) : bool =
 
 type type_decl_kind = Enum | Struct | Tuple [@@deriving show]
 
+(** Generics can be bound in two places: each item has its generics, and
+    additionally within a trait decl or impl each method has its own generics.
+    We distinguish these two cases here. In charon, the distinction is made
+    thanks to `de_bruijn_var`.
+    Note that for the generics of a top-level `fun_decl` we always use `Item`;
+    `Method` only refers to the inner binder found in the list of methods in a
+    trait_decl/trait_impl.
+    *)
+type generic_origin = Item | Method
+
 (** We use identifiers to look for name clashes *)
-type id =
+and id =
   | GlobalId of A.GlobalDeclId.id
   | FunId of fun_id
   | TerminationMeasureId of (A.fun_id * LoopId.id option)
@@ -162,12 +172,12 @@ type id =
           must be unique (it is the case in F* ) which is why we register
           them here.
        *)
-  | TypeVarId of TypeVarId.id
-  | ConstGenericVarId of ConstGenericVarId.id
   | VarId of VarId.id
   | TraitDeclId of TraitDeclId.id
   | TraitImplId of TraitImplId.id
-  | LocalTraitClauseId of TraitClauseId.id
+  | TypeVarId of generic_origin * TypeVarId.id
+  | ConstGenericVarId of generic_origin * ConstGenericVarId.id
+  | LocalTraitClauseId of generic_origin * TraitClauseId.id
   | TraitDeclConstructorId of TraitDeclId.id
   | TraitMethodId of TraitDeclId.id * string
   | TraitItemId of TraitDeclId.id * string
@@ -674,14 +684,19 @@ let id_to_string (span : Meta.span option) (id : id) (ctx : extraction_ctx) :
       let field_name = adt_field_to_string span ctx id field_id in
       "type name: " ^ type_name ^ ", field name: " ^ field_name
   | UnknownId -> "keyword"
-  | TypeVarId id -> "type_var_id: " ^ TypeVarId.to_string id
-  | ConstGenericVarId id ->
-      "const_generic_var_id: " ^ ConstGenericVarId.to_string id
   | VarId id -> "var_id: " ^ VarId.to_string id
   | TraitDeclId id -> "trait_decl_id: " ^ TraitDeclId.to_string id
   | TraitImplId id -> "trait_impl_id: " ^ TraitImplId.to_string id
-  | LocalTraitClauseId id ->
-      "local_trait_clause_id: " ^ TraitClauseId.to_string id
+  | TypeVarId (origin, id) ->
+      "type_var_id: " ^ TypeVarId.to_string id ^ " from "
+      ^ show_generic_origin origin
+  | ConstGenericVarId (origin, id) ->
+      "const_generic_var_id: "
+      ^ ConstGenericVarId.to_string id
+      ^ " from " ^ show_generic_origin origin
+  | LocalTraitClauseId (origin, id) ->
+      "local_trait_clause_id: " ^ TraitClauseId.to_string id ^ " from "
+      ^ show_generic_origin origin
   | TraitDeclConstructorId id ->
       "trait_decl_constructor: " ^ trait_decl_id_to_string id
   | TraitParentClauseId (id, clause_id) ->
@@ -771,17 +786,32 @@ let ctx_get_var (span : Meta.span) (id : VarId.id) (ctx : extraction_ctx) :
     string =
   ctx_get (Some span) (VarId id) ctx
 
-let ctx_get_type_var (span : Meta.span) (id : TypeVarId.id)
-    (ctx : extraction_ctx) : string =
-  ctx_get (Some span) (TypeVarId id) ctx
+(** This warrants explanations. Charon supports several levels of nested
+  binders; however there are currently only two cases where we bind
+  non-lifetime variables: at the top-level of each item, and for each method
+  inside a trait_decl/trait_impl. Moreover, we use `Free` vars to identify
+  item-bound vars. This means that we can identify which binder a variable
+  comes from without rigorously tracking binder levels, which is what this
+  function does.
+  Note that the `de_bruijn_id`s are wrong anyway because we kept charon's
+  binding levels but forgot all the region binders.
+  *)
+let origin_from_de_bruijn_var (var : 'a de_bruijn_var) : generic_origin * 'a =
+  match var with
+  | Bound (_, id) -> (Method, id)
+  | Free id -> (Item, id)
 
-let ctx_get_const_generic_var (span : Meta.span) (id : ConstGenericVarId.id)
-    (ctx : extraction_ctx) : string =
-  ctx_get (Some span) (ConstGenericVarId id) ctx
+let ctx_get_type_var (span : Meta.span) (origin : generic_origin)
+    (id : TypeVarId.id) (ctx : extraction_ctx) : string =
+  ctx_get (Some span) (TypeVarId (origin, id)) ctx
 
-let ctx_get_local_trait_clause (span : Meta.span) (id : TraitClauseId.id)
-    (ctx : extraction_ctx) : string =
-  ctx_get (Some span) (LocalTraitClauseId id) ctx
+let ctx_get_const_generic_var (span : Meta.span) (origin : generic_origin)
+    (id : ConstGenericVarId.id) (ctx : extraction_ctx) : string =
+  ctx_get (Some span) (ConstGenericVarId (origin, id)) ctx
+
+let ctx_get_local_trait_clause (span : Meta.span) (origin : generic_origin)
+    (id : TraitClauseId.id) (ctx : extraction_ctx) : string =
+  ctx_get (Some span) (LocalTraitClauseId (origin, id)) ctx
 
 let ctx_get_field (span : Meta.span) (type_id : type_id) (field_id : FieldId.id)
     (ctx : extraction_ctx) : string =
@@ -1956,27 +1986,29 @@ let basename_to_unique (ctx : extraction_ctx) (name : string) =
   basename_to_unique_aux collision name_append_index name
 
 (** Generate a unique type variable name and add it to the context *)
-let ctx_add_type_var (span : Meta.span) (basename : string) (id : TypeVarId.id)
-    (ctx : extraction_ctx) : extraction_ctx * string =
+let ctx_add_type_var (span : Meta.span) (origin : generic_origin)
+    (basename : string) (id : TypeVarId.id) (ctx : extraction_ctx) :
+    extraction_ctx * string =
   let name = ctx_compute_type_var_basename ctx basename in
   let name = basename_to_unique ctx name in
-  let ctx = ctx_add span (TypeVarId id) name ctx in
+  let ctx = ctx_add span (TypeVarId (origin, id)) name ctx in
   (ctx, name)
 
 (** Generate a unique const generic variable name and add it to the context *)
-let ctx_add_const_generic_var (span : Meta.span) (basename : string)
-    (id : ConstGenericVarId.id) (ctx : extraction_ctx) : extraction_ctx * string
-    =
+let ctx_add_const_generic_var (span : Meta.span) (origin : generic_origin)
+    (basename : string) (id : ConstGenericVarId.id) (ctx : extraction_ctx) :
+    extraction_ctx * string =
   let name = ctx_compute_const_generic_var_basename ctx basename in
   let name = basename_to_unique ctx name in
-  let ctx = ctx_add span (ConstGenericVarId id) name ctx in
+  let ctx = ctx_add span (ConstGenericVarId (origin, id)) name ctx in
   (ctx, name)
 
 (** See {!ctx_add_type_var} *)
-let ctx_add_type_vars (span : Meta.span) (vars : (string * TypeVarId.id) list)
-    (ctx : extraction_ctx) : extraction_ctx * string list =
+let ctx_add_type_vars (span : Meta.span) (origin : generic_origin)
+    (vars : (string * TypeVarId.id) list) (ctx : extraction_ctx) :
+    extraction_ctx * string list =
   List.fold_left_map
-    (fun ctx (name, id) -> ctx_add_type_var span name id ctx)
+    (fun ctx (name, id) -> ctx_add_type_var span origin name id ctx)
     ctx vars
 
 (** Generate a unique variable name and add it to the context *)
@@ -1995,10 +2027,11 @@ let ctx_add_trait_self_clause (span : Meta.span) (ctx : extraction_ctx) :
   (ctx, name)
 
 (** Generate a unique trait clause name and add it to the context *)
-let ctx_add_local_trait_clause (span : Meta.span) (basename : string)
-    (id : TraitClauseId.id) (ctx : extraction_ctx) : extraction_ctx * string =
+let ctx_add_local_trait_clause (span : Meta.span) (origin : generic_origin)
+    (basename : string) (id : TraitClauseId.id) (ctx : extraction_ctx) :
+    extraction_ctx * string =
   let name = basename_to_unique ctx basename in
-  let ctx = ctx_add span (LocalTraitClauseId id) name ctx in
+  let ctx = ctx_add span (LocalTraitClauseId (origin, id)) name ctx in
   (ctx, name)
 
 (** See {!ctx_add_var} *)
@@ -2010,18 +2043,20 @@ let ctx_add_vars (span : Meta.span) (vars : var list) (ctx : extraction_ctx) :
       ctx_add_var span name v.id ctx)
     ctx vars
 
-let ctx_add_type_params (span : Meta.span) (vars : type_var list)
-    (ctx : extraction_ctx) : extraction_ctx * string list =
+let ctx_add_type_params (span : Meta.span) (origin : generic_origin)
+    (vars : type_var list) (ctx : extraction_ctx) : extraction_ctx * string list
+    =
   List.fold_left_map
-    (fun ctx (var : type_var) -> ctx_add_type_var span var.name var.index ctx)
+    (fun ctx (var : type_var) ->
+      ctx_add_type_var span origin var.name var.index ctx)
     ctx vars
 
-let ctx_add_const_generic_params (span : Meta.span)
+let ctx_add_const_generic_params (span : Meta.span) (origin : generic_origin)
     (vars : const_generic_var list) (ctx : extraction_ctx) :
     extraction_ctx * string list =
   List.fold_left_map
     (fun ctx (var : const_generic_var) ->
-      ctx_add_const_generic_var span var.name var.index ctx)
+      ctx_add_const_generic_var span origin var.name var.index ctx)
     ctx vars
 
 (** Returns the lists of names for:
@@ -2034,16 +2069,16 @@ let ctx_add_const_generic_params (span : Meta.span)
     for additional information.
   *)
 let ctx_add_local_trait_clauses (span : Meta.span)
-    (current_def_name : Types.name) (llbc_generics : Types.generic_params)
-    (clauses : trait_clause list) (ctx : extraction_ctx) :
-    extraction_ctx * string list =
+    (current_def_name : Types.name) (origin : generic_origin)
+    (llbc_generics : Types.generic_params) (clauses : trait_clause list)
+    (ctx : extraction_ctx) : extraction_ctx * string list =
   List.fold_left_map
     (fun ctx (c : trait_clause) ->
       let basename =
         ctx_compute_trait_clause_basename ctx current_def_name llbc_generics
           c.clause_id
       in
-      ctx_add_local_trait_clause span basename c.clause_id ctx)
+      ctx_add_local_trait_clause span origin basename c.clause_id ctx)
     ctx clauses
 
 (** Returns the lists of names for:
@@ -2056,14 +2091,14 @@ let ctx_add_local_trait_clauses (span : Meta.span)
     for additional information.
   *)
 let ctx_add_generic_params (span : Meta.span) (current_def_name : Types.name)
-    (llbc_generics : Types.generic_params) (generics : generic_params)
-    (ctx : extraction_ctx) :
+    (origin : generic_origin) (llbc_generics : Types.generic_params)
+    (generics : generic_params) (ctx : extraction_ctx) :
     extraction_ctx * string list * string list * string list =
   let { types; const_generics; trait_clauses } = generics in
-  let ctx, tys = ctx_add_type_params span types ctx in
-  let ctx, cgs = ctx_add_const_generic_params span const_generics ctx in
+  let ctx, tys = ctx_add_type_params span origin types ctx in
+  let ctx, cgs = ctx_add_const_generic_params span origin const_generics ctx in
   let ctx, tcs =
-    ctx_add_local_trait_clauses span current_def_name llbc_generics
+    ctx_add_local_trait_clauses span current_def_name origin llbc_generics
       trait_clauses ctx
   in
   (ctx, tys, cgs, tcs)

--- a/src/extract/ExtractTypes.ml
+++ b/src/extract/ExtractTypes.ml
@@ -429,8 +429,8 @@ let extract_const_generic (span : Meta.span) (ctx : extraction_ctx)
       F.pp_print_string fmt s
   | CgValue v -> extract_literal span fmt false inside v
   | CgVar var ->
-      let id = TypesUtils.expect_free_var (Some span) var in
-      let s = ctx_get_const_generic_var span id ctx in
+      let origin, id = origin_from_de_bruijn_var var in
+      let s = ctx_get_const_generic_var span origin id ctx in
       F.pp_print_string fmt s
 
 let extract_literal_type (_ctx : extraction_ctx) (fmt : F.formatter)
@@ -583,8 +583,8 @@ let rec extract_ty (span : Meta.span) (ctx : extraction_ctx) (fmt : F.formatter)
                   (extract_trait_ref span ctx fmt no_params_tys true)
                   trait_refs)))
   | TVar var ->
-      let id = TypesUtils.expect_free_var (Some span) var in
-      F.pp_print_string fmt (ctx_get_type_var span id ctx)
+      let origin, id = origin_from_de_bruijn_var var in
+      F.pp_print_string fmt (ctx_get_type_var span origin id ctx)
   | TLiteral lty -> extract_literal_type ctx fmt lty
   | TArrow (arg_ty, ret_ty) ->
       if inside then F.pp_print_string fmt "(";
@@ -775,8 +775,8 @@ and extract_trait_instance_id (span : Meta.span) (ctx : extraction_ctx)
       extract_generic_args span ctx fmt no_params_tys ~explicit generics;
       if use_brackets then F.pp_print_string fmt ")"
   | Clause var ->
-      let id = TypesUtils.expect_free_var (Some span) var in
-      let name = ctx_get_local_trait_clause span id ctx in
+      let origin, id = origin_from_de_bruijn_var var in
+      let name = ctx_get_local_trait_clause span origin id ctx in
       F.pp_print_string fmt name
   | ParentClause (inst_id, decl_id, clause_id) ->
       (* Use the trait decl id to lookup the name *)
@@ -1298,9 +1298,10 @@ let extract_generic_params (span : Meta.span) (ctx : extraction_ctx)
     (fmt : F.formatter) (no_params_tys : TypeDeclId.Set.t) ?(use_forall = false)
     ?(use_forall_use_sep = true) ?(use_arrows = false)
     ?(as_implicits : bool = false) ?(space : bool ref option = None)
-    ?(trait_decl : trait_decl option = None) (generics : generic_params)
-    (explicit : explicit_info option) (type_params : string list)
-    (cg_params : string list) (trait_clauses : string list) : unit =
+    ?(trait_decl : trait_decl option = None) (origin : generic_origin)
+    (generics : generic_params) (explicit : explicit_info option)
+    (type_params : string list) (cg_params : string list)
+    (trait_clauses : string list) : unit =
   let all_params = List.concat [ type_params; cg_params; trait_clauses ] in
   (* HOL4 doesn't support const generics *)
   cassert __FILE__ __LINE__
@@ -1362,7 +1363,7 @@ let extract_generic_params (span : Meta.span) (ctx : extraction_ctx)
             insert_req_space ();
             (* ( *)
             left_bracket expl;
-            let n = ctx_get_const_generic_var span var.index ctx in
+            let n = ctx_get_const_generic_var span origin var.index ctx in
             print_implicit_symbol expl;
             F.pp_print_string fmt n;
             F.pp_print_space fmt ();
@@ -1381,7 +1382,7 @@ let extract_generic_params (span : Meta.span) (ctx : extraction_ctx)
           insert_req_space ();
           (* ( *)
           left_bracket expl;
-          let n = ctx_get_local_trait_clause span clause.clause_id ctx in
+          let n = ctx_get_local_trait_clause span origin clause.clause_id ctx in
           print_implicit_symbol expl;
           F.pp_print_string fmt n;
           F.pp_print_space fmt ();
@@ -1448,12 +1449,12 @@ let extract_generic_params (span : Meta.span) (ctx : extraction_ctx)
               map snd dtype_params;
               map
                 (fun ((_, cg) : _ * const_generic_var) ->
-                  ctx_get_const_generic_var trait_decl.item_meta.span cg.index
-                    ctx)
+                  ctx_get_const_generic_var trait_decl.item_meta.span origin
+                    cg.index ctx)
                 dcgs;
               map
                 (fun (_, c) ->
-                  ctx_get_local_trait_clause trait_decl.item_meta.span
+                  ctx_get_local_trait_clause trait_decl.item_meta.span origin
                     c.clause_id ctx)
                 dtrait_clauses;
             ]
@@ -1510,7 +1511,7 @@ let extract_type_decl_gen (ctx : extraction_ctx) (fmt : F.formatter)
   (* Add the type and const generic params - note that we need those bindings only for the
    * body translation (they are not top-level) *)
   let ctx_body, type_params, cg_params, trait_clauses =
-    ctx_add_generic_params def.item_meta.span def.item_meta.name
+    ctx_add_generic_params def.item_meta.span def.item_meta.name Item
       def.llbc_generics def.generics ctx
   in
   (* Add a break before *)
@@ -1556,7 +1557,7 @@ let extract_type_decl_gen (ctx : extraction_ctx) (fmt : F.formatter)
     "Constant generics and type definitions with trait clauses are not \
      supported yet when generating code for HOL4";
   (* Print the generic parameters *)
-  extract_generic_params def.item_meta.span ctx_body fmt type_decl_group
+  extract_generic_params def.item_meta.span ctx_body fmt type_decl_group Item
     ~use_forall def.generics (Some def.explicit_info) type_params cg_params
     trait_clauses;
   (* Print the "=" if we extract the body*)
@@ -1798,7 +1799,7 @@ let extract_type_decl_record_field_projectors (ctx : extraction_ctx)
       if is_rec then
         (* Add the type params *)
         let ctx, type_params, cg_params, trait_clauses =
-          ctx_add_generic_params decl.item_meta.span decl.item_meta.name
+          ctx_add_generic_params decl.item_meta.span decl.item_meta.name Item
             decl.llbc_generics decl.generics ctx
         in
         (* Record_var will be the ADT argument to the projector *)
@@ -1858,8 +1859,8 @@ let extract_type_decl_record_field_projectors (ctx : extraction_ctx)
           (* Print the generics *)
           let as_implicits = true in
           extract_generic_params decl.item_meta.span ctx fmt
-            TypeDeclId.Set.empty ~as_implicits decl.generics None type_params
-            cg_params trait_clauses;
+            TypeDeclId.Set.empty Item ~as_implicits decl.generics None
+            type_params cg_params trait_clauses;
 
           (* Print the record parameter as "(x : ADT)" *)
           F.pp_print_space fmt ();
@@ -1999,8 +2000,8 @@ let extract_type_decl_record_field_projectors_simp_lemmas (ctx : extraction_ctx)
       if is_rec then
         (* Add the type params *)
         let ctx, type_params, cg_params, trait_clauses =
-          ctx_add_generic_params span decl.item_meta.name decl.llbc_generics
-            decl.generics ctx
+          ctx_add_generic_params span decl.item_meta.name Item
+            decl.llbc_generics decl.generics ctx
         in
         (* Name of the ADT *)
         let def_name = ctx_get_local_type span decl.def_id ctx in
@@ -2045,7 +2046,7 @@ let extract_type_decl_record_field_projectors_simp_lemmas (ctx : extraction_ctx)
           (* Print the generics *)
           let as_implicits = true in
           extract_generic_params span ctx fmt TypeDeclId.Set.empty ~as_implicits
-            decl.generics None type_params cg_params trait_clauses;
+            Item decl.generics None type_params cg_params trait_clauses;
 
           (* Print the input parameters (the fields) *)
           let print_field (ctx : extraction_ctx) (field_id : FieldId.id)

--- a/src/extract/ExtractTypes.ml
+++ b/src/extract/ExtractTypes.ml
@@ -582,7 +582,9 @@ let rec extract_ty (span : Meta.span) (ctx : extraction_ctx) (fmt : F.formatter)
                 Collections.List.iter_link (F.pp_print_space fmt)
                   (extract_trait_ref span ctx fmt no_params_tys true)
                   trait_refs)))
-  | TVar vid -> F.pp_print_string fmt (ctx_get_type_var span vid ctx)
+  | TVar var ->
+      let id = TypesUtils.expect_free_var (Some span) var in
+      F.pp_print_string fmt (ctx_get_type_var span id ctx)
   | TLiteral lty -> extract_literal_type ctx fmt lty
   | TArrow (arg_ty, ret_ty) ->
       if inside then F.pp_print_string fmt "(";
@@ -772,7 +774,8 @@ and extract_trait_instance_id (span : Meta.span) (ctx : extraction_ctx)
       F.pp_print_string fmt name;
       extract_generic_args span ctx fmt no_params_tys ~explicit generics;
       if use_brackets then F.pp_print_string fmt ")"
-  | Clause id ->
+  | Clause var ->
+      let id = TypesUtils.expect_free_var (Some span) var in
       let name = ctx_get_local_trait_clause span id ctx in
       F.pp_print_string fmt name
   | ParentClause (inst_id, decl_id, clause_id) ->

--- a/src/pure/Pure.ml
+++ b/src/pure/Pure.ml
@@ -47,7 +47,6 @@ type trait_clause_id = T.trait_clause_id [@@deriving show, ord]
 type trait_item_name = T.trait_item_name [@@deriving show, ord]
 type global_decl_id = T.global_decl_id [@@deriving show, ord]
 type fun_decl_id = A.fun_decl_id [@@deriving show, ord]
-type fun_decl_ref = T.fun_decl_ref [@@deriving show, ord]
 type loop_id = LoopId.id [@@deriving show, ord]
 type region_group_id = T.region_group_id [@@deriving show, ord]
 type mutability = Mut | Const [@@deriving show, ord]
@@ -56,7 +55,6 @@ type file_name = Meta.file_name [@@deriving show, ord]
 type raw_span = Meta.raw_span [@@deriving show, ord]
 type span = Meta.span [@@deriving show, ord]
 type ref_kind = Types.ref_kind [@@deriving show, ord]
-type 'a binder = 'a Types.binder [@@deriving show, ord]
 type 'a de_bruijn_var = 'a Types.de_bruijn_var [@@deriving show, ord]
 
 (** The builtin types for the pure AST.
@@ -258,6 +256,11 @@ type ty =
 and trait_ref = {
   trait_id : trait_instance_id;
   trait_decl_ref : trait_decl_ref;
+}
+
+and fun_decl_ref = {
+  fun_id : fun_decl_id;
+  fun_generics : generic_args; (* The name: annoying field collisions... *)
 }
 
 and trait_decl_ref = {
@@ -1273,6 +1276,20 @@ type backend_attributes = {
   reducible : bool;  (** Lean "reducible" attribute *)
 }
 [@@deriving show]
+
+(** A value of type `T` bound by generic parameters. Used in any context where
+    we're adding generic parameters that aren't on the top-level item, e.g.
+    trait methods.
+ *)
+type 'a binder = {
+  binder_value : 'a;
+  binder_generics : generic_params;
+  binder_preds : predicates;
+  binder_llbc_generics : Types.generic_params;
+  binder_explicit_info : explicit_info;
+      (** Information about which inputs parameters are explicit/implicit *)
+}
+[@@deriving show, ord]
 
 type fun_decl = {
   def_id : FunDeclId.id;

--- a/src/pure/Pure.ml
+++ b/src/pure/Pure.ml
@@ -57,6 +57,7 @@ type raw_span = Meta.raw_span [@@deriving show, ord]
 type span = Meta.span [@@deriving show, ord]
 type ref_kind = Types.ref_kind [@@deriving show, ord]
 type 'a binder = 'a Types.binder [@@deriving show, ord]
+type 'a de_bruijn_var = 'a Types.de_bruijn_var [@@deriving show, ord]
 
 (** The builtin types for the pure AST.
 
@@ -246,7 +247,8 @@ type ty =
           be able to only give back part of the ADT. We need a way to encode
           such "partial" ADTs.
        *)
-  | TVar of type_var_id
+  | TVar of type_var_id de_bruijn_var
+    (* Note: the `de_bruijn_id`s are incorrect, see comment on `translate_region_binder` *)
   | TLiteral of literal_type
   | TArrow of ty * ty
   | TTraitType of trait_ref * string
@@ -277,7 +279,8 @@ and generic_args = {
 and trait_instance_id =
   | Self
   | TraitImpl of trait_impl_id * generic_args
-  | Clause of trait_clause_id
+  | Clause of trait_clause_id de_bruijn_var
+    (* Note: the `de_bruijn_id`s are incorrect, see comment on `translate_region_binder` *)
   | ParentClause of trait_instance_id * trait_decl_id * trait_clause_id
   | UnknownTrait of string
 [@@deriving

--- a/src/pure/PureUtils.ml
+++ b/src/pure/PureUtils.ml
@@ -158,12 +158,16 @@ let ty_substitute (subst : subst) (ty : ty) : ty =
   let obj =
     object
       inherit [_] map_ty
-      method! visit_TVar _ var_id = subst.ty_subst var_id
+
+      method! visit_TVar _ var =
+        subst.ty_subst (Substitute.expect_free_var None var)
 
       method! visit_CgVar _ var =
         subst.cg_subst (Substitute.expect_free_var None var)
 
-      method! visit_Clause _ id = subst.tr_subst id
+      method! visit_Clause _ var =
+        subst.tr_subst (Substitute.expect_free_var None var)
+
       method! visit_Self _ = subst.tr_self
     end
   in

--- a/src/symbolic/SymbolicToPure.ml
+++ b/src/symbolic/SymbolicToPure.ml
@@ -352,7 +352,7 @@ let bs_ctx_to_fmt_env (ctx : bs_ctx) : Print.fmt_env =
 let bs_ctx_to_pure_fmt_env (ctx : bs_ctx) : PrintPure.fmt_env =
   {
     crate = ctx.decls_ctx.crate;
-    generics = ctx.sg.generics;
+    generics = [ ctx.sg.generics ];
     vars = VarId.Map.empty;
   }
 
@@ -441,7 +441,10 @@ let bs_ctx_lookup_llbc_fun_decl (id : A.FunDeclId.id) (ctx : bs_ctx) :
 let bs_ctx_lookup_type_decl (id : TypeDeclId.id) (ctx : bs_ctx) : type_decl =
   TypeDeclId.Map.find id ctx.type_ctx.type_decls
 
-(* We simply ignore the bound regions *)
+(* We simply ignore the bound regions. Note that this messes up the de bruijn
+   ids in variables: variables inside `rb.binder_value` are nested deeper so
+   we should shift them before moving them out of their binder. We ignore this
+   because we don't yet handle complex binding situations in Aeneas. *)
 let translate_region_binder (translate_value : 'a -> 'b)
     (rb : 'a T.region_binder) : 'b =
   translate_value rb.binder_value
@@ -496,7 +499,9 @@ and translate_trait_instance_id (span : Meta.span option)
   | BuiltinOrAuto _ ->
       (* We should have eliminated those in the prepasses *)
       craise_opt_span __FILE__ __LINE__ span "Unreachable"
-  | Clause var -> Clause (TypesUtils.expect_free_var span var)
+  | Clause var ->
+      Clause var
+      (* Note: the `de_bruijn_id`s are incorrect, see comment on `translate_region_binder` *)
   | ParentClause (inst_id, decl_id, clause_id) ->
       let inst_id = translate_trait_instance_id inst_id in
       ParentClause (inst_id, decl_id, clause_id)
@@ -531,7 +536,9 @@ let rec translate_sty (span : Meta.span option) (ty : T.ty) : ty =
           | T.TArray -> TAdt (TBuiltin TArray, generics)
           | T.TSlice -> TAdt (TBuiltin TSlice, generics)
           | T.TStr -> TAdt (TBuiltin TStr, generics)))
-  | TVar var -> TVar (TypesUtils.expect_free_var span var)
+  | TVar var ->
+      TVar var
+      (* Note: the `de_bruijn_id`s are incorrect, see comment on `translate_region_binder` *)
   | TLiteral ty -> TLiteral ty
   | TNever -> craise_opt_span __FILE__ __LINE__ span "Unreachable"
   | TRef (_, rty, _) -> translate span rty
@@ -766,7 +773,7 @@ let rec translate_fwd_ty (span : Meta.span option) (type_infos : type_infos)
               craise_opt_span __FILE__ __LINE__ span
                 "Unreachable: box/vec/option receives exactly one type \
                  parameter"))
-  | TVar var -> TVar (TypesUtils.expect_free_var span var)
+  | TVar var -> TVar var
   | TNever -> craise_opt_span __FILE__ __LINE__ span "Unreachable"
   | TLiteral lty -> TLiteral lty
   | TRef (_, rty, _) -> translate rty
@@ -874,7 +881,7 @@ let rec translate_back_ty (span : Meta.span option) (type_infos : type_infos)
                 (* Note that if there is exactly one type, [mk_simpl_tuple_ty]
                  * is the identity *)
                 Some (mk_simpl_tuple_ty tys_t)))
-  | TVar var -> wrap (TVar (TypesUtils.expect_free_var span var))
+  | TVar var -> wrap (TVar var)
   | TNever -> craise_opt_span __FILE__ __LINE__ span "Unreachable"
   | TLiteral lty -> wrap (TLiteral lty)
   | TRef (r, rty, rkind) -> (
@@ -4287,7 +4294,9 @@ and translate_loop (loop : S.loop) (ctx : bs_ctx) : texpression =
        call to the loop forward function) *)
     let generics =
       let { types; const_generics; trait_clauses } = ctx.sg.generics in
-      let types = List.map (fun (ty : T.type_var) -> TVar ty.T.index) types in
+      let types =
+        List.map (fun (ty : T.type_var) -> TVar (Free ty.T.index)) types
+      in
       let const_generics =
         List.map
           (fun (cg : T.const_generic_var) -> T.CgVar (Free cg.T.index))
@@ -4299,7 +4308,7 @@ and translate_loop (loop : S.loop) (ctx : bs_ctx) : texpression =
             let trait_decl_ref =
               { trait_decl_id = c.trait_id; decl_generics = c.generics }
             in
-            { trait_id = Clause c.clause_id; trait_decl_ref })
+            { trait_id = Clause (Free c.clause_id); trait_decl_ref })
           trait_clauses
       in
       { types; const_generics; trait_refs }


### PR DESCRIPTION
The last few Charon PRs made it so we can support cases where the generics for a method fn item aren't a simple concatenation of the trait_decl/trait_impl generics + the method generics. I hadn't yet propagated these changes into Pure; this PR does that. This happens to simplify the extraction of impl methods quite a bit because we now have the correct `explicit_info` available.

For simplicity I did not attempt to make the `de_bruijn_id`s correct in `Pure` since we don't need them to be. I commented the relevant places appropriately so we know what's happening if we end up needing more complex binding situations in the future.