### PR TITLE
Don't distinguish provided and required methods

### DIFF
--- a/charon-pin
+++ b/charon-pin
@@ -1,2 +1,2 @@
 # This is the commit from https://github.com/AeneasVerif/charon that should be used with this version of aeneas.
-91f411e4de52d2fb5c7a861a374a1b9676e03dd2
+821fe7c71300e00c23e47ae97de1e8dc4ac91f9d

--- a/flake.lock
+++ b/flake.lock
@@ -12,11 +12,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1739281352,
-        "narHash": "sha256-WR6NcKcMHvjbze83pNjvsAFuB0aOO8Iat3x2wgkNeCQ=",
+        "lastModified": 1739284006,
+        "narHash": "sha256-HfvqqGbvj1ZQwRqg83IDC9Y2tIm94g/kXgV1QRCzG0Q=",
         "owner": "aeneasverif",
         "repo": "charon",
-        "rev": "91f411e4de52d2fb5c7a861a374a1b9676e03dd2",
+        "rev": "821fe7c71300e00c23e47ae97de1e8dc4ac91f9d",
         "type": "github"
       },
       "original": {

--- a/src/extract/ExtractBase.ml
+++ b/src/extract/ExtractBase.ml
@@ -2181,11 +2181,10 @@ let ctx_compute_fun_name (def : fun_decl) (ctx : extraction_ctx) : string =
           with
           | None -> def.item_meta
           | Some trait_decl -> (
-              let methods =
-                trait_decl.required_methods @ trait_decl.provided_methods
-              in
               match
-                List.find_opt (fun (name, _) -> name = item_name) methods
+                List.find_opt
+                  (fun (name, _) -> name = item_name)
+                  trait_decl.methods
               with
               | None -> def.item_meta
               | Some (_, bound_fn) ->

--- a/src/pure/Pure.ml
+++ b/src/pure/Pure.ml
@@ -1353,8 +1353,7 @@ type trait_decl = {
   llbc_parent_clauses : Types.trait_clause list;
   consts : (trait_item_name * ty) list;
   types : trait_item_name list;
-  required_methods : (trait_item_name * fun_decl_ref binder) list;
-  provided_methods : (trait_item_name * fun_decl_ref binder) list;
+  methods : (trait_item_name * fun_decl_ref binder) list;
 }
 [@@deriving show]
 
@@ -1378,7 +1377,6 @@ type trait_impl = {
   parent_trait_refs : trait_ref list;
   consts : (trait_item_name * global_decl_ref) list;
   types : (trait_item_name * ty) list;
-  required_methods : (trait_item_name * fun_decl_ref binder) list;
-  provided_methods : (trait_item_name * fun_decl_ref binder) list;
+  methods : (trait_item_name * fun_decl_ref binder) list;
 }
 [@@deriving show]

--- a/src/pure/PureUtils.ml
+++ b/src/pure/PureUtils.ml
@@ -794,24 +794,6 @@ let rec typed_pattern_to_texpression (span : Meta.span) (pat : typed_pattern) :
   | None -> None
   | Some e -> Some { e; ty = pat.ty }
 
-type trait_decl_method_decl_id = { is_provided : bool; id : fun_decl_id }
-
-let trait_decl_get_method (trait_decl : trait_decl) (method_name : string) :
-    trait_decl_method_decl_id =
-  (* First look in the required methods *)
-  let bound_method =
-    List.find_opt (fun (s, _) -> s = method_name) trait_decl.required_methods
-  in
-  match bound_method with
-  | Some (_, bound_method) ->
-      { is_provided = false; id = bound_method.binder_value.fun_id }
-  | None ->
-      (* Must be a provided method *)
-      let _, bound_method =
-        List.find (fun (s, _) -> s = method_name) trait_decl.provided_methods
-      in
-      { is_provided = true; id = bound_method.binder_value.fun_id }
-
 let trait_decl_is_empty (trait_decl : trait_decl) : bool =
   let {
     def_id = _;
@@ -825,13 +807,11 @@ let trait_decl_is_empty (trait_decl : trait_decl) : bool =
     llbc_parent_clauses = _;
     consts;
     types;
-    required_methods;
-    provided_methods;
+    methods;
   } =
     trait_decl
   in
-  parent_clauses = [] && consts = [] && types = [] && required_methods = []
-  && provided_methods = []
+  parent_clauses = [] && consts = [] && types = [] && methods = []
 
 let trait_impl_is_empty (trait_impl : trait_impl) : bool =
   let {
@@ -847,13 +827,11 @@ let trait_impl_is_empty (trait_impl : trait_impl) : bool =
     parent_trait_refs;
     consts;
     types;
-    required_methods;
-    provided_methods;
+    methods;
   } =
     trait_impl
   in
-  parent_trait_refs = [] && consts = [] && types = [] && required_methods = []
-  && provided_methods = []
+  parent_trait_refs = [] && consts = [] && types = [] && methods = []
 
 (** Return true if a type declaration should be extracted as a tuple, because
     it is a non-recursive structure with unnamed fields. *)

--- a/src/symbolic/SymbolicToPure.ml
+++ b/src/symbolic/SymbolicToPure.ml
@@ -4791,8 +4791,7 @@ let translate_trait_decl (ctx : Contexts.decls_ctx) (trait_decl : A.trait_decl)
     parent_clauses = llbc_parent_clauses;
     consts;
     types;
-    required_methods;
-    provided_methods;
+    methods;
   } : A.trait_decl =
     trait_decl
   in
@@ -4810,17 +4809,11 @@ let translate_trait_decl (ctx : Contexts.decls_ctx) (trait_decl : A.trait_decl)
     List.map (translate_trait_clause span) llbc_parent_clauses
   in
   let consts = List.map (fun (name, ty) -> (name, translate_ty ty)) consts in
-  let required_methods =
+  let methods =
     List.map
       (fun (name, bound_fn) ->
         (name, translate_trait_method span translate_ty bound_fn))
-      required_methods
-  in
-  let provided_methods =
-    List.map
-      (fun (name, bound_fn) ->
-        (name, translate_trait_method span translate_ty bound_fn))
-      provided_methods
+      methods
   in
   {
     def_id;
@@ -4834,8 +4827,7 @@ let translate_trait_decl (ctx : Contexts.decls_ctx) (trait_decl : A.trait_decl)
     llbc_parent_clauses;
     consts;
     types;
-    required_methods;
-    provided_methods;
+    methods;
   }
 
 let translate_trait_impl (ctx : Contexts.decls_ctx) (trait_impl : A.trait_impl)
@@ -4848,8 +4840,7 @@ let translate_trait_impl (ctx : Contexts.decls_ctx) (trait_impl : A.trait_impl)
     parent_trait_refs;
     consts;
     types;
-    required_methods;
-    provided_methods;
+    methods;
   } =
     trait_impl
   in
