### PR TITLE
Improve the Lean backend

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -175,6 +175,11 @@ test-%: build-dev
 	$(TEST_RUNNER_EXE) $(CHARON_EXE) $(AENEAS_EXE) $(LLBC_DIR) $(INPUTS_DIR)/"$*" $(AENEAS_OPTIONS)
 	echo "# Test $* done"
 
+# Replay the Lean tests and time them
+.PHONY: timed-lean
+timed-lean:
+	cd tests/lean && find . -type f -iname "*.lean" -not -path "./.lake/*" -exec printf "\n{}\n" \; -exec lake env time lean {} \; >& timing.out
+
 # =============================================================================
 # Nix
 # =============================================================================

--- a/backends/lean/Aeneas.lean
+++ b/backends/lean/Aeneas.lean
@@ -13,6 +13,7 @@ import Aeneas.Saturate
 import Aeneas.ScalarDecrTac
 import Aeneas.ScalarNF
 import Aeneas.ScalarTac
+import Aeneas.SimpIfs
 import Aeneas.SimpLemmas
 import Aeneas.SimpLists
 import Aeneas.Std

--- a/backends/lean/Aeneas/Bvify/Bvify.lean
+++ b/backends/lean/Aeneas/Bvify/Bvify.lean
@@ -425,4 +425,20 @@ example (x : U64) : x.val >>> 31 < 2^33 := by
   bvify 64
   bv_decide
 
+/--
+info: example
+  (x : U32)
+  (a : U32)
+  (b : U32)
+  (h : x.bv = a.bv + b.bv) :
+  x.bv % 3329#32 = (a.bv + b.bv) % 3329#32
+  := by sorry
+-/
+#guard_msgs in
+set_option linter.unusedTactic false in
+example (x a b : U32) (h : x.val = a.val + b.val) : (x.val : ZMod 3329) = (a.val : ZMod 3329) + (b.val : ZMod 3329) := by
+  bvify 32 at *
+  extract_goal1
+  simp [h]
+
 end Aeneas.Bvify

--- a/backends/lean/Aeneas/List/List.lean
+++ b/backends/lean/Aeneas/List/List.lean
@@ -245,12 +245,19 @@ theorem getElem!_set_neq
   have := getElem?_set_neq l i j x h
   simp_all
 
-@[simp, simp_lists_simps]
+@[simp]
 theorem getElem!_set_self
   {α : Type u} [Inhabited α] (l: List α) (i: Nat) (x: α)
   (h : i < l.length) : getElem! (l.set i x) i = x
   := by
   simp [*]
