### PR TITLE
Mark the constant definitions extracted for Lean as irreducible

### DIFF
--- a/backends/lean/Aeneas/ScalarTac/Init.lean
+++ b/backends/lean/Aeneas/ScalarTac/Init.lean
@@ -1,5 +1,4 @@
 import Aeneas.Extensions
-import Aesop
 open Lean Meta Meta.Simp
 
 namespace Aeneas.ScalarTac

--- a/backends/lean/Aeneas/Std/Global.lean
+++ b/backends/lean/Aeneas/Std/Global.lean
@@ -1,0 +1,20 @@
+import Lean
+open Lean Meta Meta.Simp
+
+namespace Aeneas.Std
+
+/-- The `global_simps` simp attribute. -/
+initialize globalSimpExt : SimpExtension ←
+  registerSimpAttr `global_simps "\
+    The `global_simps` attribute registers simp lemmas to be used when proving
+    that global/constant definitions successfully evaluate."
+
+initialize scalarTacSimprocsRef : IO.Ref Simprocs ← IO.mkRef {}
+
+/-- The `global_simps_proc` simp attribute for the simp rocs. -/
+initialize globalSimprocExt : Simp.SimprocExtension ←
+  Simp.registerSimprocAttr `global_simps_proc "\
+    The `global_simps_roc` attribute registers simp procedures to be used when proving
+    that global/constant definitions successfully evaluate." (some scalarTacSimprocsRef)
+
+end Aeneas.Std

--- a/backends/lean/Aeneas/Std/Primitives.lean
+++ b/backends/lean/Aeneas/Std/Primitives.lean
@@ -1,4 +1,5 @@
 import Lean
+import Aeneas.Std.Global
 
 namespace Aeneas
 
@@ -22,6 +23,10 @@ def assertImpl : CommandElab := fun (stx: Syntax) => do
       throwError ("Expression reduced to false:\n"  ++ stx[1])
     pure ())
 
+/--
+info: true
+-/
+#guard_msgs in
 #eval 2 == 2
 #assert (2 == 2)
 
@@ -71,6 +76,7 @@ instance Result_Nonempty (α : Type u) : Nonempty (Result α) :=
 # Helpers
 -/
 
+@[global_simps]
 def ok? {α: Type u} (r: Result α): Bool :=
   match r with
   | ok _ => true
@@ -84,8 +90,9 @@ def div? {α: Type u} (r: Result α): Bool :=
 def massert (b:Bool) : Result Unit :=
   if b then ok () else fail assertionFailure
 
-macro "prove_eval_global" : tactic => `(tactic| first | apply Eq.refl | decide)
+macro "prove_eval_global" : tactic => `(tactic| simp (failIfUnchanged := false) only [global_simps] <;> first | apply Eq.refl | decide)
 
+@[global_simps]
 def eval_global {α: Type u} (x: Result α) (_: ok? x := by prove_eval_global) : α :=
   match x with
   | fail _ | div => by contradiction

--- a/backends/lean/Aeneas/Std/PrimitivesLemmas.lean
+++ b/backends/lean/Aeneas/Std/PrimitivesLemmas.lean
@@ -19,7 +19,7 @@ theorem massert_decide_spec (b : Prop) [Decidable b] (h : b) :
 @[simp, progress_pre_simps, bvify_simps]
 theorem massert_ok (b : Bool) : massert b = ok () ↔ b := by simp [massert]
 
-@[simp] theorem massert_true : massert true = ok () := by simp [massert]
-@[simp] theorem massert_false : massert false = fail .assertionFailure := by simp [massert]
+@[simp, global_simps] theorem massert_true : massert true = ok () := by simp [massert]
+@[simp, global_simps] theorem massert_false : massert false = fail .assertionFailure := by simp [massert]
 
 end Aeneas.Std

--- a/src/Translate.ml
+++ b/src/Translate.ml
@@ -1370,7 +1370,8 @@ let translate_crate (filename : string) (dest_dir : string)
     match !Config.subdir with
     | None -> crate_name
     | Some subdir ->
-        String.concat module_delimiter (String.split_on_char '/' subdir)
+        String.concat module_delimiter
+          (List.filter (fun s -> s <> "") (String.split_on_char '/' subdir))
   in
   let import_prefix = import_prefix ^ module_delimiter in
   log#ltrace (lazy (__FUNCTION__ ^ ": import_prefix: " ^ import_prefix));

--- a/src/extract/Extract.ml
+++ b/src/extract/Extract.ml
@@ -1969,7 +1969,6 @@ let extract_global_decl_body_gen (span : Meta.span) (ctx : extraction_ctx)
 
   (* Open the definition boxes (depth=0) *)
   F.pp_open_hvbox fmt 0;
-  F.pp_open_hvbox fmt ctx.indent_incr;
 
   (* For lean: add the irreducible attribute *)
   sanity_check __FILE__ __LINE__
@@ -1978,6 +1977,9 @@ let extract_global_decl_body_gen (span : Meta.span) (ctx : extraction_ctx)
   if irreducible then (
     F.pp_print_string fmt "@[irreducible]";
     F.pp_print_space fmt ());
+
+  (* Second definition box *)
+  F.pp_open_hvbox fmt ctx.indent_incr;
 
   (* Open "QUALIF NAME PARAMS : TYPE =" box (depth=1) *)
   F.pp_open_hovbox fmt ctx.indent_incr;

