### PR TITLE
Let charon manage `Self` clauses

### DIFF
--- a/charon-pin
+++ b/charon-pin
@@ -1,2 +1,2 @@
 # This is the commit from https://github.com/AeneasVerif/charon that should be used with this version of aeneas.
-c35fbd1fd623d9a93e1364097b18c0567641cc0e
+fb95ce55c3c910624342780193e24d20730cc1c1

--- a/flake.lock
+++ b/flake.lock
@@ -9,11 +9,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1748546405,
-        "narHash": "sha256-vf2Jp+eWBLI7PrM27xnZi1b05rp3FA6OU9Aa3XiXLac=",
+        "lastModified": 1749044865,
+        "narHash": "sha256-e/WbJunDhtZRVq0+xBrVJ3hdpXFhuB8PH22tSNrfBd4=",
         "owner": "aeneasverif",
         "repo": "charon",
-        "rev": "c35fbd1fd623d9a93e1364097b18c0567641cc0e",
+        "rev": "fb95ce55c3c910624342780193e24d20730cc1c1",
         "type": "github"
       },
       "original": {

--- a/src/Translate.ml
+++ b/src/Translate.ml
@@ -1148,7 +1148,6 @@ let translate_crate (filename : string) (dest_dir : string)
       use_dep_ite =
         Config.backend () = Lean && !Config.extract_decreases_clauses;
       trait_decl_id = None (* None by default *);
-      is_provided_method = false (* false by default *);
       trans_trait_decls;
       trans_trait_impls;
       trans_types;

--- a/src/extract/Extract.ml
+++ b/src/extract/Extract.ml
@@ -697,7 +697,6 @@ and extract_function_call (span : Meta.span) (ctx : extraction_ctx)
             TraitDeclId.Map.find trait_decl_id ctx.trans_trait_decls
           in
 
-          (* Required method *)
           sanity_check __FILE__ __LINE__ (lp_id = None)
             trait_decl.item_meta.span;
           extract_trait_ref trait_decl.item_meta.span ctx fmt
@@ -1481,21 +1480,7 @@ let extract_fun_parameters (space : bool ref) (ctx : extraction_ctx)
      About the order: we want to make sure the names are reserved for
      those (variable names might collide with them but it is ok, we will add
      suffixes to the variables).
-
-     TODO: micro-pass to update what happens when calling trait provided
-     functions.
   *)
-  let ctx, trait_decl =
-    match def.kind with
-    | TraitDeclItem (trait_ref, _, true) ->
-        let trait_decl =
-          T.TraitDeclId.Map.find trait_ref.trait_decl_id ctx.trans_trait_decls
-        in
-        let ctx, _ = ctx_add_trait_self_clause def.item_meta.span ctx in
-        let ctx = { ctx with is_provided_method = true } in
-        (ctx, Some trait_decl)
-    | _ -> (ctx, None)
-  in
   (* Add the type parameters - note that we need those bindings only for the
    * body translation (they are not top-level) *)
   let ctx, type_params, cg_params, trait_clauses =
@@ -1508,8 +1493,8 @@ let extract_fun_parameters (space : bool ref) (ctx : extraction_ctx)
   let explicit = def.signature.explicit_info in
   (let space = Some space in
    extract_generic_params def.item_meta.span ctx fmt TypeDeclId.Set.empty ~space
-     ~trait_decl Item def.signature.generics (Some explicit) type_params
-     cg_params trait_clauses);
+     Item def.signature.generics (Some explicit) type_params cg_params
+     trait_clauses);
   (* Close the box for the generics *)
   F.pp_close_box fmt ();
   (* The input parameters - note that doing this adds bindings to the context *)

--- a/src/extract/ExtractTypes.ml
+++ b/src/extract/ExtractTypes.ml
@@ -438,8 +438,8 @@ let rec extract_ty (span : Meta.span) (ctx : extraction_ctx) (fmt : F.formatter)
         *)
         match trait_ref.trait_id with
         | Self ->