+
+@[simp_lists_simps]
+theorem getElem!_set_self'
+  {α : Type u} [Inhabited α] (l: List α) (i i': Nat) (x: α)
+  (h : i' < l.length ∧ i = i') : getElem! (l.set i x) i' = x
+  := by
+  simp only [getElem!_set_self, *]
 
 -- TODO: we need "composite" patterns for scalar_tac here
 theorem length_getElem!_le_length_flatten (ls : List (List α)) :

--- a/backends/lean/Aeneas/Progress/Init.lean
+++ b/backends/lean/Aeneas/Progress/Init.lean
@@ -93,7 +93,7 @@ def programTelescope[Inhabited (m α)] [Nonempty (m α)] (ty: Expr)
     trace[Progress] "After splitting the equality:\n- lhs: {program}\n- rhs: {res}"
     k (xs.map (·.mvarId!) |>.zip xs_bi) (zs.map (·.fvarId!)) program res post?
 
-  /- Analyze a goal or a pspec theorem to decompose its arguments.
+  /- Analyze a goal or a progress theorem to decompose its arguments.
 
      ProgressSpec theorems should be of the following shape:
      ```
@@ -234,7 +234,7 @@ private def saveProgressSpecFromThm (ext : Extension) (attrKind : AttributeKind)
 
 /- Initiliaze the `progress` attribute. -/
 initialize progressAttr : ProgressSpecAttr ← do
-  let ext ← mkExtension `pspecMap
+  let ext ← mkExtension `progressMap
   let attrImpl : AttributeImpl := {
     name := `progress
     descr := "Adds theorems to the `progress` database"
@@ -363,7 +363,7 @@ def reduceProdProjs (e : Expr) : MetaM Expr := do
     ∃ x y, toResult some_pair = ok (x, y) ∧ P x ∧ Q y
     ```
 -/
-def liftThm (pat : Syntax) (n : Name) (suffix : String := "progress_spec") : MetaM Name := do
+def liftThm (stx pat : Syntax) (n : Name) (suffix : String := "progress_spec") : MetaM Name := do
   trace[Progress] "Name: {n}"
   let env ← getEnv
   let decl := env.constants.find! n
@@ -489,6 +489,8 @@ def liftThm (pat : Syntax) (n : Name) (suffix : String := "progress_spec") : Met
     value := thm
   }
   addDecl (.thmDecl auxDecl)
+  /- Save the range -/
+  addDeclarationRangesFromSyntax name stx
   /- -/
   pure name
 
@@ -496,7 +498,7 @@ local elab "#progress_pure_lift_thm" id:ident pat:term : command => do
   Lean.Elab.Command.runTermElabM (fun _ => do
   let some cs ← Term.resolveId? id | throwError m!"Unknown id: {id}"
   let name := cs.constName!
-  let _ ← liftThm pat name)
+  let _ ← liftThm id pat name)
 
 namespace Test
   #progress_pure_lift_thm pos_pair_is_pos (∃ x y, pos_pair = (x, y))
@@ -573,7 +575,7 @@ structure ProgressPureSpecAttr where
    If we don't put an equality in the pattern, `progress_pure` will introduce one variable
    per field in the type of the pattern, if it is a tuple.
  -/
-initialize pspecPureAttribute : ProgressPureSpecAttr ← do
+initialize progressPureAttribute : ProgressPureSpecAttr ← do
   let attrImpl : AttributeImpl := {
     name := `progress_pure
     descr := "Adds lifted version of pure theorems to the `progress_pure` database"
@@ -585,7 +587,7 @@ initialize pspecPureAttribute : ProgressPureSpecAttr ← do
         -- Elaborate the pattern
         let pat ← elabProgressPureAttribute stx
         -- Introduce the lifted theorem
-        let liftedThmName ← MetaM.run' (liftThm pat thName)
+        let liftedThmName ← MetaM.run' (liftThm stx pat thName)
         -- Save the lifted theorem to the `progress` database
         saveProgressSpecFromThm progressAttr.ext attrKind liftedThmName
   }
@@ -606,7 +608,7 @@ structure ProgressPureDefSpecAttr where
   attr : AttributeImpl
   deriving Inhabited
 
-def mkProgressPureDefThm (pat : Option Syntax) (n : Name) (suffix : String := "progress_spec") : MetaM Name := do
+def mkProgressPureDefThm (stx : Syntax) (pat : Option Syntax) (n : Name) (suffix : String := "progress_spec") : MetaM Name := do
   trace[Progress] "Name: {n}"
   let env ← getEnv
   let decl := env.constants.find! n
@@ -710,6 +712,8 @@ def mkProgressPureDefThm (pat : Option Syntax) (n : Name) (suffix : String := "p
     value := thm
   }
   addDecl (.thmDecl auxDecl)
+  /- Save the range -/
+  addDeclarationRangesFromSyntax name stx
   /- -/
   pure name
 
@@ -717,7 +721,7 @@ local elab "#progress_pure_def" id:ident pat:(term)? : command => do
   Lean.Elab.Command.runTermElabM (fun _ => do
   let some cs ← Term.resolveId? id | throwError m!"Unknown id: {id}"
   let name := cs.constName!
-  let _ ← mkProgressPureDefThm pat name)
+  let _ ← mkProgressPureDefThm id pat name)
 
 namespace Test
   def wrapping_add (x y : U8) : U8 := ⟨ x.val + y.val ⟩
@@ -748,7 +752,7 @@ end Test
 
    Note that `progress_pure_def` takes a,n
  -/