--- a/src/extract/Extract.ml
+++ b/src/extract/Extract.ml
@@ -1971,11 +1971,10 @@ let extract_global_decl_body_gen (span : Meta.span) (ctx : extraction_ctx)
   F.pp_open_hvbox fmt 0;
 
   (* For lean: add the irreducible attribute *)
-  sanity_check __FILE__ __LINE__
-    (Config.backend () = Lean || not irreducible)
-    span;
-  if irreducible then (
-    F.pp_print_string fmt "@[irreducible]";
+  sanity_check __FILE__ __LINE__ (backend () = Lean || not irreducible) span;
+  if backend () = Lean then (
+    if irreducible then F.pp_print_string fmt "@[global_simps, irreducible]"
+    else F.pp_print_string fmt "@[global_simps]";
     F.pp_print_space fmt ());
 
   (* Second definition box *)

--- a/src/extract/Extract.ml
+++ b/src/extract/Extract.ml
@@ -1951,7 +1951,7 @@ let extract_fun_decl (ctx : extraction_ctx) (fmt : F.formatter)
     of those declarations. See {!extract_global_decl} for more explanations.
  *)
 let extract_global_decl_body_gen (span : Meta.span) (ctx : extraction_ctx)
-    (fmt : F.formatter) (kind : decl_kind) (name : string)
+    (fmt : F.formatter) (kind : decl_kind) ~(irreducible : bool) (name : string)
     (generics : generic_params) (explicit : explicit_info)
     (type_params : string list) (cg_params : string list)
     (trait_clauses : string list) (ty : ty)
@@ -1970,6 +1970,14 @@ let extract_global_decl_body_gen (span : Meta.span) (ctx : extraction_ctx)
   (* Open the definition boxes (depth=0) *)
   F.pp_open_hvbox fmt 0;
   F.pp_open_hvbox fmt ctx.indent_incr;
+
+  (* For lean: add the irreducible attribute *)
+  sanity_check __FILE__ __LINE__
+    (Config.backend () = Lean || not irreducible)
+    span;
+  if irreducible then (
+    F.pp_print_string fmt "@[irreducible]";
+    F.pp_print_space fmt ());
 
   (* Open "QUALIF NAME PARAMS : TYPE =" box (depth=1) *)
   F.pp_open_hovbox fmt ctx.indent_incr;
@@ -2133,20 +2141,22 @@ let extract_global_decl_aux (ctx : extraction_ctx) (fmt : F.formatter)
         extract_global_decl_hol4_opaque span ctx fmt decl_name global.generics
           decl_ty
       else
-        extract_global_decl_body_gen span ctx fmt kind decl_name global.generics
-          global.explicit_info type_params cg_params trait_clauses decl_ty None
+        extract_global_decl_body_gen span ctx fmt kind ~irreducible:false
+          decl_name global.generics global.explicit_info type_params cg_params
+          trait_clauses decl_ty None
   | Some body ->
       (* There is a body *)
       (* Generate: [let x_body : result u32 = Return 3] *)
-      extract_global_decl_body_gen span ctx fmt SingleNonRec body_name
-        global.generics global.explicit_info type_params cg_params trait_clauses
-        body_ty
+      extract_global_decl_body_gen span ctx fmt SingleNonRec ~irreducible:false
+        body_name global.generics global.explicit_info type_params cg_params
+        trait_clauses body_ty
         (Some (fun fmt -> extract_texpression span ctx fmt false body.body));
       F.pp_print_break fmt 0 0;
       (* Generate: [let x_c : u32 = eval_global x_body] *)