@@ -4876,17 +4867,11 @@ let translate_trait_impl (ctx : Contexts.decls_ctx) (trait_impl : A.trait_impl)
       consts
   in
   let types = List.map (fun (name, ty) -> (name, translate_ty ty)) types in
-  let required_methods =
+  let methods =
     List.map
       (fun (name, bound_fn) ->
         (name, translate_trait_method span translate_ty bound_fn))
-      required_methods
-  in
-  let provided_methods =
-    List.map
-      (fun (name, bound_fn) ->
-        (name, translate_trait_method span translate_ty bound_fn))
-      provided_methods
+      methods
   in
   {
     def_id;
@@ -4901,8 +4886,7 @@ let translate_trait_impl (ctx : Contexts.decls_ctx) (trait_impl : A.trait_impl)
     parent_trait_refs;
     consts;
     types;
-    required_methods;
-    provided_methods;
+    methods;
   }
 
 let translate_global (ctx : Contexts.decls_ctx) (decl : A.global_decl) :

--- a/tests/coq/rename_attribute/RenameAttribute.v
+++ b/tests/coq/rename_attribute/RenameAttribute.v
@@ -12,10 +12,12 @@ Module RenameAttribute.
     Source: 'tests/src/rename_attribute.rs', lines 8:0-18:1 *)
 Record BoolTest_t (Self : Type) := mkBoolTest_t {
   BoolTest_t_getTest : Self -> result bool;
+  BoolTest_t_retTest : Self -> result bool;
 }.
 
 Arguments mkBoolTest_t { _ }.
 Arguments BoolTest_t_getTest { _ } _.
