### PR TITLE
Don't run `make format` in `make build`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ IN_CI ?=
 
 # Build the compiler, after formatting the code
 .PHONY: build
-build: format build-dev
+build: build-dev
 
 # Build the project, test it and verify the generated files
 .PHONY: build-test-verify


### PR DESCRIPTION
`make format` requires a rust toolchain with `rustfmt` which is an unnecessary requirement for building aeneas. May as well split them up; CI will catch unformatted ocaml code. It won't catch unformatted rust code but that's only in tests so :shrug:.