### PR TITLE
chore: Add sorry'ed definitions for rotate_{left/right}

### DIFF
--- a/backends/lean/Aeneas/Std/Scalar.lean
+++ b/backends/lean/Aeneas/Std/Scalar.lean
@@ -1439,7 +1439,7 @@ def core.num.Isize.wrapping_sub := @Scalar.wrapping_sub ScalarTy.Isize
 
 -- Rotate left
 def Scalar.rotate_left {ty} (x y : Scalar ty) : Scalar ty := sorry
-/- [core::num::{u8}::wrapping_sub] -/
+/- [core::num::{u8}::rotate_left] -/
 def core.num.U8.rotate_left := @Scalar.rotate_left ScalarTy.U8
 
 /- [core::num::{u16}::rotate_left] -/

--- a/backends/lean/Aeneas/Std/Scalar.lean
+++ b/backends/lean/Aeneas/Std/Scalar.lean
@@ -1439,6 +1439,7 @@ def core.num.Isize.wrapping_sub := @Scalar.wrapping_sub ScalarTy.Isize
 
 -- Rotate left
 def Scalar.rotate_left {ty} (x y : Scalar ty) : Scalar ty := sorry
+
 /- [core::num::{u8}::rotate_left] -/
 def core.num.U8.rotate_left := @Scalar.rotate_left ScalarTy.U8
 

--- a/backends/lean/Aeneas/Std/Scalar.lean
+++ b/backends/lean/Aeneas/Std/Scalar.lean
@@ -1480,6 +1480,7 @@ def core.num.Isize.rotate_left := @Scalar.rotate_left ScalarTy.Isize
 
 -- Rotate right
 def Scalar.rotate_right {ty} (x y : Scalar ty) : Scalar ty := sorry
+
 /- [core::num::{u8}::rotate_right] -/
 def core.num.U8.rotate_right := @Scalar.rotate_right ScalarTy.U8
 

--- a/backends/lean/Aeneas/Std/Scalar.lean
+++ b/backends/lean/Aeneas/Std/Scalar.lean
@@ -1479,7 +1479,7 @@ def core.num.Isize.rotate_left := @Scalar.rotate_left ScalarTy.Isize
 
 -- Rotate right
 def Scalar.rotate_right {ty} (x y : Scalar ty) : Scalar ty := sorry
-/- [core::num::{u8}::wrapping_sub] -/
+/- [core::num::{u8}::rotate_right] -/
 def core.num.U8.rotate_right := @Scalar.rotate_right ScalarTy.U8
 
 /- [core::num::{u16}::rotate_right] -/

--- a/backends/lean/Aeneas/Std/Scalar.lean
+++ b/backends/lean/Aeneas/Std/Scalar.lean
@@ -1438,7 +1438,7 @@ def core.num.Isize.wrapping_sub := @Scalar.wrapping_sub ScalarTy.Isize
 -- TODO: reasoning lemmas for wrapping sub
 
 -- Rotate left
-def Scalar.rotate_left {ty} (x y : Scalar ty) : Scalar ty := sorry
+def Scalar.rotate_left {ty} (x  : Scalar ty) (shift : U32) : Scalar ty := sorry
 
 /- [core::num::{u8}::rotate_left] -/
 def core.num.U8.rotate_left := @Scalar.rotate_left ScalarTy.U8

--- a/backends/lean/Aeneas/Std/Scalar.lean
+++ b/backends/lean/Aeneas/Std/Scalar.lean
@@ -1479,7 +1479,7 @@ def core.num.Isize.rotate_left := @Scalar.rotate_left ScalarTy.Isize
 -- TODO: reasoning lemmas for rotate left
 
 -- Rotate right
-def Scalar.rotate_right {ty} (x y : Scalar ty) : Scalar ty := sorry
+def Scalar.rotate_right {ty} (x : Scalar ty) (shift : U32) : Scalar ty := sorry
 
 /- [core::num::{u8}::rotate_right] -/
 def core.num.U8.rotate_right := @Scalar.rotate_right ScalarTy.U8

--- a/backends/lean/Aeneas/Std/Scalar.lean
+++ b/backends/lean/Aeneas/Std/Scalar.lean
@@ -1437,6 +1437,86 @@ def core.num.Isize.wrapping_sub := @Scalar.wrapping_sub ScalarTy.Isize
 
 -- TODO: reasoning lemmas for wrapping sub
 