+Arguments BoolTest_t_retTest { _ } _.
 
 (** [rename_attribute::{rename_attribute::BoolTrait for bool}::get_bool]:
     Source: 'tests/src/rename_attribute.rs', lines 22:4-24:5 *)
@@ -31,6 +33,7 @@ Definition boolTraitBool_retTest (self : bool) : result bool :=
     Source: 'tests/src/rename_attribute.rs', lines 21:0-25:1 *)
 Definition BoolImpl : BoolTest_t bool := {|
   BoolTest_t_getTest := boolTraitBool_getTest;
+  BoolTest_t_retTest := boolTraitBool_retTest;
 |}.
 
 (** [rename_attribute::test_bool_trait]:

--- a/tests/coq/traits/Traits.v
+++ b/tests/coq/traits/Traits.v
@@ -12,10 +12,12 @@ Module Traits.
     Source: 'tests/src/traits.rs', lines 3:0-11:1 *)
 Record BoolTrait_t (Self : Type) := mkBoolTrait_t {
   BoolTrait_t_get_bool : Self -> result bool;
+  BoolTrait_t_ret_true : Self -> result bool;
 }.
 
 Arguments mkBoolTrait_t { _ }.
 Arguments BoolTrait_t_get_bool { _ } _.
+Arguments BoolTrait_t_ret_true { _ } _.
 
 (** [traits::{traits::BoolTrait for bool}::get_bool]:
     Source: 'tests/src/traits.rs', lines 14:4-16:5 *)