-      extract_global_decl_body_gen span ctx fmt SingleNonRec decl_name
-        global.generics global.explicit_info type_params cg_params trait_clauses
-        decl_ty
+      extract_global_decl_body_gen span ctx fmt SingleNonRec
+        ~irreducible:(backend () = Lean)
+        decl_name global.generics global.explicit_info type_params cg_params
+        trait_clauses decl_ty
         (Some
            (fun fmt ->
              let all_params =

--- a/tests/lean/Arrays.lean
+++ b/tests/lean/Arrays.lean
@@ -452,7 +452,7 @@ def f3 : Result U32 :=
 /- [arrays::SZ]
    Source: 'tests/src/arrays.rs', lines 316:0-316:25 -/
 def SZ_body : Result Usize := ok 32#usize
-def SZ : Usize := eval_global SZ_body
+@[irreducible] def SZ : Usize := eval_global SZ_body
 
 /- [arrays::f5]:
    Source: 'tests/src/arrays.rs', lines 319:0-321:1 -/

--- a/tests/lean/Arrays.lean
+++ b/tests/lean/Arrays.lean
@@ -451,8 +451,8 @@ def f3 : Result U32 :=
 
 /- [arrays::SZ]
    Source: 'tests/src/arrays.rs', lines 316:0-316:25 -/
-def SZ_body : Result Usize := ok 32#usize
-@[irreducible] def SZ : Usize := eval_global SZ_body
+@[global_simps] def SZ_body : Result Usize := ok 32#usize
+@[global_simps, irreducible] def SZ : Usize := eval_global SZ_body
 
 /- [arrays::f5]:
    Source: 'tests/src/arrays.rs', lines 319:0-321:1 -/

--- a/tests/lean/Constants.lean
+++ b/tests/lean/Constants.lean
@@ -161,8 +161,7 @@ structure V (T : Type) (N : Usize) where
    Source: 'tests/src/constants.rs', lines 94:4-94:29 -/
 def V.LEN_body (T : Type) (N : Usize) : Result Usize := ok N
 @[irreducible]
-  def V.LEN (T : Type) (N : Usize) : Usize :=
-  eval_global (V.LEN_body T N)
+def V.LEN (T : Type) (N : Usize) : Usize := eval_global (V.LEN_body T N)
 
 /- [constants::use_v]:
    Source: 'tests/src/constants.rs', lines 97:0-99:1 -/

--- a/tests/lean/Constants.lean
+++ b/tests/lean/Constants.lean
@@ -10,18 +10,18 @@ namespace constants
 
 /- [constants::X0]
    Source: 'tests/src/constants.rs', lines 8:0-8:22 -/
-def X0_body : Result U32 := ok 0#u32
-@[irreducible] def X0 : U32 := eval_global X0_body
+@[global_simps] def X0_body : Result U32 := ok 0#u32
+@[global_simps, irreducible] def X0 : U32 := eval_global X0_body
 
 /- [constants::X1]
    Source: 'tests/src/constants.rs', lines 10:0-10:29 -/
-def X1_body : Result U32 := ok core_u32_max
-@[irreducible] def X1 : U32 := eval_global X1_body
+@[global_simps] def X1_body : Result U32 := ok core_u32_max
+@[global_simps, irreducible] def X1 : U32 := eval_global X1_body
 
 /- [constants::X2]
    Source: 'tests/src/constants.rs', lines 13:0-16:2 -/
-def X2_body : Result U32 := ok 3#u32
-@[irreducible] def X2 : U32 := eval_global X2_body
+@[global_simps] def X2_body : Result U32 := ok 3#u32
+@[global_simps, irreducible] def X2 : U32 := eval_global X2_body
 
 /- [constants::incr]:
    Source: 'tests/src/constants.rs', lines 20:0-22:1 -/
@@ -30,8 +30,8 @@ def incr (n : U32) : Result U32 :=
 
 /- [constants::X3]
    Source: 'tests/src/constants.rs', lines 18:0-18:29 -/
-def X3_body : Result U32 := incr 32#u32
-@[irreducible] def X3 : U32 := eval_global X3_body
+@[global_simps] def X3_body : Result U32 := incr 32#u32
+@[global_simps, irreducible] def X3 : U32 := eval_global X3_body
 
 /- [constants::mk_pair0]:
    Source: 'tests/src/constants.rs', lines 26:0-28:1 -/
@@ -51,23 +51,24 @@ def mk_pair1 (x : U32) (y : U32) : Result (Pair U32 U32) :=
 
 /- [constants::P0]
    Source: 'tests/src/constants.rs', lines 34:0-34:42 -/
-def P0_body : Result (U32 × U32) := mk_pair0 0#u32 1#u32
-@[irreducible] def P0 : (U32 × U32) := eval_global P0_body
+@[global_simps] def P0_body : Result (U32 × U32) := mk_pair0 0#u32 1#u32
+@[global_simps, irreducible] def P0 : (U32 × U32) := eval_global P0_body
 
 /- [constants::P1]
    Source: 'tests/src/constants.rs', lines 35:0-35:46 -/
-def P1_body : Result (Pair U32 U32) := mk_pair1 0#u32 1#u32
-@[irreducible] def P1 : Pair U32 U32 := eval_global P1_body
+@[global_simps] def P1_body : Result (Pair U32 U32) := mk_pair1 0#u32 1#u32
+@[global_simps, irreducible] def P1 : Pair U32 U32 := eval_global P1_body
 
 /- [constants::P2]
    Source: 'tests/src/constants.rs', lines 36:0-36:34 -/
-def P2_body : Result (U32 × U32) := ok (0#u32, 1#u32)
-@[irreducible] def P2 : (U32 × U32) := eval_global P2_body
+@[global_simps] def P2_body : Result (U32 × U32) := ok (0#u32, 1#u32)
+@[global_simps, irreducible] def P2 : (U32 × U32) := eval_global P2_body
 
 /- [constants::P3]
    Source: 'tests/src/constants.rs', lines 37:0-37:51 -/
+@[global_simps]
 def P3_body : Result (Pair U32 U32) := ok { x := 0#u32, y := 1#u32 }
-@[irreducible] def P3 : Pair U32 U32 := eval_global P3_body
+@[global_simps, irreducible] def P3 : Pair U32 U32 := eval_global P3_body
 
 /- [constants::Wrap]
    Source: 'tests/src/constants.rs', lines 52:0-54:1 -/
@@ -81,8 +82,8 @@ def Wrap.new {T : Type} (value : T) : Result (Wrap T) :=
 
 /- [constants::Y]
    Source: 'tests/src/constants.rs', lines 44:0-44:38 -/
-def Y_body : Result (Wrap I32) := Wrap.new 2#i32
-@[irreducible] def Y : Wrap I32 := eval_global Y_body
+@[global_simps] def Y_body : Result (Wrap I32) := Wrap.new 2#i32
+@[global_simps, irreducible] def Y : Wrap I32 := eval_global Y_body
 
 /- [constants::unwrap_y]:
    Source: 'tests/src/constants.rs', lines 46:0-48:1 -/
@@ -91,13 +92,13 @@ def unwrap_y : Result I32 :=
 
 /- [constants::YVAL]
    Source: 'tests/src/constants.rs', lines 50:0-50:33 -/
-def YVAL_body : Result I32 := unwrap_y
-@[irreducible] def YVAL : I32 := eval_global YVAL_body
+@[global_simps] def YVAL_body : Result I32 := unwrap_y
+@[global_simps, irreducible] def YVAL : I32 := eval_global YVAL_body
 
 /- [constants::get_z1::Z1]
    Source: 'tests/src/constants.rs', lines 65:4-65:22 -/
-def get_z1.Z1_body : Result I32 := ok 3#i32
-@[irreducible] def get_z1.Z1 : I32 := eval_global get_z1.Z1_body
+@[global_simps] def get_z1.Z1_body : Result I32 := ok 3#i32
+@[global_simps, irreducible] def get_z1.Z1 : I32 := eval_global get_z1.Z1_body
 
 /- [constants::get_z1]:
    Source: 'tests/src/constants.rs', lines 64:0-67:1 -/
@@ -111,18 +112,18 @@ def add (a : I32) (b : I32) : Result I32 :=
 
 /- [constants::Q1]
    Source: 'tests/src/constants.rs', lines 77:0-77:22 -/
-def Q1_body : Result I32 := ok 5#i32
-@[irreducible] def Q1 : I32 := eval_global Q1_body
+@[global_simps] def Q1_body : Result I32 := ok 5#i32
+@[global_simps, irreducible] def Q1 : I32 := eval_global Q1_body
 
 /- [constants::Q2]
    Source: 'tests/src/constants.rs', lines 78:0-78:23 -/
-def Q2_body : Result I32 := ok Q1
-@[irreducible] def Q2 : I32 := eval_global Q2_body
+@[global_simps] def Q2_body : Result I32 := ok Q1
+@[global_simps, irreducible] def Q2 : I32 := eval_global Q2_body
 
 /- [constants::Q3]
    Source: 'tests/src/constants.rs', lines 79:0-79:31 -/
-def Q3_body : Result I32 := add Q2 3#i32
-@[irreducible] def Q3 : I32 := eval_global Q3_body
+@[global_simps] def Q3_body : Result I32 := add Q2 3#i32
+@[global_simps, irreducible] def Q3 : I32 := eval_global Q3_body
 
 /- [constants::get_z2]:
    Source: 'tests/src/constants.rs', lines 73:0-75:1 -/
@@ -134,23 +135,23 @@ def get_z2 : Result I32 :=
 
 /- [constants::S1]
    Source: 'tests/src/constants.rs', lines 83:0-83:23 -/
-def S1_body : Result U32 := ok 6#u32
-@[irreducible] def S1 : U32 := eval_global S1_body
+@[global_simps] def S1_body : Result U32 := ok 6#u32
+@[global_simps, irreducible] def S1 : U32 := eval_global S1_body
 
 /- [constants::S2]
    Source: 'tests/src/constants.rs', lines 84:0-84:30 -/
-def S2_body : Result U32 := incr S1
-@[irreducible] def S2 : U32 := eval_global S2_body
+@[global_simps] def S2_body : Result U32 := incr S1
+@[global_simps, irreducible] def S2 : U32 := eval_global S2_body
 
 /- [constants::S3]
    Source: 'tests/src/constants.rs', lines 85:0-85:35 -/
-def S3_body : Result (Pair U32 U32) := ok P3
-@[irreducible] def S3 : Pair U32 U32 := eval_global S3_body
+@[global_simps] def S3_body : Result (Pair U32 U32) := ok P3
+@[global_simps, irreducible] def S3 : Pair U32 U32 := eval_global S3_body
 
 /- [constants::S4]
    Source: 'tests/src/constants.rs', lines 86:0-86:47 -/
-def S4_body : Result (Pair U32 U32) := mk_pair1 7#u32 8#u32
-@[irreducible] def S4 : Pair U32 U32 := eval_global S4_body
+@[global_simps] def S4_body : Result (Pair U32 U32) := mk_pair1 7#u32 8#u32
+@[global_simps, irreducible] def S4 : Pair U32 U32 := eval_global S4_body
 
 /- [constants::V]
    Source: 'tests/src/constants.rs', lines 89:0-91:1 -/
@@ -159,8 +160,8 @@ structure V (T : Type) (N : Usize) where
 
 /- [constants::{constants::V<T, N>}#1::LEN]
    Source: 'tests/src/constants.rs', lines 94:4-94:29 -/
-def V.LEN_body (T : Type) (N : Usize) : Result Usize := ok N
-@[irreducible]
+@[global_simps] def V.LEN_body (T : Type) (N : Usize) : Result Usize := ok N
+@[global_simps, irreducible]
 def V.LEN (T : Type) (N : Usize) : Usize := eval_global (V.LEN_body T N)
 
 /- [constants::use_v]:

--- a/tests/lean/Constants.lean
+++ b/tests/lean/Constants.lean
@@ -11,17 +11,17 @@ namespace constants
 /- [constants::X0]
    Source: 'tests/src/constants.rs', lines 8:0-8:22 -/
 def X0_body : Result U32 := ok 0#u32
-def X0 : U32 := eval_global X0_body
+@[irreducible] def X0 : U32 := eval_global X0_body
 
 /- [constants::X1]
    Source: 'tests/src/constants.rs', lines 10:0-10:29 -/
 def X1_body : Result U32 := ok core_u32_max
-def X1 : U32 := eval_global X1_body
+@[irreducible] def X1 : U32 := eval_global X1_body
 
 /- [constants::X2]
    Source: 'tests/src/constants.rs', lines 13:0-16:2 -/
 def X2_body : Result U32 := ok 3#u32
-def X2 : U32 := eval_global X2_body
+@[irreducible] def X2 : U32 := eval_global X2_body
 
 /- [constants::incr]:
    Source: 'tests/src/constants.rs', lines 20:0-22:1 -/
@@ -31,7 +31,7 @@ def incr (n : U32) : Result U32 :=
 /- [constants::X3]
    Source: 'tests/src/constants.rs', lines 18:0-18:29 -/
 def X3_body : Result U32 := incr 32#u32
-def X3 : U32 := eval_global X3_body
+@[irreducible] def X3 : U32 := eval_global X3_body
 
 /- [constants::mk_pair0]:
    Source: 'tests/src/constants.rs', lines 26:0-28:1 -/
@@ -52,22 +52,22 @@ def mk_pair1 (x : U32) (y : U32) : Result (Pair U32 U32) :=
 /- [constants::P0]
    Source: 'tests/src/constants.rs', lines 34:0-34:42 -/
 def P0_body : Result (U32 × U32) := mk_pair0 0#u32 1#u32
-def P0 : (U32 × U32) := eval_global P0_body
+@[irreducible] def P0 : (U32 × U32) := eval_global P0_body
 
 /- [constants::P1]
    Source: 'tests/src/constants.rs', lines 35:0-35:46 -/
 def P1_body : Result (Pair U32 U32) := mk_pair1 0#u32 1#u32
-def P1 : Pair U32 U32 := eval_global P1_body
+@[irreducible] def P1 : Pair U32 U32 := eval_global P1_body
 
 /- [constants::P2]
    Source: 'tests/src/constants.rs', lines 36:0-36:34 -/
 def P2_body : Result (U32 × U32) := ok (0#u32, 1#u32)
-def P2 : (U32 × U32) := eval_global P2_body
+@[irreducible] def P2 : (U32 × U32) := eval_global P2_body
 
 /- [constants::P3]
    Source: 'tests/src/constants.rs', lines 37:0-37:51 -/
 def P3_body : Result (Pair U32 U32) := ok { x := 0#u32, y := 1#u32 }
-def P3 : Pair U32 U32 := eval_global P3_body
+@[irreducible] def P3 : Pair U32 U32 := eval_global P3_body
 
 /- [constants::Wrap]
    Source: 'tests/src/constants.rs', lines 52:0-54:1 -/
@@ -82,7 +82,7 @@ def Wrap.new {T : Type} (value : T) : Result (Wrap T) :=
 /- [constants::Y]
    Source: 'tests/src/constants.rs', lines 44:0-44:38 -/
 def Y_body : Result (Wrap I32) := Wrap.new 2#i32
-def Y : Wrap I32 := eval_global Y_body
+@[irreducible] def Y : Wrap I32 := eval_global Y_body
 
 /- [constants::unwrap_y]:
    Source: 'tests/src/constants.rs', lines 46:0-48:1 -/
@@ -92,12 +92,12 @@ def unwrap_y : Result I32 :=
 /- [constants::YVAL]
    Source: 'tests/src/constants.rs', lines 50:0-50:33 -/
 def YVAL_body : Result I32 := unwrap_y
-def YVAL : I32 := eval_global YVAL_body
+@[irreducible] def YVAL : I32 := eval_global YVAL_body
 
 /- [constants::get_z1::Z1]
    Source: 'tests/src/constants.rs', lines 65:4-65:22 -/
 def get_z1.Z1_body : Result I32 := ok 3#i32
-def get_z1.Z1 : I32 := eval_global get_z1.Z1_body
+@[irreducible] def get_z1.Z1 : I32 := eval_global get_z1.Z1_body
 
 /- [constants::get_z1]:
    Source: 'tests/src/constants.rs', lines 64:0-67:1 -/
@@ -112,17 +112,17 @@ def add (a : I32) (b : I32) : Result I32 :=
 /- [constants::Q1]
    Source: 'tests/src/constants.rs', lines 77:0-77:22 -/
 def Q1_body : Result I32 := ok 5#i32
-def Q1 : I32 := eval_global Q1_body
+@[irreducible] def Q1 : I32 := eval_global Q1_body
 
 /- [constants::Q2]
    Source: 'tests/src/constants.rs', lines 78:0-78:23 -/
 def Q2_body : Result I32 := ok Q1
-def Q2 : I32 := eval_global Q2_body
+@[irreducible] def Q2 : I32 := eval_global Q2_body
 
 /- [constants::Q3]
    Source: 'tests/src/constants.rs', lines 79:0-79:31 -/
 def Q3_body : Result I32 := add Q2 3#i32
-def Q3 : I32 := eval_global Q3_body
+@[irreducible] def Q3 : I32 := eval_global Q3_body
 
 /- [constants::get_z2]:
    Source: 'tests/src/constants.rs', lines 73:0-75:1 -/
@@ -135,22 +135,22 @@ def get_z2 : Result I32 :=
 /- [constants::S1]
    Source: 'tests/src/constants.rs', lines 83:0-83:23 -/
 def S1_body : Result U32 := ok 6#u32
-def S1 : U32 := eval_global S1_body
+@[irreducible] def S1 : U32 := eval_global S1_body
 
 /- [constants::S2]
    Source: 'tests/src/constants.rs', lines 84:0-84:30 -/
 def S2_body : Result U32 := incr S1
-def S2 : U32 := eval_global S2_body
+@[irreducible] def S2 : U32 := eval_global S2_body
 
 /- [constants::S3]
    Source: 'tests/src/constants.rs', lines 85:0-85:35 -/
 def S3_body : Result (Pair U32 U32) := ok P3
-def S3 : Pair U32 U32 := eval_global S3_body
+@[irreducible] def S3 : Pair U32 U32 := eval_global S3_body
 
 /- [constants::S4]
    Source: 'tests/src/constants.rs', lines 86:0-86:47 -/
 def S4_body : Result (Pair U32 U32) := mk_pair1 7#u32 8#u32
-def S4 : Pair U32 U32 := eval_global S4_body
+@[irreducible] def S4 : Pair U32 U32 := eval_global S4_body
 
 /- [constants::V]
    Source: 'tests/src/constants.rs', lines 89:0-91:1 -/
@@ -160,7 +160,9 @@ structure V (T : Type) (N : Usize) where
 /- [constants::{constants::V<T, N>}#1::LEN]
    Source: 'tests/src/constants.rs', lines 94:4-94:29 -/
 def V.LEN_body (T : Type) (N : Usize) : Result Usize := ok N
-def V.LEN (T : Type) (N : Usize) : Usize := eval_global (V.LEN_body T N)
+@[irreducible]
+  def V.LEN (T : Type) (N : Usize) : Usize :=
+  eval_global (V.LEN_body T N)
 
 /- [constants::use_v]:
    Source: 'tests/src/constants.rs', lines 97:0-99:1 -/

--- a/tests/lean/RenameAttribute.lean
+++ b/tests/lean/RenameAttribute.lean
@@ -58,12 +58,12 @@ structure StructTest where
 def Const_Test_body : Result U32 := do
                                     let i ← 100#u32 + 10#u32
                                     i + 1#u32
-def Const_Test : U32 := eval_global Const_Test_body
+@[irreducible] def Const_Test : U32 := eval_global Const_Test_body
 
 /- [rename_attribute::CA]
    Source: 'tests/src/rename_attribute.rs', lines 54:0-54:23 -/
 def Const_Aeneas11_body : Result U32 := 10#u32 + 1#u32
-def Const_Aeneas11 : U32 := eval_global Const_Aeneas11_body
+@[irreducible] def Const_Aeneas11 : U32 := eval_global Const_Aeneas11_body
 
 /- [rename_attribute::factorial]:
    Source: 'tests/src/rename_attribute.rs', lines 57:0-63:1 -/

--- a/tests/lean/RenameAttribute.lean
+++ b/tests/lean/RenameAttribute.lean
@@ -55,15 +55,18 @@ structure StructTest where
 
 /- [rename_attribute::C]
    Source: 'tests/src/rename_attribute.rs', lines 51:0-51:28 -/
+@[global_simps]
 def Const_Test_body : Result U32 := do
                                     let i ← 100#u32 + 10#u32
                                     i + 1#u32
-@[irreducible] def Const_Test : U32 := eval_global Const_Test_body
+@[global_simps, irreducible]
+def Const_Test : U32 := eval_global Const_Test_body
 
 /- [rename_attribute::CA]
    Source: 'tests/src/rename_attribute.rs', lines 54:0-54:23 -/
-def Const_Aeneas11_body : Result U32 := 10#u32 + 1#u32
-@[irreducible] def Const_Aeneas11 : U32 := eval_global Const_Aeneas11_body
+@[global_simps] def Const_Aeneas11_body : Result U32 := 10#u32 + 1#u32
+@[global_simps, irreducible]
+def Const_Aeneas11 : U32 := eval_global Const_Aeneas11_body
 
 /- [rename_attribute::factorial]:
    Source: 'tests/src/rename_attribute.rs', lines 57:0-63:1 -/

--- a/tests/lean/Traits.lean
+++ b/tests/lean/Traits.lean
@@ -250,8 +250,9 @@ def ToTypetraitsBoolWrapperT {T : Type} (ToTypeBoolTInst : ToType Bool T) :
 def WithConstTy.LEN2_default_body (Self : Type) (Self_V : Type) (Self_W : Type)
   (LEN : Usize) : Result Usize :=
   ok 32#usize
-def WithConstTy.LEN2_default (Self : Type) (Self_V : Type) (Self_W : Type) (LEN
-  : Usize) : Usize :=
+@[irreducible]
+  def WithConstTy.LEN2_default (Self : Type) (Self_V : Type) (Self_W : Type)
+    (LEN : Usize) : Usize :=
   eval_global (WithConstTy.LEN2_default_body Self Self_V Self_W LEN)
 
 /- Trait declaration: [traits::WithConstTy]
@@ -266,7 +267,8 @@ structure WithConstTy (Self : Type) (Self_V : Type) (Self_W : Type) (LEN :
 /- [traits::{traits::WithConstTy<u8, u64, 32: usize> for bool}#8::LEN1]
    Source: 'tests/src/traits.rs', lines 177:4-177:27 -/
 def WithConstTyBoolU8U6432.LEN1_body : Result Usize := ok 12#usize
-def WithConstTyBoolU8U6432.LEN1 : Usize :=
+@[irreducible]
+  def WithConstTyBoolU8U6432.LEN1 : Usize :=
   eval_global WithConstTyBoolU8U6432.LEN1_body
 
 /- [traits::{traits::WithConstTy<u8, u64, 32: usize> for bool}#8::f]:
@@ -489,7 +491,8 @@ structure Trait (Self : Type) where
 /- [traits::{traits::Trait for @Array<T, N>}#14::LEN]
    Source: 'tests/src/traits.rs', lines 317:4-317:25 -/
 def TraitArray.LEN_body (T : Type) (N : Usize) : Result Usize := ok N
-def TraitArray.LEN (T : Type) (N : Usize) : Usize :=
+@[irreducible]
+  def TraitArray.LEN (T : Type) (N : Usize) : Usize :=
   eval_global (TraitArray.LEN_body T N)
 
 /- Trait implementation: [traits::{traits::Trait for @Array<T, N>}#14]
@@ -504,7 +507,8 @@ def TraitArray (T : Type) (N : Usize) : Trait (Array T N) := {
 def TraittraitsWrapper.LEN_body {T : Type} (TraitInst : Trait T)
   : Result Usize :=
   ok 0#usize
-def TraittraitsWrapper.LEN {T : Type} (TraitInst : Trait T) : Usize :=
+@[irreducible]
+  def TraittraitsWrapper.LEN {T : Type} (TraitInst : Trait T) : Usize :=
   eval_global (TraittraitsWrapper.LEN_body TraitInst)
 
 /- Trait implementation: [traits::{traits::Trait for traits::Wrapper<T>}#15]
@@ -531,8 +535,9 @@ structure Foo (T : Type) (U : Type) where
 def Foo.FOO_body {T : Type} (U : Type) (TraitInst : Trait T)
   : Result (core.result.Result T I32) :=
   ok (core.result.Result.Err 0#i32)
-def Foo.FOO {T : Type} (U : Type) (TraitInst : Trait T)
-  : core.result.Result T I32 :=
+@[irreducible]
+  def Foo.FOO {T : Type} (U : Type) (TraitInst : Trait T)
+    : core.result.Result T I32 :=
   eval_global (Foo.FOO_body U TraitInst)
 
 /- [traits::use_foo1]:

--- a/tests/lean/Traits.lean
+++ b/tests/lean/Traits.lean
@@ -247,10 +247,11 @@ def ToTypetraitsBoolWrapperT {T : Type} (ToTypeBoolTInst : ToType Bool T) :
 
 /- [traits::WithConstTy::LEN2]
    Source: 'tests/src/traits.rs', lines 166:4-166:27 -/
+@[global_simps]
 def WithConstTy.LEN2_default_body (Self : Type) (Self_V : Type) (Self_W : Type)
   (LEN : Usize) : Result Usize :=
   ok 32#usize
-@[irreducible]
+@[global_simps, irreducible]
 def WithConstTy.LEN2_default (Self : Type) (Self_V : Type) (Self_W : Type) (LEN
   : Usize) : Usize :=
   eval_global (WithConstTy.LEN2_default_body Self Self_V Self_W LEN)
@@ -266,8 +267,9 @@ structure WithConstTy (Self : Type) (Self_V : Type) (Self_W : Type) (LEN :
 
 /- [traits::{traits::WithConstTy<u8, u64, 32: usize> for bool}#8::LEN1]
    Source: 'tests/src/traits.rs', lines 177:4-177:27 -/
+@[global_simps]
 def WithConstTyBoolU8U6432.LEN1_body : Result Usize := ok 12#usize
-@[irreducible]
+@[global_simps, irreducible]
 def WithConstTyBoolU8U6432.LEN1 : Usize :=
   eval_global WithConstTyBoolU8U6432.LEN1_body
 
@@ -490,8 +492,9 @@ structure Trait (Self : Type) where
 
 /- [traits::{traits::Trait for @Array<T, N>}#14::LEN]
    Source: 'tests/src/traits.rs', lines 317:4-317:25 -/
+@[global_simps]
 def TraitArray.LEN_body (T : Type) (N : Usize) : Result Usize := ok N
-@[irreducible]
+@[global_simps, irreducible]
 def TraitArray.LEN (T : Type) (N : Usize) : Usize :=
   eval_global (TraitArray.LEN_body T N)
 
@@ -504,10 +507,11 @@ def TraitArray (T : Type) (N : Usize) : Trait (Array T N) := {
 
 /- [traits::{traits::Trait for traits::Wrapper<T>}#15::LEN]
    Source: 'tests/src/traits.rs', lines 321:4-321:25 -/
+@[global_simps]
 def TraittraitsWrapper.LEN_body {T : Type} (TraitInst : Trait T)
   : Result Usize :=
   ok 0#usize
-@[irreducible]
+@[global_simps, irreducible]
 def TraittraitsWrapper.LEN {T : Type} (TraitInst : Trait T) : Usize :=
   eval_global (TraittraitsWrapper.LEN_body TraitInst)
 
@@ -532,10 +536,11 @@ structure Foo (T : Type) (U : Type) where
 
 /- [traits::{traits::Foo<T, U>}#16::FOO]
    Source: 'tests/src/traits.rs', lines 334:4-334:43 -/
+@[global_simps]
 def Foo.FOO_body {T : Type} (U : Type) (TraitInst : Trait T)
   : Result (core.result.Result T I32) :=
   ok (core.result.Result.Err 0#i32)
-@[irreducible]
+@[global_simps, irreducible]
 def Foo.FOO {T : Type} (U : Type) (TraitInst : Trait T)
   : core.result.Result T I32 :=
   eval_global (Foo.FOO_body U TraitInst)

--- a/tests/lean/Traits.lean
+++ b/tests/lean/Traits.lean
@@ -251,8 +251,8 @@ def WithConstTy.LEN2_default_body (Self : Type) (Self_V : Type) (Self_W : Type)
   (LEN : Usize) : Result Usize :=
   ok 32#usize
 @[irreducible]
-  def WithConstTy.LEN2_default (Self : Type) (Self_V : Type) (Self_W : Type)
-    (LEN : Usize) : Usize :=
+def WithConstTy.LEN2_default (Self : Type) (Self_V : Type) (Self_W : Type) (LEN
+  : Usize) : Usize :=
   eval_global (WithConstTy.LEN2_default_body Self Self_V Self_W LEN)
 
 /- Trait declaration: [traits::WithConstTy]
@@ -268,7 +268,7 @@ structure WithConstTy (Self : Type) (Self_V : Type) (Self_W : Type) (LEN :
    Source: 'tests/src/traits.rs', lines 177:4-177:27 -/
 def WithConstTyBoolU8U6432.LEN1_body : Result Usize := ok 12#usize
 @[irreducible]
-  def WithConstTyBoolU8U6432.LEN1 : Usize :=
+def WithConstTyBoolU8U6432.LEN1 : Usize :=
   eval_global WithConstTyBoolU8U6432.LEN1_body
 
 /- [traits::{traits::WithConstTy<u8, u64, 32: usize> for bool}#8::f]:
@@ -492,7 +492,7 @@ structure Trait (Self : Type) where
    Source: 'tests/src/traits.rs', lines 317:4-317:25 -/
 def TraitArray.LEN_body (T : Type) (N : Usize) : Result Usize := ok N
 @[irreducible]
-  def TraitArray.LEN (T : Type) (N : Usize) : Usize :=
+def TraitArray.LEN (T : Type) (N : Usize) : Usize :=
   eval_global (TraitArray.LEN_body T N)
 
 /- Trait implementation: [traits::{traits::Trait for @Array<T, N>}#14]
@@ -508,7 +508,7 @@ def TraittraitsWrapper.LEN_body {T : Type} (TraitInst : Trait T)
   : Result Usize :=
   ok 0#usize
 @[irreducible]
-  def TraittraitsWrapper.LEN {T : Type} (TraitInst : Trait T) : Usize :=
+def TraittraitsWrapper.LEN {T : Type} (TraitInst : Trait T) : Usize :=
   eval_global (TraittraitsWrapper.LEN_body TraitInst)
 
 /- Trait implementation: [traits::{traits::Trait for traits::Wrapper<T>}#15]
@@ -536,8 +536,8 @@ def Foo.FOO_body {T : Type} (U : Type) (TraitInst : Trait T)
   : Result (core.result.Result T I32) :=
   ok (core.result.Result.Err 0#i32)
 @[irreducible]
-  def Foo.FOO {T : Type} (U : Type) (TraitInst : Trait T)
-    : core.result.Result T I32 :=
+def Foo.FOO {T : Type} (U : Type) (TraitInst : Trait T)
+  : core.result.Result T I32 :=
   eval_global (Foo.FOO_body U TraitInst)
 
 /- [traits::use_foo1]:

--- a/tests/src/mutually-recursive-traits.lean.out
+++ b/tests/src/mutually-recursive-traits.lean.out
@@ -13,5 +13,5 @@ Called from Aeneas__Translate.extract_definitions.export_decl_group in file "Tra
 Called from Stdlib__List.iter in file "list.ml", line 110, characters 12-15
 Called from Aeneas__Translate.extract_definitions in file "Translate.ml", line 876, characters 2-177
 Called from Aeneas__Translate.extract_file in file "Translate.ml", line 1008, characters 2-36
-Called from Aeneas__Translate.translate_crate in file "Translate.ml", line 1669, characters 5-42
+Called from Aeneas__Translate.translate_crate in file "Translate.ml", line 1670, characters 5-42
 Called from Dune__exe__Main in file "Main.ml", line 592, characters 11-78


### PR DESCRIPTION
The following Rust definition:
```rust
const X : u32 = 32;
```

now gets extracted to:
```lean
def X_body : Result Usize = ok 0#u32
@[irreducible] def X : Usize = eval_global X_body
```

The reason for this is that constant bodies can be quite big (in the case of arrays for instance), leading to reduction problems if Lean attempts to unfold them at some point, when unifying terms for instance.