+-- Rotate left
+def Scalar.rotate_left {ty} (x y : Scalar ty) : Scalar ty := sorry
+/- [core::num::{u8}::wrapping_sub] -/
+def core.num.U8.rotate_left := @Scalar.rotate_left ScalarTy.U8
+
+/- [core::num::{u16}::rotate_left] -/
+def core.num.U16.rotate_left := @Scalar.rotate_left ScalarTy.U16
+
+/- [core::num::{u32}::rotate_left] -/
+def core.num.U32.rotate_left := @Scalar.rotate_left ScalarTy.U32
+
+/- [core::num::{u64}::rotate_left] -/
+def core.num.U64.rotate_left := @Scalar.rotate_left ScalarTy.U64
+
+/- [core::num::{u128}::rotate_left] -/
+def core.num.U128.rotate_left := @Scalar.rotate_left ScalarTy.U128
+
+/- [core::num::{usize}::rotate_left] -/
+def core.num.Usize.rotate_left := @Scalar.rotate_left ScalarTy.Usize
+
+/- [core::num::{i8}::rotate_left] -/
+def core.num.I8.rotate_left := @Scalar.rotate_left ScalarTy.I8
+
+/- [core::num::{i16}::rotate_left] -/
+def core.num.I16.rotate_left := @Scalar.rotate_left ScalarTy.I16
+
+/- [core::num::{i32}::rotate_left] -/
+def core.num.I32.rotate_left := @Scalar.rotate_left ScalarTy.I32
+
+/- [core::num::{i64}::rotate_left] -/
+def core.num.I64.rotate_left := @Scalar.rotate_left ScalarTy.I64
+
+/- [core::num::{i128}::rotate_left] -/
+def core.num.I128.rotate_left := @Scalar.rotate_left ScalarTy.I128
+
+/- [core::num::{isize}::rotate_left] -/
+def core.num.Isize.rotate_left := @Scalar.rotate_left ScalarTy.Isize
+
+-- TODO: reasoning lemmas for rotate left
+
+-- Rotate right
+def Scalar.rotate_right {ty} (x y : Scalar ty) : Scalar ty := sorry
+/- [core::num::{u8}::wrapping_sub] -/
+def core.num.U8.rotate_right := @Scalar.rotate_right ScalarTy.U8
+
+/- [core::num::{u16}::rotate_right] -/
+def core.num.U16.rotate_right := @Scalar.rotate_right ScalarTy.U16
+
+/- [core::num::{u32}::rotate_right] -/
+def core.num.U32.rotate_right := @Scalar.rotate_right ScalarTy.U32
+
+/- [core::num::{u64}::rotate_right] -/
+def core.num.U64.rotate_right := @Scalar.rotate_right ScalarTy.U64
+
+/- [core::num::{u128}::rotate_right] -/
+def core.num.U128.rotate_right := @Scalar.rotate_right ScalarTy.U128
+
+/- [core::num::{usize}::rotate_right] -/
+def core.num.Usize.rotate_right := @Scalar.rotate_right ScalarTy.Usize
+
+/- [core::num::{i8}::rotate_right] -/
+def core.num.I8.rotate_right := @Scalar.rotate_right ScalarTy.I8
+
+/- [core::num::{i16}::rotate_right] -/
+def core.num.I16.rotate_right := @Scalar.rotate_right ScalarTy.I16
+
+/- [core::num::{i32}::rotate_right] -/
+def core.num.I32.rotate_right := @Scalar.rotate_right ScalarTy.I32
+
+/- [core::num::{i64}::rotate_right] -/
+def core.num.I64.rotate_right := @Scalar.rotate_right ScalarTy.I64
+
+/- [core::num::{i128}::rotate_right] -/
+def core.num.I128.rotate_right := @Scalar.rotate_right ScalarTy.I128
+
+/- [core::num::{isize}::rotate_right] -/
+def core.num.Isize.rotate_right := @Scalar.rotate_right ScalarTy.Isize
+
+-- TODO: reasoning lemmas for rotate right
+
 end Std
 
 end Aeneas

--- a/tests/lean/Scalars.lean
+++ b/tests/lean/Scalars.lean
@@ -48,4 +48,24 @@ def u32_use_shift_left (x : U32) : Result U32 :=
 def i32_use_shift_left (x : I32) : Result I32 :=
   x <<< 2#i32
 
+/- [scalars::u32_use_rotate_right]:
+   Source: 'tests/src/scalars.rs', lines 35:0-37:1 -/
+def u32_use_rotate_right (x : U32) : Result U32 :=
+  Result.ok (core.num.U32.rotate_right x 2#u32)
+
+/- [scalars::i32_use_rotate_right]:
+   Source: 'tests/src/scalars.rs', lines 39:0-41:1 -/
+def i32_use_rotate_right (x : I32) : Result I32 :=
+  Result.ok (core.num.I32.rotate_right x 2#u32)
+
+/- [scalars::u32_use_rotate_left]:
+   Source: 'tests/src/scalars.rs', lines 43:0-45:1 -/
+def u32_use_rotate_left (x : U32) : Result U32 :=
+  Result.ok (core.num.U32.rotate_left x 2#u32)
+
+/- [scalars::i32_use_rotate_left]:
+   Source: 'tests/src/scalars.rs', lines 47:0-49:1 -/
+def i32_use_rotate_left (x : I32) : Result I32 :=
+  Result.ok (core.num.I32.rotate_left x 2#u32)
+
 end scalars

--- a/tests/src/scalars.rs
+++ b/tests/src/scalars.rs
@@ -31,3 +31,19 @@ fn u32_use_shift_left(x: u32) -> u32 {
 fn i32_use_shift_left(x: i32) -> i32 {
     x << 2
 }
+
+fn u32_use_rotate_right(x: u32) -> u32 {
+    x.rotate_right(2)
+}
+
+fn i32_use_rotate_right(x: i32) -> i32 {
+    x.rotate_right(2)
+}
+
+fn u32_use_rotate_left(x: u32) -> u32 {
+    x.rotate_left(2)
+}
+
+fn i32_use_rotate_left(x: i32) -> i32 {
+    x.rotate_left(2)
+}


### PR DESCRIPTION
Definitions for `rotate_{left/right}` were missing. I've left them following what was done for `wrapping_add/sub`.