@@ -31,6 +33,7 @@ Definition boolTraitBool_ret_true (self : bool) : result bool :=
     Source: 'tests/src/traits.rs', lines 13:0-17:1 *)
 Definition BoolTraitBool : BoolTrait_t bool := {|
   BoolTrait_t_get_bool := boolTraitBool_get_bool;
+  BoolTrait_t_ret_true := boolTraitBool_ret_true;
 |}.
 
 (** [traits::test_bool_trait_bool]:
@@ -58,6 +61,7 @@ Definition boolTraitOption_ret_true
     Source: 'tests/src/traits.rs', lines 24:0-31:1 *)
 Definition BoolTraitOption (T : Type) : BoolTrait_t (option T) := {|
   BoolTrait_t_get_bool := boolTraitOption_get_bool;
+  BoolTrait_t_ret_true := boolTraitOption_ret_true;
 |}.
 
 (** [traits::test_bool_trait_option]:

--- a/tests/fstar/rename_attribute/RenameAttribute.Funs.fst
+++ b/tests/fstar/rename_attribute/RenameAttribute.Funs.fst
@@ -19,7 +19,10 @@ let boolTraitBool_retTest (self : bool) : result bool =
 
 (** Trait implementation: [rename_attribute::{rename_attribute::BoolTrait for bool}]
     Source: 'tests/src/rename_attribute.rs', lines 21:0-25:1 *)
-let boolImpl : boolTest_t bool = { getTest = boolTraitBool_getTest; }
+let boolImpl : boolTest_t bool = {
+  getTest = boolTraitBool_getTest;
+  retTest = boolTraitBool_retTest;
+}
 
 (** [rename_attribute::test_bool_trait]:
     Source: 'tests/src/rename_attribute.rs', lines 28:0-30:1 *)

--- a/tests/fstar/rename_attribute/RenameAttribute.Types.fst
+++ b/tests/fstar/rename_attribute/RenameAttribute.Types.fst
@@ -7,7 +7,10 @@ open Primitives
 
 (** Trait declaration: [rename_attribute::BoolTrait]
     Source: 'tests/src/rename_attribute.rs', lines 8:0-18:1 *)
-noeq type boolTest_t (self : Type0) = { getTest : self -> result bool; }
+noeq type boolTest_t (self : Type0) = {
+  getTest : self -> result bool;
+  retTest : self -> result bool;
+}
 
 (** [rename_attribute::SimpleEnum]
     Source: 'tests/src/rename_attribute.rs', lines 36:0-41:1 *)

--- a/tests/fstar/traits/Traits.fst
+++ b/tests/fstar/traits/Traits.fst
@@ -7,7 +7,10 @@ open Primitives
 
 (** Trait declaration: [traits::BoolTrait]
     Source: 'tests/src/traits.rs', lines 3:0-11:1 *)
-noeq type boolTrait_t (self : Type0) = { get_bool : self -> result bool; }
+noeq type boolTrait_t (self : Type0) = {
+  get_bool : self -> result bool;
+  ret_true : self -> result bool;
+}
 
 (** [traits::{traits::BoolTrait for bool}::get_bool]:
     Source: 'tests/src/traits.rs', lines 14:4-16:5 *)
@@ -21,7 +24,10 @@ let boolTraitBool_ret_true (self : bool) : result bool =
 
 (** Trait implementation: [traits::{traits::BoolTrait for bool}]
     Source: 'tests/src/traits.rs', lines 13:0-17:1 *)
-let boolTraitBool : boolTrait_t bool = { get_bool = boolTraitBool_get_bool; }
+let boolTraitBool : boolTrait_t bool = {
+  get_bool = boolTraitBool_get_bool;
+  ret_true = boolTraitBool_ret_true;
+}
 
 (** [traits::test_bool_trait_bool]:
     Source: 'tests/src/traits.rs', lines 19:0-21:1 *)
@@ -43,6 +49,7 @@ let boolTraitOption_ret_true (#t : Type0) (self : option t) : result bool =
     Source: 'tests/src/traits.rs', lines 24:0-31:1 *)
 let boolTraitOption (t : Type0) : boolTrait_t (option t) = {
   get_bool = boolTraitOption_get_bool;
+  ret_true = boolTraitOption_ret_true;
 }
 
 (** [traits::test_bool_trait_option]:

--- a/tests/lean/RenameAttribute.lean
+++ b/tests/lean/RenameAttribute.lean
@@ -12,6 +12,7 @@ namespace rename_attribute
    Source: 'tests/src/rename_attribute.rs', lines 8:0-18:1 -/
 structure BoolTest (Self : Type) where
   getTest : Self → Result Bool
+  retTest : Self → Result Bool
 
 /- [rename_attribute::{rename_attribute::BoolTrait for bool}::get_bool]:
    Source: 'tests/src/rename_attribute.rs', lines 22:4-24:5 -/
@@ -28,6 +29,7 @@ def BoolTraitBool.retTest (self : Bool) : Result Bool :=
 @[reducible]
 def BoolImpl : BoolTest Bool := {
   getTest := BoolTraitBool.getTest
+  retTest := BoolTraitBool.retTest
 }
 
 /- [rename_attribute::test_bool_trait]:

--- a/tests/lean/Traits.lean
+++ b/tests/lean/Traits.lean
@@ -12,6 +12,7 @@ namespace traits
    Source: 'tests/src/traits.rs', lines 3:0-11:1 -/
 structure BoolTrait (Self : Type) where
   get_bool : Self → Result Bool
+  ret_true : Self → Result Bool
 
 /- [traits::{traits::BoolTrait for bool}::get_bool]:
    Source: 'tests/src/traits.rs', lines 14:4-16:5 -/
@@ -28,6 +29,7 @@ def BoolTraitBool.ret_true (self : Bool) : Result Bool :=
 @[reducible]
 def BoolTraitBool : BoolTrait Bool := {
   get_bool := BoolTraitBool.get_bool
+  ret_true := BoolTraitBool.ret_true
 }
 
 /- [traits::test_bool_trait_bool]:
@@ -56,6 +58,7 @@ def BoolTraitOption.ret_true {T : Type} (self : Option T) : Result Bool :=
 @[reducible]
 def BoolTraitOption (T : Type) : BoolTrait (Option T) := {
   get_bool := BoolTraitOption.get_bool
+  ret_true := BoolTraitOption.ret_true
 }
 
 /- [traits::test_bool_trait_option]:


### PR DESCRIPTION
Companion PR to https://github.com/AeneasVerif/charon/pull/551. Now that all methods are present in a given trait impl, we no longer need to special-case provided methods.