-initialize pspecPureDefAttribute : ProgressPureDefSpecAttr ← do
+initialize progressPureDefAttribute : ProgressPureDefSpecAttr ← do
   let attrImpl : AttributeImpl := {
     name := `progress_pure_def
     descr := "Automatically generate `progress` theorems for pure definitions"
@@ -761,7 +765,7 @@ initialize pspecPureDefAttribute : ProgressPureDefSpecAttr ← do
         trace[Saturate.attribute] "Syntax: {stx}"
         let pat ← elabProgressPureDefAttribute stx
         -- Introduce the lifted theorem
-        let thmName ← MetaM.run' (mkProgressPureDefThm pat declName)
+        let thmName ← MetaM.run' (mkProgressPureDefThm stx pat declName)
         -- Save the lifted theorem to the `progress` database
         saveProgressSpecFromThm progressAttr.ext attrKind thmName
   }

--- a/backends/lean/Aeneas/Progress/ProgressStar.lean
+++ b/backends/lean/Aeneas/Progress/ProgressStar.lean
@@ -388,9 +388,9 @@ def add1 (x0 x1 : U32) : Std.Result U32 := do
 
 /--
 info: Try this:
-  let* ⟨ x2, x2_post ⟩ ← Aeneas.Std.U32.add_spec
-  let* ⟨ x3, x3_post ⟩ ← Aeneas.Std.U32.add_spec
-  let* ⟨ res, res_post ⟩ ← Aeneas.Std.U32.add_spec
+  let* ⟨ x2, x2_post ⟩ ← U32.add_spec
+  let* ⟨ x3, x3_post ⟩ ← U32.add_spec
+  let* ⟨ res, res_post ⟩ ← U32.add_spec
 -/
 #guard_msgs in
 example (x y : U32) (h : 2 * x.val + 2 * y.val + 4 ≤ U32.max) :
@@ -410,11 +410,11 @@ def add2 (b : Bool) (x0 x1 : U32) : Std.Result U32 := do
 /--
 info: Try this:
   split
-  . let* ⟨ x2, x2_post ⟩ ← Aeneas.Std.U32.add_spec
-    let* ⟨ x3, x3_post ⟩ ← Aeneas.Std.U32.add_spec
-    let* ⟨ res, res_post ⟩ ← Aeneas.Std.U32.add_spec
-  . let* ⟨ y, y_post ⟩ ← Aeneas.Std.U32.add_spec
-    let* ⟨ res, res_post ⟩ ← Aeneas.Std.U32.add_spec
+  . let* ⟨ x2, x2_post ⟩ ← U32.add_spec
+    let* ⟨ x3, x3_post ⟩ ← U32.add_spec
+    let* ⟨ res, res_post ⟩ ← U32.add_spec
+  . let* ⟨ y, y_post ⟩ ← U32.add_spec
+    let* ⟨ res, res_post ⟩ ← U32.add_spec
 -/
 #guard_msgs in
 example b (x y : U32) (h : 2 * x.val + 2 * y.val + 4 ≤ U32.max) :
@@ -425,15 +425,15 @@ example b (x y : U32) (h : 2 * x.val + 2 * y.val + 4 ≤ U32.max) :
 /--
 info: Try this:
   split
-  . let* ⟨ x2, x2_post ⟩ ← Aeneas.Std.U32.add_spec
+  . let* ⟨ x2, x2_post ⟩ ← U32.add_spec
     · sorry
-    let* ⟨ x3, x3_post ⟩ ← Aeneas.Std.U32.add_spec
+    let* ⟨ x3, x3_post ⟩ ← U32.add_spec
     · sorry
-    let* ⟨ res, res_post ⟩ ← Aeneas.Std.U32.add_spec
+    let* ⟨ res, res_post ⟩ ← U32.add_spec
     · sorry
-  . let* ⟨ y, y_post ⟩ ← Aeneas.Std.U32.add_spec
+  . let* ⟨ y, y_post ⟩ ← U32.add_spec
     · sorry
-    let* ⟨ res, res_post ⟩ ← Aeneas.Std.U32.add_spec
+    let* ⟨ res, res_post ⟩ ← U32.add_spec
     · sorry
 ---
 error: unsolved goals

--- a/backends/lean/Aeneas/Progress/ProgressStar.lean
+++ b/backends/lean/Aeneas/Progress/ProgressStar.lean
@@ -354,11 +354,14 @@ where
       else mkNode ``Lean.binderIdent #[mkIdent n]
     Lean.mkNode ``Lean.Parser.Tactic.caseArg #[tag, mkNullNode (args := binderIdents)]
 
-syntax «progress*_args» := ("by" tactic)?
-
+syntax «progress*_args» := ("by" tacticSeq)?
 def parseArgs: TSyntax `Aeneas.ProgressStar.«progress*_args» → CoreM Config
-| `(«progress*_args»| $[by $preconditionTac:tactic]?) => do
-  return {preconditionTac}
+| `(«progress*_args»| $[by $preconditionTac:tacticSeq]?) => do
+  match preconditionTac with
+  | none => return {preconditionTac := none}
+  | some preconditionTac => do
+    let preconditionTac : Syntax.Tactic := ⟨preconditionTac.raw⟩
+    return {preconditionTac}
 | _ => throwUnsupportedSyntax
 
 elab "progress" noWs "*" stx:«progress*_args»: tactic => do

--- a/backends/lean/Aeneas/Progress/ProgressStar.lean
+++ b/backends/lean/Aeneas/Progress/ProgressStar.lean
@@ -308,8 +308,11 @@ where
         setGoals [sg]
         try
           -- Try evaluating the tactic then chaining it with `fail` to make sure it closes the goal
-          evalTactic (←`(tactic| $tac <;> fail ""))
-          pure (←`(tactic| · $(#[tac])*), none)
+          evalTactic (←`(tactic| $tac))
+          -- Check that there are no remaining goals
+          let gl ← Tactic.getUnsolvedGoals
+          if ¬ gl.isEmpty then throwError "tactic failed"
+          else pure (←`(tactic| · $(#[tac])*), none)
         catch _ =>
           let defaultTac ← `(tactic| · sorry)
           pure (defaultTac, sg)

--- a/backends/lean/Aeneas/Progress/ProgressStar.lean
+++ b/backends/lean/Aeneas/Progress/ProgressStar.lean
@@ -299,7 +299,7 @@ where
       return (infos, mkStx)
 
   tryProgress := do
-    try some <$> Progress.evalProgress none (some (.str .anonymous "_")) none #[]
+    try some <$> Progress.evalProgress none (some (.str .anonymous "_")) none #[] none
     catch _ => pure none
 
   handleProgressPreconditions (preconditions : Array MVarId) : TacticM (Array Syntax.Tactic × Array MVarId) := do

--- a/backends/lean/Aeneas/Saturate/Attribute.lean
+++ b/backends/lean/Aeneas/Saturate/Attribute.lean
@@ -12,6 +12,7 @@ namespace Saturate
 
 initialize registerTraceClass `Saturate
 initialize registerTraceClass `Saturate.attribute
+initialize registerTraceClass `Saturate.diagnostics
 
 namespace Attribute
 

--- a/backends/lean/Aeneas/Saturate/Tactic.lean
+++ b/backends/lean/Aeneas/Saturate/Tactic.lean
@@ -190,6 +190,10 @@ private partial def visit (depth : Nat) (preprocessThm : Option (Array Expr → 
     trace[Saturate] ".proj"
     visit (depth + 1) preprocessThm nameToRule dtrees boundVars dinfo matched b
 
+def arithOpArity3 : Std.HashSet Name := Std.HashSet.ofList [
+  ``Nat.cast, ``Int.cast
+]
+
 def propConsts : Std.HashSet Name := Std.HashSet.ofList [
   ``Iff, ``And, ``Or
 ]
@@ -199,7 +203,7 @@ def arithComparisonConsts : Std.HashSet Name := Std.HashSet.ofList [
 ]
 
 def arithOpArity6 : Std.HashSet Name := Std.HashSet.ofList [
-  ``HShiftRight.hShiftRight, ``HShiftLeft.hShiftLeft, ``HPow.hPow
+  ``HShiftRight.hShiftRight, ``HShiftLeft.hShiftLeft, ``HPow.hPow, ``HMod.hMod
 ]
 
 def exploreArithSubterms (f : Expr) (args : Array Expr) : MetaM (Array Expr) := do
@@ -208,6 +212,8 @@ def exploreArithSubterms (f : Expr) (args : Array Expr) : MetaM (Array Expr) := 
   if constName == ``Eq ∧ args.size == 3 then
     trace[Saturate] "Found `=`"
     pure #[args[1]!, args[2]!]
+  else if constName ∈ arithOpArity3 ∧ args.size == 3 then
+    pure #[args[2]!]
   else if constName ∈ propConsts ∧ args.size == 2 then
     trace[Saturate] "Found prop const: {f}"
     pure #[args[0]!, args[1]!]

--- a/backends/lean/Aeneas/Saturate/Tactic.lean
+++ b/backends/lean/Aeneas/Saturate/Tactic.lean
@@ -198,6 +198,10 @@ def arithComparisonConsts : Std.HashSet Name := Std.HashSet.ofList [
   ``LT.lt, ``LE.le, ``GT.gt, ``GE.ge
 ]
 
+def arithOpArity6 : Std.HashSet Name := Std.HashSet.ofList [
+  ``HShiftRight.hShiftRight, ``HShiftLeft.hShiftLeft, ``HPow.hPow
+]
+
 def exploreArithSubterms (f : Expr) (args : Array Expr) : MetaM (Array Expr) := do
   if ¬ f.isConst then return #[]
   let constName := f.constName!
@@ -210,6 +214,9 @@ def exploreArithSubterms (f : Expr) (args : Array Expr) : MetaM (Array Expr) := 
   else if constName ∈ arithComparisonConsts ∧ args.size == 4 then
     trace[Saturate] "Found arith comparison: {f}"
     pure #[args[2]!, args[3]!]
+  else if constName ∈ arithOpArity6 ∧ args.size == 6 then
+    trace[Saturate] "Found arith op of arity 6: {f}"
+    pure #[args[4]!, args[5]!]
   else
     pure #[]
 

--- a/backends/lean/Aeneas/ScalarTac/CondSimpTac.lean
+++ b/backends/lean/Aeneas/ScalarTac/CondSimpTac.lean
@@ -69,6 +69,7 @@ def condSimpTac
      time we call `scalar_tac`: as `saturate` is not compiled it saves a lot of time -/
   withMainContext do
   let scalarTacAsms ← ScalarTac.scalarTacSaturateForward true false
+  trace[Utils] "Goal after saturating the context: {← getMainGoal}"
   let additionalSimpThms ← addSimpThms
   trace[Utils] "Goal after adding the additional simp assumptions: {← getMainGoal}"
   /- Simplify the targets (note that we preserve the new assumptions for `scalar_tac`) -/

--- a/backends/lean/Aeneas/ScalarTac/Lemmas.lean
+++ b/backends/lean/Aeneas/ScalarTac/Lemmas.lean
@@ -223,14 +223,14 @@ namespace ScalarTac
 
 open Std
 
-@[scalar_tac x]
+@[scalar_tac x.val]
 theorem UScalar.bounds {ty : UScalarTy} (x : UScalar ty) :
   x.val ≤ UScalar.max ty := by
   simp [UScalar.max]
   have := x.hBounds
   omega
 
-@[scalar_tac x]
+@[scalar_tac x.val]
 theorem IScalar.bounds {ty : IScalarTy} (x : IScalar ty) :
   IScalar.min ty ≤ x.val ∧ x.val ≤ IScalar.max ty := by
   simp [IScalar.max, IScalar.min]

--- a/backends/lean/Aeneas/ScalarTac/ScalarTac.lean
+++ b/backends/lean/Aeneas/ScalarTac/ScalarTac.lean
@@ -168,11 +168,7 @@ attribute [scalar_tac_simps]
   Bool.true_eq_false Bool.false_eq_true
   decide_eq_true_eq decide_eq_false_iff_not Bool.or_eq_true Bool.and_eq_true
 
-/-  Boosting a bit the `omega` tac.
-
-    - `extraPrePreprocess`: extra-preprocessing to be done *before* this preprocessing
-    - `extraPreprocess`: extra-preprocessing to be done *after* this preprocessing
- -/
+/-  Boosting a bit the `omega` tac. -/
 def scalarTacPreprocess (config : Config) : Tactic.TacticM Unit := do
   Tactic.withMainContext do
   -- Pre-preprocessing

--- a/backends/lean/Aeneas/SimpIfs.lean
+++ b/backends/lean/Aeneas/SimpIfs.lean
@@ -1,0 +1,1 @@
+import Aeneas.SimpIfs.SimpIfs

--- a/backends/lean/Aeneas/SimpIfs/Init.lean
+++ b/backends/lean/Aeneas/SimpIfs/Init.lean
@@ -1,0 +1,32 @@
+import Aeneas.Extensions
+import Aeneas.Saturate
+open Lean Meta
+
+namespace Aeneas.SimpIfs
+
+/-!
+# Tracing
+-/
+
+-- We can't define and use trace classes in the same file
+initialize registerTraceClass `SimpIfs
+
+/-!
+# Simp Lists Simpsets
+-/
+
+/-- The `simp_ifs_simps` simp attribute. -/
+initialize simpListsSimpExt : SimpExtension ←
+  registerSimpAttr `simp_ifs_simps "\
+    The `simp_ifs_simps` attribute registers simp lemmas to be used by `simp_ifs`."
+
+-- TODO: initialization fails with this, while the same works for `scalar_tac`??
+--initialize simpListsSimprocsRef : IO.Ref Simprocs ← IO.mkRef {}
+
+/-- The `simp_ifs_simps_proc` simp attribute for the simp rocs. -/
+initialize simpListsSimprocExt : Simp.SimprocExtension ←
+  Simp.registerSimprocAttr `simp_ifs_simps_proc "\
+    The `simp_ifs_simps_proc` attribute registers simp procedures to be used by `simp_ifs`
+    during its preprocessing phase." none --(some simpListsSimprocsRef)
+
+end Aeneas.SimpIfs

--- a/backends/lean/Aeneas/Std/Array/Array.lean
+++ b/backends/lean/Aeneas/Std/Array/Array.lean
@@ -23,13 +23,21 @@ instance [BEq α] : BEq (Array α n) := SubtypeBEq _
 instance [BEq α] [LawfulBEq α] : LawfulBEq (Array α n) := SubtypeLawfulBEq _
 
 /- Registering some theorems for `scalar_tac` -/
-@[scalar_tac a, scalar_tac_simps]
+@[scalar_tac_simps]
 theorem Array.length_eq {α : Type u} {n : Usize} (a : Array α n) : a.val.length = n.val := by
   cases a; simp[*]
 
--- TODO: move/remove?
-@[scalar_tac a]
-theorem Array.subtype_property {α : Type u} {n : Usize} {p : Array α n → Prop} (a : Subtype p) : p a.val := a.property
+-- TODO: remove
+@[scalar_tac a.val]
+theorem Array.length_eq' {α : Type u} {n : Usize} (a : Array α n) : a.val.length = n.val ∧ n.val ≤ Usize.max := by
+  cases a; simp[*]
+  scalar_tac
+
+-- TODO: remove
+@[scalar_tac a.val.length]
+theorem Array.length_eq'' {α : Type u} {n : Usize} (a : Array α n) : a.val.length = n.val ∧ n.val ≤ Usize.max := by
+  cases a; simp[*]
+  scalar_tac
 
 @[simp]
 abbrev Array.length {α : Type u} {n : Usize} (v : Array α n) : Nat := v.val.length

--- a/backends/lean/Aeneas/Std/Slice.lean
+++ b/backends/lean/Aeneas/Std/Slice.lean
@@ -23,13 +23,13 @@ instance [BEq α] : BEq (Slice α) := SubtypeBEq _
 
 instance [BEq α] [LawfulBEq α] : LawfulBEq (Slice α) := SubtypeLawfulBEq _
 
-@[scalar_tac s]
+@[scalar_tac s.val]
 theorem Slice.length_ineq {α : Type u} (s : Slice α) : s.val.length ≤ Usize.max := by
   cases s; simp[*]
 
--- TODO: move/remove?
-@[scalar_tac s]
-theorem Slice.subtype_property {α : Type u} {p : Slice α → Prop} (s : Subtype p) : p s.val := s.property
+-- TODO: update `scalar_tac` so that we can remove this theorem
+@[scalar_tac s.val.length]
+theorem Slice.length_ineq' {α : Type u} (s : Slice α) : s.val.length ≤ Usize.max := Slice.length_ineq s
 
 @[simp]
 abbrev Slice.length {α : Type u} (v : Slice α) : Nat := v.val.length

--- a/backends/lean/Aeneas/Std/Vec.lean
+++ b/backends/lean/Aeneas/Std/Vec.lean
@@ -27,13 +27,14 @@ instance [BEq α] : BEq (Vec α) := SubtypeBEq _
 
 instance [BEq α] [LawfulBEq α] : LawfulBEq (Vec α) := SubtypeLawfulBEq _
 
-@[scalar_tac v]
+@[scalar_tac v.val]
 theorem Vec.len_ineq {α : Type u} (v : Vec α) : v.val.length ≤ Usize.max := by
   cases v; simp[*]
 
--- TODO: move/remove?
-@[scalar_tac v]
-theorem Vec.subtype_property {α : Type u} {p : Vec α → Prop} (v : Subtype p) : p v.val := v.property
+-- TODO: update scalar_tac so that we can remove this one
+@[scalar_tac v.val.length]
+theorem Vec.len_ineq' {α : Type u} (v : Vec α) : v.val.length ≤ Usize.max := by
+  cases v; simp[*]
 
 @[simp]
 abbrev Vec.length {α : Type u} (v : Vec α) : Nat := v.val.length
@@ -317,9 +318,7 @@ namespace Tests
       (↑capacity : ℕ) * (↑dividend : ℕ) ≤ Usize.max ∧
         (↑capacity : ℕ) * (↑dividend : ℕ) ≥ (↑divisor : ℕ))
     (slots : alloc.vec.Vec (List α))
-    (h2 : (↑slots.len : ℕ) = (↑(alloc.vec.Vec.new (List α)).len : ℕ) + (↑capacity : ℕ))
-    (i1 : Usize)
-    (i2 : Usize) :
+    (h2 : (↑slots.len : ℕ) = (↑(alloc.vec.Vec.new (List α)).len : ℕ) + (↑capacity : ℕ)) :
     (↑(↑divisor : ℕ) : ℤ) ≤
     (↑(↑slots : List (List α)).length : ℤ) * (↑(↑dividend : ℕ) : ℤ)
     := by

--- a/tests/coq/arrays/Arrays.v
+++ b/tests/coq/arrays/Arrays.v
@@ -575,4 +575,36 @@ Definition sum_mut_slice
   i <- sum_mut_slice_loop n a 0%usize 0%u32; Ok (i, a)
 .
 
+(** [arrays::add_acc]: loop 0:
+    Source: 'tests/src/arrays.rs', lines 362:4-371:5 *)
+Fixpoint add_acc_loop
+  (n : nat) (pa_src : array u32 256%usize) (pe_dst : array u32 256%usize)
+  (i : usize) :
+  result ((array u32 256%usize) * (array u32 256%usize))
+  :=
+  match n with
+  | O => Fail_ OutOfFuel
+  | S n1 =>
+    if i s< 256%usize
+    then (
+      a <- array_index_usize pa_src i;
+      pa_src1 <- array_update_usize pa_src i 0%u32;
+      c <- array_index_usize pe_dst i;
+      c1 <- u32_add c a;
+      pe_dst1 <- array_update_usize pe_dst i c1;
+      i1 <- usize_add i 1%usize;
+      add_acc_loop n1 pa_src1 pe_dst1 i1)
+    else Ok (pa_src, pe_dst)
+  end
+.
+
+(** [arrays::add_acc]:
+    Source: 'tests/src/arrays.rs', lines 360:0-372:1 *)
+Definition add_acc
+  (n : nat) (pa_src : array u32 256%usize) (pe_dst : array u32 256%usize) :
+  result ((array u32 256%usize) * (array u32 256%usize))
+  :=
+  add_acc_loop n pa_src pe_dst 0%usize
+.
+
 End Arrays.

--- a/tests/fstar/arrays/Arrays.Clauses.Template.fst
+++ b/tests/fstar/arrays/Arrays.Clauses.Template.fst
@@ -36,3 +36,10 @@ unfold
 let sum_mut_slice_loop_decreases (a : slice u32) (i : usize) (s : u32) : nat =
   admit ()
 
+(** [arrays::add_acc]: decreases clause
+    Source: 'tests/src/arrays.rs', lines 362:4-371:5 *)
+unfold
+let add_acc_loop_decreases (pa_src : array u32 256) (pe_dst : array u32 256)
+  (i : usize) : nat =
+  admit ()
+

--- a/tests/fstar/arrays/Arrays.Clauses.fst
+++ b/tests/fstar/arrays/Arrays.Clauses.fst
@@ -35,3 +35,6 @@ unfold
 let sum_mut_slice_loop_decreases (a : slice u32) (i : usize) (s : u32) : nat =
   if i < slice_len a then slice_len a - i else 0
 
+unfold
+let add_acc_loop_decreases (pa_src : array u32 256) (pe_dst : array u32 256) (i : usize) : nat =
+  if i < 256 then 256 - i else 0

--- a/tests/fstar/arrays/Arrays.Funs.fst
+++ b/tests/fstar/arrays/Arrays.Funs.fst
@@ -474,3 +474,29 @@ let rec sum_mut_slice_loop
 let sum_mut_slice (a : slice u32) : result (u32 & (slice u32)) =
   let* i = sum_mut_slice_loop a 0 0 in Ok (i, a)
 
+(** [arrays::add_acc]: loop 0:
+    Source: 'tests/src/arrays.rs', lines 362:4-371:5 *)
+let rec add_acc_loop
+  (pa_src : array u32 256) (pe_dst : array u32 256) (i : usize) :
+  Tot (result ((array u32 256) & (array u32 256)))
+  (decreases (add_acc_loop_decreases pa_src pe_dst i))
+  =
+  if i < 256
+  then
+    let* a = array_index_usize pa_src i in
+    let* pa_src1 = array_update_usize pa_src i 0 in
+    let* c = array_index_usize pe_dst i in
+    let* c1 = u32_add c a in
+    let* pe_dst1 = array_update_usize pe_dst i c1 in
+    let* i1 = usize_add i 1 in
+    add_acc_loop pa_src1 pe_dst1 i1
+  else Ok (pa_src, pe_dst)
+
+(** [arrays::add_acc]:
+    Source: 'tests/src/arrays.rs', lines 360:0-372:1 *)
+let add_acc
+  (pa_src : array u32 256) (pe_dst : array u32 256) :
+  result ((array u32 256) & (array u32 256))
+  =
+  add_acc_loop pa_src pe_dst 0
+

--- a/tests/lean/Arrays.lean
+++ b/tests/lean/Arrays.lean
@@ -541,4 +541,32 @@ def sum_mut_slice (a : Slice U32) : Result (U32 × (Slice U32)) :=
   let i ← sum_mut_slice_loop a 0#usize 0#u32
   ok (i, a)
 
+/- [arrays::add_acc]: loop 0:
+   Source: 'tests/src/arrays.rs', lines 362:4-371:5 -/
+def add_acc_loop
+  (paSrc : Array U32 256#usize) (peDst : Array U32 256#usize) (i : Usize) :
+  Result ((Array U32 256#usize) × (Array U32 256#usize))
+  :=
+  if i < 256#usize
+  then
+    do
+    let a ← Array.index_usize paSrc i
+    let paSrc1 ← Array.update paSrc i 0#u32
+    let c ← Array.index_usize peDst i
+    let c1 ← c + a
+    let peDst1 ← Array.update peDst i c1
+    let i1 ← i + 1#usize
+    add_acc_loop paSrc1 peDst1 i1
+  else ok (paSrc, peDst)
+partial_fixpoint
+
+/- [arrays::add_acc]:
+   Source: 'tests/src/arrays.rs', lines 360:0-372:1 -/
+@[reducible]
+def add_acc
+  (paSrc : Array U32 256#usize) (peDst : Array U32 256#usize) :
+  Result ((Array U32 256#usize) × (Array U32 256#usize))
+  :=
+  add_acc_loop paSrc peDst 0#usize
+
 end arrays

--- a/tests/src/arrays.rs
+++ b/tests/src/arrays.rs
@@ -356,3 +356,17 @@ pub fn sum_mut_slice(a: &mut [u32]) -> u32 {
     }
     s
 }
+
+fn add_acc(paSrc: &mut [u32; 256], peDst: &mut [u32; 256]) {
+    let mut i = 0;
+    while (i < 256) {
+        let mut a = paSrc[i];
+        paSrc[i] = 0;
+
+        let mut c = peDst[i];
+        c += a;
+        peDst[i] = c;
+
+        i += 1;
+    }
+}


### PR DESCRIPTION
This PR does the following:
- the `saturate` tactic now has diagnostic information
- remove and update some `scalar_tac` patterns which trigger too many times, leading to important slowdowns
- `progress?` now prints shorter names (e.g., `U32.add` instead of `Aeneas.Std.U32.add`)
- it is now possible to jump to the location of theorems automatically introduced by `progress_pure` and `progress_pure_def`
- implements a new tactic `simp_ifs` to simplify `if then else` expressions with `scalar_tac`
- the Makefile now has a command `timed-lean` to measure the time necessary to recheck the individual Lean files in the tests
- fix minor issues with `progress*, `bvify` and `bv_tac`
- improve the micro-pass `PureMicroPasses.simplify_array_slice_update`
- it is now possible to use the syntax `progress by ...`, `let* ⟨ z, h1 ⟩ ← *` (similar to `progress as ⟨ z, h1 ⟩`) and `let* ⟨ z, h1 ⟩ ← *?` (similar to `progress? as ⟨ z, h1 ⟩`)