### PR TITLE
Fix some bugs and improve the handling of copyable symbolic values with borrows

### DIFF
--- a/src/Logging.ml
+++ b/src/Logging.ml
@@ -20,6 +20,9 @@ let pre_passes_log = create_logger "PrePasses"
 (** Logger for RegionsHierarchy *)
 let regions_hierarchy_log = create_logger "RegionsHierarchy"
 
+(** Logger for TypesAnalysis *)
+let types_analysis_log = create_logger "TypesAnalysis"
+
 (** Logger for Translate *)
 let translate_log = create_logger "Translate"
 

--- a/src/Translate.ml
+++ b/src/Translate.ml
@@ -24,10 +24,8 @@ type symbolic_fun_translation = symbolic_value list * SA.expression
 let translate_function_to_symbolics (trans_ctx : trans_ctx) (fdef : fun_decl) :
     symbolic_fun_translation option =
   (* Debug *)
-  log#ldebug
-    (lazy
-      ("translate_function_to_symbolics: "
-      ^ name_to_string trans_ctx fdef.item_meta.name));
+  log#ltrace
+    (lazy (__FUNCTION__ ^ ": " ^ name_to_string trans_ctx fdef.item_meta.name));
 
   match fdef.body with
   | None -> None
@@ -49,10 +47,8 @@ let translate_function_to_pure_aux (trans_ctx : trans_ctx)
     (fun_dsigs : Pure.decomposed_fun_sig FunDeclId.Map.t) (fdef : fun_decl) :
     pure_fun_translation_no_loops =
   (* Debug *)
-  log#ldebug
-    (lazy
-      ("translate_function_to_pure: "
-      ^ name_to_string trans_ctx fdef.item_meta.name));
+  log#ltrace
+    (lazy (__FUNCTION__ ^ ": " ^ name_to_string trans_ctx fdef.item_meta.name));
 
   (* Compute the symbolic ASTs, if the function is transparent *)
   let symbolic_trans = translate_function_to_symbolics trans_ctx fdef in
@@ -222,7 +218,7 @@ let translate_crate_to_pure (crate : crate) :
     * Pure.trait_decl list
     * Pure.trait_impl list =
   (* Debug *)
-  log#ldebug (lazy "translate_crate_to_pure");
+  log#ltrace (lazy __FUNCTION__);
 
   (* Compute the translation context *)
   let trans_ctx = compute_contexts crate in
@@ -383,9 +379,9 @@ let crate_has_opaque_non_builtin_decls (ctx : gen_ctx) (filter_builtin : bool) :
   let types, funs =
     LlbcAstUtils.crate_get_opaque_non_builtin_decls ctx.crate filter_builtin
   in
-  log#ldebug
+  log#ltrace
     (lazy
-      ("Opaque decls:" ^ "\n- types:\n"
+      (__FUNCTION__ ^ ": opaque decls:" ^ "\n- types:\n"
       ^ String.concat ",\n" (List.map show_type_decl types)
       ^ "\n- functions:\n"
       ^ String.concat ",\n" (List.map show_fun_decl funs)));

--- a/src/interp/InterpreterBorrows.mli
+++ b/src/interp/InterpreterBorrows.mli
@@ -122,7 +122,7 @@ val abs_is_destructured : Meta.span -> bool -> eval_ctx -> abs -> bool
     ids (we do not end them, nor their loans).
  *)
 val simplify_dummy_values_useless_abs :
-  config -> Meta.span -> simplify_abs:bool -> AbstractionId.Set.t -> cm_fun
+  config -> Meta.span -> AbstractionId.Set.t -> cm_fun
 
 (** Turn a value into a abstractions.
 

--- a/src/interp/InterpreterLoops.ml
+++ b/src/interp/InterpreterLoops.ml
@@ -444,7 +444,7 @@ let eval_loop (config : config) (span : span) (eval_loop_body : stl_cm_fun) :
          rid of the useless symbolic values (which are in anonymous variables) *)
       let ctx, cc =
         InterpreterBorrows.simplify_dummy_values_useless_abs config span