-            extract_trait_instance_id_with_dot span ctx fmt no_params_tys false
-              trait_ref.trait_id;
+            extract_trait_instance_id_if_not_self span ctx fmt no_params_tys
+              false trait_ref.trait_id;
             F.pp_print_string fmt type_name
         | _ ->
             (* HOL4 doesn't have 1st class types *)
@@ -515,12 +515,12 @@ and extract_generic_args (span : Meta.span) (ctx : extraction_ctx)
 (** We sometimes need to ignore references to `Self` when generating the
     code, espcially when we project associated items. For this reason we
     have a special function for the cases where we project from an instance
-    id (e.g., `<Self as Foo>::foo` - note that in the extracted code, the
-    projections are often written with a dot '.').
+    id (e.g., `<Self as Foo>::foo`).
  *)
-and extract_trait_instance_id_with_dot (span : Meta.span) (ctx : extraction_ctx)
-    (fmt : F.formatter) (no_params_tys : TypeDeclId.Set.t) (inside : bool)
-    (id : trait_instance_id) : unit =
+and extract_trait_instance_id_if_not_self (span : Meta.span)
+    (ctx : extraction_ctx) (fmt : F.formatter)
+    (no_params_tys : TypeDeclId.Set.t) (inside : bool) (id : trait_instance_id)
+    : unit =
   match id with
   | Self ->
       (* This can only happen inside a trait (not inside its methods) so there
@@ -588,7 +588,8 @@ and extract_trait_instance_id (span : Meta.span) (ctx : extraction_ctx)
   | ParentClause (inst_id, decl_id, clause_id) ->
       (* Use the trait decl id to lookup the name *)
       let name = ctx_get_trait_parent_clause span decl_id clause_id ctx in
-      extract_trait_instance_id_with_dot span ctx fmt no_params_tys true inst_id;
+      extract_trait_instance_id_if_not_self span ctx fmt no_params_tys true
+        inst_id;
       F.pp_print_string fmt (add_brackets name)
   | UnknownTrait _ ->
       (* This is an error case *)

--- a/src/pure/Pure.ml
+++ b/src/pure/Pure.ml
@@ -300,9 +300,6 @@ class ['self] iter_ty_base =
   object (_self : 'self)
     inherit [_] iter_type_id
     inherit! [_] T.iter_const_generic
-
-    method visit_trait_item_name : 'env -> trait_item_name -> unit =
-      fun _ _ -> ()
   end
 
 (** Ancestor for map visitor for [ty] *)
@@ -310,30 +307,20 @@ class ['self] map_ty_base =
   object (_self : 'self)
     inherit [_] map_type_id
     inherit! [_] T.map_const_generic
-
-    method visit_trait_item_name : 'env -> trait_item_name -> trait_item_name =
-      fun _ x -> x
   end
 
 (** Ancestor for reduce visitor for [ty] *)
 class virtual ['self] reduce_ty_base =
-  object (self : 'self)
+  object (_self : 'self)
     inherit [_] reduce_type_id
     inherit! [_] T.reduce_const_generic
-
-    method visit_trait_item_name : 'env -> trait_item_name -> 'a =
-      fun _ _ -> self#zero
   end
 
 (** Ancestor for mapreduce visitor for [ty] *)
 class virtual ['self] mapreduce_ty_base =
-  object (self : 'self)
+  object (_self : 'self)
     inherit [_] mapreduce_type_id
     inherit! [_] T.mapreduce_const_generic
-
-    method visit_trait_item_name
-        : 'env -> trait_item_name -> trait_item_name * 'a =
-      fun _ x -> (x, self#zero)
   end
 
 type ty =
@@ -446,6 +433,9 @@ class ['self] iter_type_decl_base =
 
     method visit_builtin_type_info : 'env -> builtin_type_info -> unit =
       fun _ _ -> ()
+
+    method visit_trait_item_name : 'env -> trait_item_name -> unit =
+      fun _ _ -> ()
   end
 
 (** Ancestor for map visitor for [type_decl] *)
@@ -474,6 +464,9 @@ class ['self] map_type_decl_base =
     method visit_builtin_type_info
         : 'env -> builtin_type_info -> builtin_type_info =
       fun _ x -> x
+
+    method visit_trait_item_name : 'env -> trait_item_name -> trait_item_name =
+      fun _ x -> x
   end
 
 (** Ancestor for reduce visitor for [type_decl] *)
@@ -497,6 +490,9 @@ class virtual ['self] reduce_type_decl_base =
     method visit_item_meta : 'env -> T.item_meta -> 'a = fun _ _ -> self#zero
 
     method visit_builtin_type_info : 'env -> builtin_type_info -> 'a =
+      fun _ _ -> self#zero
+
+    method visit_trait_item_name : 'env -> trait_item_name -> 'a =
       fun _ _ -> self#zero
   end
 
@@ -524,6 +520,10 @@ class virtual ['self] mapreduce_type_decl_base =
 
     method visit_builtin_type_info
         : 'env -> builtin_type_info -> builtin_type_info * 'a =
+      fun _ x -> (x, self#zero)
+
+    method visit_trait_item_name
+        : 'env -> trait_item_name -> trait_item_name * 'a =
       fun _ x -> (x, self#zero)
   end
 

--- a/src/pure/PureMicroPasses.ml
+++ b/src/pure/PureMicroPasses.ml
@@ -3646,6 +3646,8 @@ let add_type_annotations_to_fun_decl (trans_ctx : trans_ctx)
                     (Charon.Substitute.lookup_flat_method_sig trans_ctx.crate
                        tref.trait_decl_ref.trait_decl_id method_name)
                 in
+                (* TODO: we shouldn't call `SymbolicToPure` here, there should
+                   be a way to translate these signatures earlier. *)
                 SymbolicToPure.translate_fun_sig trans_ctx
                   (FRegular method_decl_id) method_name method_sig
                   (List.map (fun _ -> None) method_sig.inputs)

--- a/tests/coq/misc/BlanketImpl.v
+++ b/tests/coq/misc/BlanketImpl.v
@@ -37,9 +37,7 @@ Definition Trait2_Blanket {T : Type} (trait1Inst : Trait1_t T) : Trait2_t T
 
 (** [blanket_impl::Trait2::foo]:
     Source: 'tests/src/blanket_impl.rs', lines 5:4-5:15 *)
-Definition trait2_foo_default
-  {Self : Type} (self_clause : Trait2_t Self) : result unit :=
-  Ok tt
-.
+Definition trait2_foo_default (Self : Type) : result unit :=
+  Ok tt.
 
 End BlanketImpl.

--- a/tests/coq/misc/DefaultedMethod.v
+++ b/tests/coq/misc/DefaultedMethod.v
@@ -8,15 +8,86 @@ Import ListNotations.
 Local Open Scope Primitives_scope.
 Module DefaultedMethod.
 
+(** Trait declaration: [defaulted_method::Trait]
+    Source: 'tests/src/defaulted_method.rs', lines 2:0-7:1 *)
+Record Trait_t (Self : Type) := mkTrait_t {
+  Trait_t_provided_method : Self -> result u32;
+  Trait_t_required_method : Self -> result u32;
+}.
+
+Arguments mkTrait_t { _ }.
+Arguments Trait_t_provided_method { _ } _.
+Arguments Trait_t_required_method { _ } _.
+
+(** [defaulted_method::NoOverride]
+    Source: 'tests/src/defaulted_method.rs', lines 9:0-9:18 *)
+Definition NoOverride_t : Type := unit.
+
+(** [defaulted_method::{defaulted_method::Trait for defaulted_method::NoOverride}::provided_method]:
+    Source: 'tests/src/defaulted_method.rs', lines 11:4-13:5 *)
+Definition traitdefaulted_methodNoOverride_provided_method
+  (self : NoOverride_t) : result u32 :=
+  Ok 73%u32
+.
+
+(** [defaulted_method::{defaulted_method::Trait for defaulted_method::NoOverride}::required_method]:
+    Source: 'tests/src/defaulted_method.rs', lines 14:4-16:5 *)
+Definition traitdefaulted_methodNoOverride_required_method
+  (self : NoOverride_t) : result u32 :=
+  Ok 12%u32
+.
+
+(** Trait implementation: [defaulted_method::{defaulted_method::Trait for defaulted_method::NoOverride}]
+    Source: 'tests/src/defaulted_method.rs', lines 10:0-17:1 *)
+Definition Traitdefaulted_methodNoOverride : Trait_t NoOverride_t := {|
+  Trait_t_provided_method := traitdefaulted_methodNoOverride_provided_method;
+  Trait_t_required_method := traitdefaulted_methodNoOverride_required_method;
+|}.
+
+(** [defaulted_method::YesOverride]
+    Source: 'tests/src/defaulted_method.rs', lines 19:0-19:19 *)
+Definition YesOverride_t : Type := unit.
+
+(** [defaulted_method::{defaulted_method::Trait for defaulted_method::YesOverride}#1::required_method]:
+    Source: 'tests/src/defaulted_method.rs', lines 21:4-23:5 *)
+Definition traitdefaulted_methodYesOverride_required_method
+  (self : YesOverride_t) : result u32 :=
+  Ok 42%u32
+.
+
+(** [defaulted_method::{defaulted_method::Trait for defaulted_method::YesOverride}#1::provided_method]:
+    Source: 'tests/src/defaulted_method.rs', lines 3:4-5:5 *)
+Definition traitdefaulted_methodYesOverride_provided_method
+  (self : YesOverride_t) : result u32 :=
+  traitdefaulted_methodYesOverride_required_method self
+.
+
+(** Trait implementation: [defaulted_method::{defaulted_method::Trait for defaulted_method::YesOverride}#1]
+    Source: 'tests/src/defaulted_method.rs', lines 20:0-24:1 *)
+Definition Traitdefaulted_methodYesOverride : Trait_t YesOverride_t := {|
+  Trait_t_provided_method := traitdefaulted_methodYesOverride_provided_method;
+  Trait_t_required_method := traitdefaulted_methodYesOverride_required_method;
+|}.
+
 (** [core::cmp::impls::{core::cmp::Ord for i32}#77::min]:
     Source: '/rustc/library/core/src/cmp.rs', lines 1048:4-1050:20
     Name pattern: [core::cmp::impls::{core::cmp::Ord<i32>}::min] *)
 Axiom core_cmp_impls_OrdI32_min : i32 -> i32 -> result i32.
 
 (** [defaulted_method::main]:
-    Source: 'tests/src/defaulted_method.rs', lines 2:0-5:1 *)
+    Source: 'tests/src/defaulted_method.rs', lines 26:0-33:1 *)
 Definition main : result unit :=
-  n <- core_cmp_impls_OrdI32_min 10%i32 1%i32; massert (n s= 1%i32)
+  _ <- traitdefaulted_methodNoOverride_provided_method tt;
+  _ <- traitdefaulted_methodYesOverride_provided_method tt;
+  n <- core_cmp_impls_OrdI32_min 10%i32 1%i32;
+  massert (n s= 1%i32)
+.
+
+(** [defaulted_method::Trait::provided_method]:
+    Source: 'tests/src/defaulted_method.rs', lines 3:4-5:5 *)
+Definition trait_provided_method_default
+  {Self : Type} (traitInst : Trait_t Self) (self : Self) : result u32 :=
+  traitInst.(Trait_t_required_method) self
 .
 
 (** Trait declaration: [core::cmp::PartialEq]
@@ -86,7 +157,7 @@ Arguments core_cmp_Ord_t_min { _ } _.
     Source: '/rustc/library/core/src/cmp.rs', lines 1048:4-1050:20
     Name pattern: [core::cmp::Ord::min] *)
 Axiom core_cmp_Ord_min_default :
-  forall{Self : Type} (self_clause : core_cmp_Ord_t Self),
+  forall{Self : Type} (ordInst : core_cmp_Ord_t Self),
         Self -> Self -> result Self
 .
 

--- a/tests/coq/misc/RenameAttribute.v
+++ b/tests/coq/misc/RenameAttribute.v
@@ -103,7 +103,7 @@ Definition no_borrows_sum (n : nat) (max : u32) : result u32 :=
 (** [rename_attribute::BoolTrait::ret_true]:
     Source: 'tests/src/rename_attribute.rs', lines 16:4-18:5 *)
 Definition boolTrait_retTest_default
-  {Self : Type} (self_clause : BoolTest_t Self) (self : Self) : result bool :=
+  {Self : Type} (self : Self) : result bool :=
   Ok true
 .
 

--- a/tests/coq/misc/Traits.v
+++ b/tests/coq/misc/Traits.v
@@ -683,7 +683,7 @@ Definition use_foo2
 (** [traits::BoolTrait::ret_true]:
     Source: 'tests/src/traits.rs', lines 8:4-10:5 *)
 Definition boolTrait_ret_true_default
-  {Self : Type} (self_clause : BoolTrait_t Self) (self : Self) : result bool :=
+  {Self : Type} (self : Self) : result bool :=
   Ok true
 .
 

--- a/tests/fstar/misc/BlanketImpl.fst
+++ b/tests/fstar/misc/BlanketImpl.fst
@@ -26,7 +26,6 @@ let trait2_Blanket (#t : Type0) (trait1Inst : trait1_t t) : trait2_t t = {
 
 (** [blanket_impl::Trait2::foo]:
     Source: 'tests/src/blanket_impl.rs', lines 5:4-5:15 *)
-let trait2_foo_default
-  (#self : Type0) (self_clause : trait2_t self) : result unit =
+let trait2_foo_default (self : Type0) : result unit =
   Ok ()
 

--- a/tests/fstar/misc/DefaultedMethod.fst
+++ b/tests/fstar/misc/DefaultedMethod.fst
@@ -5,16 +5,77 @@ open Primitives
 
 #set-options "--z3rlimit 50 --fuel 1 --ifuel 1"
 
+(** Trait declaration: [defaulted_method::Trait]
+    Source: 'tests/src/defaulted_method.rs', lines 2:0-7:1 *)
+noeq type trait_t (self : Type0) = {
+  provided_method : self -> result u32;
+  required_method : self -> result u32;
+}
+
+(** [defaulted_method::NoOverride]
+    Source: 'tests/src/defaulted_method.rs', lines 9:0-9:18 *)
+type noOverride_t = unit
+
+(** [defaulted_method::{defaulted_method::Trait for defaulted_method::NoOverride}::provided_method]:
+    Source: 'tests/src/defaulted_method.rs', lines 11:4-13:5 *)
+let traitdefaulted_methodNoOverride_provided_method
+  (self : noOverride_t) : result u32 =
+  Ok 73
+
+(** [defaulted_method::{defaulted_method::Trait for defaulted_method::NoOverride}::required_method]:
+    Source: 'tests/src/defaulted_method.rs', lines 14:4-16:5 *)
+let traitdefaulted_methodNoOverride_required_method
+  (self : noOverride_t) : result u32 =
+  Ok 12
+
+(** Trait implementation: [defaulted_method::{defaulted_method::Trait for defaulted_method::NoOverride}]
+    Source: 'tests/src/defaulted_method.rs', lines 10:0-17:1 *)
+let traitdefaulted_methodNoOverride : trait_t noOverride_t = {
+  provided_method = traitdefaulted_methodNoOverride_provided_method;
+  required_method = traitdefaulted_methodNoOverride_required_method;
+}
+
+(** [defaulted_method::YesOverride]
+    Source: 'tests/src/defaulted_method.rs', lines 19:0-19:19 *)
+type yesOverride_t = unit
+
+(** [defaulted_method::{defaulted_method::Trait for defaulted_method::YesOverride}#1::required_method]:
+    Source: 'tests/src/defaulted_method.rs', lines 21:4-23:5 *)
+let traitdefaulted_methodYesOverride_required_method
+  (self : yesOverride_t) : result u32 =
+  Ok 42
+
+(** [defaulted_method::{defaulted_method::Trait for defaulted_method::YesOverride}#1::provided_method]:
+    Source: 'tests/src/defaulted_method.rs', lines 3:4-5:5 *)
+let traitdefaulted_methodYesOverride_provided_method
+  (self : yesOverride_t) : result u32 =
+  traitdefaulted_methodYesOverride_required_method self
+
+(** Trait implementation: [defaulted_method::{defaulted_method::Trait for defaulted_method::YesOverride}#1]
+    Source: 'tests/src/defaulted_method.rs', lines 20:0-24:1 *)
+let traitdefaulted_methodYesOverride : trait_t yesOverride_t = {
+  provided_method = traitdefaulted_methodYesOverride_provided_method;
+  required_method = traitdefaulted_methodYesOverride_required_method;
+}
+
 (** [core::cmp::impls::{core::cmp::Ord for i32}#77::min]:
     Source: '/rustc/library/core/src/cmp.rs', lines 1048:4-1050:20
     Name pattern: [core::cmp::impls::{core::cmp::Ord<i32>}::min] *)
 assume val core_cmp_impls_OrdI32_min : i32 -> i32 -> result i32
 
 (** [defaulted_method::main]:
-    Source: 'tests/src/defaulted_method.rs', lines 2:0-5:1 *)
+    Source: 'tests/src/defaulted_method.rs', lines 26:0-33:1 *)
 let main : result unit =
+  let* _ = traitdefaulted_methodNoOverride_provided_method () in
+  let* _ = traitdefaulted_methodYesOverride_provided_method () in
   let* n = core_cmp_impls_OrdI32_min 10 1 in
   if n = 1 then Ok () else Fail Failure
+
+(** [defaulted_method::Trait::provided_method]:
+    Source: 'tests/src/defaulted_method.rs', lines 3:4-5:5 *)
+let trait_provided_method_default
+  (#self : Type0) (traitInst : trait_t self) (self1 : self) : result u32 =
+  traitInst.required_method self1
 
 (** Trait declaration: [core::cmp::PartialEq]
     Source: '/rustc/library/core/src/cmp.rs', lines 249:0-249:39
@@ -60,8 +121,7 @@ noeq type core_cmp_Ord_t (self : Type0) = {
     Source: '/rustc/library/core/src/cmp.rs', lines 1048:4-1050:20
     Name pattern: [core::cmp::Ord::min] *)
 assume val core_cmp_Ord_min_default
-  (#self : Type0) (self_clause : core_cmp_Ord_t self) :
-  self -> self -> result self
+  (#self : Type0) (ordInst : core_cmp_Ord_t self) : self -> self -> result self
 
 (** [core::cmp::impls::{core::cmp::PartialEq<i32> for i32}#30::eq]:
     Source: '/rustc/library/core/src/cmp.rs', lines 1813:16-1813:50

--- a/tests/fstar/misc/RenameAttribute.Funs.fst
+++ b/tests/fstar/misc/RenameAttribute.Funs.fst
@@ -67,9 +67,6 @@ let no_borrows_sum (max : u32) : result u32 =
 
 (** [rename_attribute::BoolTrait::ret_true]:
     Source: 'tests/src/rename_attribute.rs', lines 16:4-18:5 *)
-let boolTrait_retTest_default
-  (#self : Type0) (self_clause : boolTest_t self) (self1 : self) :
-  result bool
-  =
+let boolTrait_retTest_default (#self : Type0) (self1 : self) : result bool =
   Ok true
 

--- a/tests/fstar/misc/Traits.fst
+++ b/tests/fstar/misc/Traits.fst
@@ -540,10 +540,7 @@ let use_foo2
 
 (** [traits::BoolTrait::ret_true]:
     Source: 'tests/src/traits.rs', lines 8:4-10:5 *)
-let boolTrait_ret_true_default
-  (#self : Type0) (self_clause : boolTrait_t self) (self1 : self) :
-  result bool
-  =
+let boolTrait_ret_true_default (#self : Type0) (self1 : self) : result bool =
   Ok true
 
 (** Trait declaration: [traits::{traits::TestType<T>}#6::test::TestTrait]

--- a/tests/lean/BlanketImpl.lean
+++ b/tests/lean/BlanketImpl.lean
@@ -31,8 +31,7 @@ def Trait2.Blanket {T : Type} (Trait1Inst : Trait1 T) : Trait2 T := {
 
 /- [blanket_impl::Trait2::foo]:
    Source: 'tests/src/blanket_impl.rs', lines 5:4-5:15 -/
-def Trait2.foo.default
-  {Self : Type} (self_clause : Trait2 Self) : Result Unit :=
+def Trait2.foo.default (Self : Type) : Result Unit :=
   ok ()
 
 end blanket_impl

--- a/tests/lean/DefaultedMethod.lean
+++ b/tests/lean/DefaultedMethod.lean
@@ -8,11 +8,73 @@ set_option linter.unusedVariables false
 
 namespace defaulted_method
 
+/- Trait declaration: [defaulted_method::Trait]
+   Source: 'tests/src/defaulted_method.rs', lines 2:0-7:1 -/
+structure Trait (Self : Type) where
+  provided_method : Self → Result U32
+  required_method : Self → Result U32
+
+/- [defaulted_method::NoOverride]
+   Source: 'tests/src/defaulted_method.rs', lines 9:0-9:18 -/
+@[reducible] def NoOverride := Unit
+
+/- [defaulted_method::{defaulted_method::Trait for defaulted_method::NoOverride}::provided_method]:
+   Source: 'tests/src/defaulted_method.rs', lines 11:4-13:5 -/
+def Traitdefaulted_methodNoOverride.provided_method
+  (self : NoOverride) : Result U32 :=
+  ok 73#u32
+
+/- [defaulted_method::{defaulted_method::Trait for defaulted_method::NoOverride}::required_method]:
+   Source: 'tests/src/defaulted_method.rs', lines 14:4-16:5 -/
+def Traitdefaulted_methodNoOverride.required_method
+  (self : NoOverride) : Result U32 :=
+  ok 12#u32
+
+/- Trait implementation: [defaulted_method::{defaulted_method::Trait for defaulted_method::NoOverride}]
+   Source: 'tests/src/defaulted_method.rs', lines 10:0-17:1 -/
+@[reducible]
+def Traitdefaulted_methodNoOverride : Trait NoOverride := {
+  provided_method := Traitdefaulted_methodNoOverride.provided_method
+  required_method := Traitdefaulted_methodNoOverride.required_method
+}
+
+/- [defaulted_method::YesOverride]
+   Source: 'tests/src/defaulted_method.rs', lines 19:0-19:19 -/
+@[reducible] def YesOverride := Unit
+
+/- [defaulted_method::{defaulted_method::Trait for defaulted_method::YesOverride}#1::required_method]:
+   Source: 'tests/src/defaulted_method.rs', lines 21:4-23:5 -/
+def Traitdefaulted_methodYesOverride.required_method
+  (self : YesOverride) : Result U32 :=
+  ok 42#u32
+
+/- [defaulted_method::{defaulted_method::Trait for defaulted_method::YesOverride}#1::provided_method]:
+   Source: 'tests/src/defaulted_method.rs', lines 3:4-5:5 -/
+def Traitdefaulted_methodYesOverride.provided_method
+  (self : YesOverride) : Result U32 :=
+  Traitdefaulted_methodYesOverride.required_method self
+
+/- Trait implementation: [defaulted_method::{defaulted_method::Trait for defaulted_method::YesOverride}#1]
+   Source: 'tests/src/defaulted_method.rs', lines 20:0-24:1 -/
+@[reducible]
+def Traitdefaulted_methodYesOverride : Trait YesOverride := {
+  provided_method := Traitdefaulted_methodYesOverride.provided_method
+  required_method := Traitdefaulted_methodYesOverride.required_method
+}
+
 /- [defaulted_method::main]:
-   Source: 'tests/src/defaulted_method.rs', lines 2:0-5:1 -/
+   Source: 'tests/src/defaulted_method.rs', lines 26:0-33:1 -/
 def main : Result Unit :=
   do
+  let _ ← Traitdefaulted_methodNoOverride.provided_method ()
+  let _ ← Traitdefaulted_methodYesOverride.provided_method ()
   let n ← (↑(core.cmp.impls.OrdI32.min 10#i32 1#i32) : Result I32)
   massert (n = 1#i32)
+
+/- [defaulted_method::Trait::provided_method]:
+   Source: 'tests/src/defaulted_method.rs', lines 3:4-5:5 -/
+def Trait.provided_method.default
+  {Self : Type} (TraitInst : Trait Self) (self : Self) : Result U32 :=
+  TraitInst.required_method self
 
 end defaulted_method

--- a/tests/lean/RenameAttribute.lean
+++ b/tests/lean/RenameAttribute.lean
@@ -98,8 +98,7 @@ def No_borrows_sum (max : U32) : Result U32 :=
 
 /- [rename_attribute::BoolTrait::ret_true]:
    Source: 'tests/src/rename_attribute.rs', lines 16:4-18:5 -/
-def BoolTrait.retTest.default
-  {Self : Type} (self_clause : BoolTest Self) (self : Self) : Result Bool :=
+def BoolTrait.retTest.default {Self : Type} (self : Self) : Result Bool :=
   ok true
 
 end rename_attribute

--- a/tests/lean/Traits.lean
+++ b/tests/lean/Traits.lean
@@ -563,8 +563,7 @@ def use_foo2
 
 /- [traits::BoolTrait::ret_true]:
    Source: 'tests/src/traits.rs', lines 8:4-10:5 -/
-def BoolTrait.ret_true.default
-  {Self : Type} (self_clause : BoolTrait Self) (self : Self) : Result Bool :=
+def BoolTrait.ret_true.default {Self : Type} (self : Self) : Result Bool :=
   ok true
 
 /- Trait declaration: [traits::{traits::TestType<T>}#6::test::TestTrait]

--- a/tests/src/defaulted_method.rs
+++ b/tests/src/defaulted_method.rs
@@ -1,5 +1,33 @@
 //@ [fstar,coq] subdir=misc
+trait Trait {
+    fn provided_method(&self) -> u32 {
+        self.required_method()
+    }
+    fn required_method(&self) -> u32;
+}
+
+struct NoOverride;
+impl Trait for NoOverride {
+    fn provided_method(&self) -> u32 {
+        73
+    }
+    fn required_method(&self) -> u32 {
+        12
+    }
+}
+
+struct YesOverride;
+impl Trait for YesOverride {
+    fn required_method(&self) -> u32 {
+        42
+    }
+}
+
 fn main() {
+    NoOverride.provided_method();
+    YesOverride.provided_method();
+
+    // `min` is a default method of standard trait `Ord`.
     let n = 10.min(1);
     assert!(n == 1);
 }

--- a/tests/src/mutually-recursive-traits.lean.out
+++ b/tests/src/mutually-recursive-traits.lean.out
@@ -13,5 +13,5 @@ Called from Aeneas__Translate.extract_definitions.export_decl_group in file "Tra
 Called from Stdlib__List.iter in file "list.ml", line 110, characters 12-15
 Called from Aeneas__Translate.extract_definitions in file "Translate.ml", line 911, characters 2-177
 Called from Aeneas__Translate.extract_file in file "Translate.ml", line 1043, characters 2-36
-Called from Aeneas__Translate.translate_crate in file "Translate.ml", line 1716, characters 5-42
+Called from Aeneas__Translate.translate_crate in file "Translate.ml", line 1715, characters 5-42
 Called from Dune__exe__Main in file "Main.ml", line 588, characters 11-78


### PR DESCRIPTION
Companion PR to https://github.com/AeneasVerif/charon/pull/514.

This removes the need for managing the special `Self` clause in methods ourselves. One consequence is that in https://github.com/AeneasVerif/charon/pull/514 I had to add a pass that removes unused `Self` clauses otherwise any trait impl that reuses an associated constant default would end up self-recursive. That's why you can see in the tests diff that some provided methods end up losing their `Self` clause: it's because of that same pass. This may be leaving the translation in a bit of an incorrect state while https://github.com/AeneasVerif/charon/issues/180 isn't finished.