-          ~simplify_abs:false AbstractionId.Set.empty ctx
+          AbstractionId.Set.empty ctx
       in
 
       (* We want to make sure the loop will *not* manipulate shared avalues

--- a/src/interp/InterpreterLoopsJoinCtxs.ml
+++ b/src/interp/InterpreterLoopsJoinCtxs.ml
@@ -871,11 +871,11 @@ let join_ctxs (span : Meta.span) (loop_id : LoopId.id) (fixed_ids : ids_sets)
   (* Debug *)
   log#ltrace
     (lazy
-      ("join_ctxs:\n\n- fixed_ids:\n" ^ show_ids_sets fixed_ids
+      (__FUNCTION__ ^ ":\n\n- fixed_ids:\n" ^ show_ids_sets fixed_ids
      ^ "\n\n- ctx0:\n"
-      ^ eval_ctx_to_string ~span:(Some span) ~filter:false ctx0
+      ^ eval_ctx_to_string ~span:(Some span) ~filter:true ctx0
       ^ "\n\n- ctx1:\n"
-      ^ eval_ctx_to_string ~span:(Some span) ~filter:false ctx1
+      ^ eval_ctx_to_string ~span:(Some span) ~filter:true ctx1
       ^ "\n\n"));
 
   let env0 = List.rev ctx0.env in
@@ -887,8 +887,8 @@ let join_ctxs (span : Meta.span) (loop_id : LoopId.id) (fixed_ids : ids_sets)
     (* Debug *)
     log#ltrace
       (lazy
-        ("join_suffixes:\n\n- fixed_ids:\n" ^ show_ids_sets fixed_ids
-       ^ "\n\n- ctx0:\n"
+        (__FUNCTION__ ^ ": join_suffixes:\n\n- fixed_ids:\n"
+       ^ show_ids_sets fixed_ids ^ "\n\n- ctx0:\n"
         ^ eval_ctx_to_string ~span:(Some span) ~filter:false
             { ctx0 with env = List.rev env0 }
         ^ "\n\n- ctx1:\n"
@@ -948,7 +948,7 @@ let join_ctxs (span : Meta.span) (loop_id : LoopId.id) (fixed_ids : ids_sets)
         (* Debug *)
         log#ldebug
           (lazy
-            ("join_prefixes: BDummys:\n\n- fixed_ids:\n" ^ "\n"
+            (__FUNCTION__ ^ ": join_prefixes: BDummys:\n\n- fixed_ids:\n" ^ "\n"
            ^ show_ids_sets fixed_ids ^ "\n\n- value0:\n"
             ^ env_elem_to_string span ctx0 var0
             ^ "\n\n- value1:\n"
@@ -973,7 +973,7 @@ let join_ctxs (span : Meta.span) (loop_id : LoopId.id) (fixed_ids : ids_sets)
         (* Debug *)
         log#ldebug
           (lazy
-            ("join_prefixes: BVars:\n\n- fixed_ids:\n" ^ "\n"
+            (__FUNCTION__ ^ ": join_prefixes: BVars:\n\n- fixed_ids:\n" ^ "\n"
            ^ show_ids_sets fixed_ids ^ "\n\n- value0:\n"
             ^ env_elem_to_string span ctx0 var0
             ^ "\n\n- value1:\n"
@@ -993,7 +993,7 @@ let join_ctxs (span : Meta.span) (loop_id : LoopId.id) (fixed_ids : ids_sets)
         (* Debug *)
         log#ldebug
           (lazy
-            ("join_prefixes: Abs:\n\n- fixed_ids:\n" ^ "\n"
+            (__FUNCTION__ ^ ": join_prefixes: Abs:\n\n- fixed_ids:\n" ^ "\n"
            ^ show_ids_sets fixed_ids ^ "\n\n- abs0:\n"
             ^ abs_to_string span ctx0 abs0
             ^ "\n\n- abs1:\n"
@@ -1164,8 +1164,7 @@ let loop_join_origin_with_continue_ctxs (config : config) (span : Meta.span)
     (* Simplify the dummy values, by removing as many as we can -
        we ignore the synthesis continuation *)
     let ctx, _ =
-      simplify_dummy_values_useless_abs config span ~simplify_abs:false
-        fixed_ids.aids ctx
+      simplify_dummy_values_useless_abs config span fixed_ids.aids ctx
     in
     log#ltrace
       (lazy

--- a/src/interp/InterpreterLoopsJoinCtxs.ml
+++ b/src/interp/InterpreterLoopsJoinCtxs.ml
@@ -885,7 +885,7 @@ let join_ctxs (span : Meta.span) (loop_id : LoopId.id) (fixed_ids : ids_sets)
   (* Explore the environments. *)
   let join_suffixes (env0 : env) (env1 : env) : env =
     (* Debug *)
-    log#ltrace
+    log#ldebug
       (lazy
         (__FUNCTION__ ^ ": join_suffixes:\n\n- fixed_ids:\n"
        ^ show_ids_sets fixed_ids ^ "\n\n- ctx0:\n"
@@ -1168,7 +1168,11 @@ let loop_join_origin_with_continue_ctxs (config : config) (span : Meta.span)
     in
     log#ltrace
       (lazy
-        (__FUNCTION__ ^ ":join_one: after simplify_dummy_values_useless_abs:\n"
+        (__FUNCTION__
+       ^ ":join_one: after simplify_dummy_values_useless_abs \
+          (fixed_ids.abs_ids = "
+        ^ AbstractionId.Set.to_string None fixed_ids.aids
+        ^ "):\n"
         ^ eval_ctx_to_string ~span:(Some span) ctx));
 
     (* Destructure the abstractions introduced in the new context *)

--- a/src/interp/InterpreterLoopsMatchCtxs.ml
+++ b/src/interp/InterpreterLoopsMatchCtxs.ml
@@ -92,19 +92,8 @@ let compute_abs_borrows_loans_maps (span : Meta.span) (explore : abs -> bool)
     let norm_proj_ty = normalize_proj_ty abs.regions.owned proj_ty in
     let proj : marked_norm_symb_proj = { pm; sv_id; norm_proj_ty } in
     RAbsSymbProj.register_mapping false abs_to_borrow_projs abs.abs_id proj;
-    (* This mapping is not generally injective as it is possible to copy symbolic values.
-       For now we still force it to be injective because we don't handle well the case
-       when we join contexts where symbolic values have been copied.
-       A more general, easy-to-implement solution would be to freshen the copied
-       symbolic values like so (when copying symbolic values containing borrows):
-       {[
-         // x ~> s0
-         y = copy x
-         // x ~> s1
-         // y ~> s2
-         // abs { proj_borrows s0, proj_loans s1, proj_loans s2 }
-       ]}
-    *)
+    (* This mapping is *actually* injective because we refresh symbolic values
+       with borrows when copying them. See [InterpreterExpressions.copy_value]. *)
     RSymbProjAbs.register_mapping true borrow_proj_to_abs proj abs.abs_id
   in
   let register_loan_proj abs pm (sv_id : symbolic_value_id) (proj_ty : ty) =

--- a/src/interp/InterpreterLoopsMatchCtxs.ml
+++ b/src/interp/InterpreterLoopsMatchCtxs.ml
@@ -1870,8 +1870,7 @@ let loop_match_ctx_with_target (config : config) (span : Meta.span)
 
   (* Simplify the target context *)
   let tgt_ctx, cc =
-    simplify_dummy_values_useless_abs config span ~simplify_abs:false
-      fixed_ids.aids tgt_ctx
+    simplify_dummy_values_useless_abs config span fixed_ids.aids tgt_ctx
   in
 
   (* We first reorganize [tgt_ctx] so that we can match [src_ctx] with it (by

--- a/src/llbc/Print.ml
+++ b/src/llbc/Print.ml
@@ -350,6 +350,7 @@ module Values = struct
         ^ loop_abs_kind_to_string abs_kind
         ^ ")"
     | Identity -> "Identity"
+    | CopySymbolicValue -> "CopySymbolicValue"
 
   let abs_to_string ?(span : Meta.span option = None) (env : fmt_env)
       ?(with_ended : bool = false) (verbose : bool) (indent : string)

--- a/src/llbc/TypesAnalysis.ml
+++ b/src/llbc/TypesAnalysis.ml
@@ -3,6 +3,8 @@ open LlbcAst
 open Errors
 open Substitute
 
+let log = Logging.types_analysis_log
+
 type subtype_info = {
   under_borrow : bool;  (** Are we inside a borrow? *)
   under_mut_borrow : bool;  (** Are we inside a mut borrow? *)
@@ -147,7 +149,7 @@ let analyze_full_ty (span : Meta.span option) (updated : bool ref)
     match mut_region with
     | RStatic | RVar (Bound _) ->
         mut_regions (* We can have bound vars because of arrows *)
-    | RErased -> craise_opt_span __FILE__ __LINE__ span "Unreachable"
+    | RErased -> internal_error_opt_span __FILE__ __LINE__ span
     | RVar (Free rid) -> update_mut_regions_with_rid mut_regions rid
   in
 
@@ -463,6 +465,7 @@ let analyze_type_declarations (type_decls : type_decl TypeDeclId.Map.t)
  *)
 let analyze_ty (span : Meta.span option) (infos : type_infos) (ty : ty) :
     ty_info =
+  log#ltrace (lazy (__FUNCTION__ ^ ": ty:\n" ^ show_ty ty));
   (* We don't use [updated] but need to give it as parameter *)
   let updated = ref false in
   (* We don't need to compute whether the type contains 'static or not *)

--- a/src/llbc/Values.ml
+++ b/src/llbc/Values.ml
@@ -825,6 +825,9 @@ type abs_kind =
           We introduce them to abstract the context a bit, for instance
           to compute fixed-points.
         *)
+  | CopySymbolicValue
+      (** See [InterpreterExpressions.copy_value]: a auxiliary region abstraction
+          which we introduced because of a copy of a symbolic value containing borrows. *)
 [@@deriving show, ord]
 
 (** Ancestor for {!abs} iter visitor *)

--- a/src/pure/PureMicroPasses.ml
+++ b/src/pure/PureMicroPasses.ml
@@ -1455,10 +1455,10 @@ let simplify_aggregates (ctx : trans_ctx) (def : fun_decl) : fun_decl =
                            args)
                         def.item_meta.span;
                       { e with e = Var x })
-                    else super#visit_texpression env e
-                  else super#visit_texpression env e
-                else super#visit_texpression env e
-            | _ -> super#visit_texpression env e)
+                    else e
+                  else e
+                else e
+            | _ -> e)
         | StructUpdate { struct_id; init = None; updates } ->
             let adt_ty = e.ty in
             (* Attempt to convert all the field updates to projections
@@ -1484,7 +1484,7 @@ let simplify_aggregates (ctx : trans_ctx) (def : fun_decl) : fun_decl =
             in
             let expr_projs = List.map to_expr_proj updates in
             let filt_expr_projs = List.filter_map (fun x -> x) expr_projs in
-            if filt_expr_projs = [] then super#visit_texpression env e
+            if filt_expr_projs = [] then e
             else
               (* If all the projections are from the same expression [x], we
                  simply replace the whole expression with [x] *)
@@ -1533,9 +1533,9 @@ let simplify_aggregates (ctx : trans_ctx) (def : fun_decl) : fun_decl =
                   StructUpdate { struct_id; init = Some !x; updates }
                 in
                 let e = { e with e = supd } in
-                super#visit_texpression env e)
-              else super#visit_texpression env e
-        | _ -> super#visit_texpression env e
+                e)
+              else e
+        | _ -> e
     end
   in
   match def.body with

--- a/src/symbolic/SymbolicToPure.ml
+++ b/src/symbolic/SymbolicToPure.ml
@@ -3190,7 +3190,8 @@ and translate_end_abstraction (ectx : C.eval_ctx) (abs : V.abs)
   | V.SynthRet rg_id -> translate_end_abstraction_synth_ret ectx abs e ctx rg_id
   | V.Loop (loop_id, rg_id, abs_kind) ->
       translate_end_abstraction_loop ectx abs e ctx loop_id rg_id abs_kind
-  | V.Identity -> translate_end_abstraction_identity ectx abs e ctx
+  | V.Identity | V.CopySymbolicValue ->
+      translate_end_abstraction_identity ectx abs e ctx
 
 and translate_end_abstraction_synth_input (ectx : C.eval_ctx) (abs : V.abs)
     (e : S.expression) (ctx : bs_ctx) (rg_id : T.RegionGroupId.id) : texpression

--- a/tests/src/mutually-recursive-traits.lean.out
+++ b/tests/src/mutually-recursive-traits.lean.out
@@ -1,17 +1,17 @@
 [[92mInfo[39m ] Imported: tests/llbc/mutually_recursive_traits.llbc
-[[91mError[39m] In file Translate.ml, line 872:
+[[91mError[39m] In file Translate.ml, line 853:
 Mutually recursive trait declarations are not supported
 
 Uncaught exception:
   
   (Failure
-    "In file Translate.ml, line 872:\
+    "In file Translate.ml, line 853:\
    \nMutually recursive trait declarations are not supported")
 
 Raised at Aeneas__Errors.craise_opt_span in file "Errors.ml", line 72, characters 4-23
-Called from Aeneas__Translate.extract_definitions.export_decl_group in file "Translate.ml", line 872, characters 8-114
+Called from Aeneas__Translate.extract_definitions.export_decl_group in file "Translate.ml", line 853, characters 8-114
 Called from Stdlib__List.iter in file "list.ml", line 110, characters 12-15
-Called from Aeneas__Translate.extract_definitions in file "Translate.ml", line 901, characters 2-177
-Called from Aeneas__Translate.extract_file in file "Translate.ml", line 1033, characters 2-36
-Called from Aeneas__Translate.translate_crate in file "Translate.ml", line 1667, characters 5-42
+Called from Aeneas__Translate.extract_definitions in file "Translate.ml", line 882, characters 2-177
+Called from Aeneas__Translate.extract_file in file "Translate.ml", line 1014, characters 2-36
+Called from Aeneas__Translate.translate_crate in file "Translate.ml", line 1648, characters 5-42
 Called from Dune__exe__Main in file "Main.ml", line 577, characters 11-63

--- a/tests/src/mutually-recursive-traits.lean.out
+++ b/tests/src/mutually-recursive-traits.lean.out
@@ -1,17 +1,17 @@
 [[92mInfo[39m ] Imported: tests/llbc/mutually_recursive_traits.llbc
-[[91mError[39m] In file Translate.ml, line 857:
+[[91mError[39m] In file Translate.ml, line 872:
 Mutually recursive trait declarations are not supported
 
 Uncaught exception:
   
   (Failure
-    "In file Translate.ml, line 857:\
+    "In file Translate.ml, line 872:\
    \nMutually recursive trait declarations are not supported")
 
 Raised at Aeneas__Errors.craise_opt_span in file "Errors.ml", line 72, characters 4-23
-Called from Aeneas__Translate.extract_definitions.export_decl_group in file "Translate.ml", line 857, characters 8-114
+Called from Aeneas__Translate.extract_definitions.export_decl_group in file "Translate.ml", line 872, characters 8-114
 Called from Stdlib__List.iter in file "list.ml", line 110, characters 12-15
-Called from Aeneas__Translate.extract_definitions in file "Translate.ml", line 886, characters 2-177
-Called from Aeneas__Translate.extract_file in file "Translate.ml", line 1018, characters 2-36
-Called from Aeneas__Translate.translate_crate in file "Translate.ml", line 1652, characters 5-42
+Called from Aeneas__Translate.extract_definitions in file "Translate.ml", line 901, characters 2-177
+Called from Aeneas__Translate.extract_file in file "Translate.ml", line 1033, characters 2-36
+Called from Aeneas__Translate.translate_crate in file "Translate.ml", line 1667, characters 5-42
 Called from Dune__exe__Main in file "Main.ml", line 577, characters 11-63


### PR DESCRIPTION
This PR fixes some bugs and generalizes the handling of copyable symbolic values containing borrows.
Previously, when copying symbolic values with borrows we did not introduce a fresh identifier for the symbolic value, leading to duplicates. It would cause problems when computing joins and fixed points, because then eliminating all the markers would become non trivial. This PR fixes that by refreshing the copied symbolic values and introducing auxiliary abstractions, to make sure there are no duplicates.

On a small example:
``` 
// x -> s0
y = copy x
// x -> s1 -- we updated the value inside of x!
// y -> s2
// abs { proj_borrows s0, proj_loans s1, proj_loans s2 }
```