### PR TITLE
feat: Improve the Lean backend

### DIFF
--- a/backends/lean/Aeneas/Bvify/Bvify.lean
+++ b/backends/lean/Aeneas/Bvify/Bvify.lean
@@ -271,19 +271,21 @@ def bvifyAddSimpThms (n : Expr) : TacticM (Array FVarId) := do
   let eq_iff ← addThm ``BitVec.iff_ofNat_eq'
   pure #[le_iff, lt_iff, lt_max_iff, eq_iff]
 
+def bvifySimpConfig : Simp.Config := {maxDischargeDepth := 2, failIfUnchanged := false}
+
 def bvifyTacSimp (loc : Utils.Location) : TacticM Unit := do
   let args : ScalarTac.CondSimpArgs := {
       simpThms := #[← bvifySimpExt.getTheorems]
       simprocs := #[← bvifySimprocExt.getSimprocs]
     }
-  ScalarTac.condSimpTacSimp args loc #[] false
+  ScalarTac.condSimpTacSimp bvifySimpConfig args loc #[] false
 
 def bvifyTac (n : Expr) (loc : Utils.Location) : TacticM Unit := do
   let args : ScalarTac.CondSimpArgs := {
       simpThms := #[← bvifySimpExt.getTheorems]
       simprocs := #[← bvifySimprocExt.getSimprocs]
     }
-  ScalarTac.condSimpTac "bvify" args (bvifyAddSimpThms n) true loc
+  ScalarTac.condSimpTac "bvify" bvifySimpConfig args (bvifyAddSimpThms n) true loc
 
 syntax (name := bvify) "bvify " colGt term (location)? : tactic
 

--- a/backends/lean/Aeneas/Saturate/Tactic.lean
+++ b/backends/lean/Aeneas/Saturate/Tactic.lean
@@ -203,7 +203,8 @@ def arithComparisonConsts : Std.HashSet Name := Std.HashSet.ofList [
 ]
 
 def arithOpArity6 : Std.HashSet Name := Std.HashSet.ofList [
-  ``HShiftRight.hShiftRight, ``HShiftLeft.hShiftLeft, ``HPow.hPow, ``HMod.hMod
+  ``HShiftRight.hShiftRight, ``HShiftLeft.hShiftLeft,
+  ``HPow.hPow, ``HMod.hMod, ``HAdd.hAdd, ``HSub.hSub, ``HMul.hMul, ``HDiv.hDiv
 ]
 
 def exploreArithSubterms (f : Expr) (args : Array Expr) : MetaM (Array Expr) := do

--- a/backends/lean/Aeneas/ScalarTac/ScalarTac.lean
+++ b/backends/lean/Aeneas/ScalarTac/ScalarTac.lean
@@ -108,6 +108,8 @@ attribute [scalar_tac_simps]
   Int.reducePow Int.reduceAdd Int.reduceSub Int.reduceMul Int.reduceDiv Int.reduceMod
   Int.reduceNegSucc Int.reduceNeg Int.reduceToNat
   not_lt not_le
+  lt_inf_iff le_inf_iff
+  Fin.is_le'
 
 /- Small trick to prevent `simp_all` from simplifying an assumption `h1 : P v` when we have
   `h0 : ∀ x, P x` in the context: we replace the forall quantifiers with our own definition
@@ -167,6 +169,10 @@ attribute [scalar_tac_simps]
   true_or or_true false_or or_false
   Bool.true_eq_false Bool.false_eq_true
   decide_eq_true_eq decide_eq_false_iff_not Bool.or_eq_true Bool.and_eq_true
+  not_or
+
+@[scalar_tac_simps]
+theorem not_and_equiv_or_not (a b : Prop) : ¬ (a ∧ b) ↔ ¬ a ∨ ¬ b := by tauto
 
 /-  Boosting a bit the `omega` tac. -/
 def scalarTacPreprocess (config : Config) : Tactic.TacticM Unit := do

--- a/backends/lean/Aeneas/SimpIfs/SimpIfs.lean
+++ b/backends/lean/Aeneas/SimpIfs/SimpIfs.lean
@@ -25,7 +25,7 @@ def simpIfsTac (args : Args) (loc : Utils.Location) : TacticM Unit := do
       addSimpThms := args.addSimpThms,
       hypsToUse := args.hypsToUse,
     }
-  ScalarTac.condSimpTac "simp_ifs" args addSimpThms false loc
+  ScalarTac.condSimpTac "simp_ifs" {maxDischargeDepth := 2, failIfUnchanged := false} args addSimpThms false loc
 
 syntax (name := simp_ifs) "simp_ifs" ("[" term,* "]")? (location)? : tactic
 

--- a/backends/lean/Aeneas/SimpLists/SimpLists.lean
+++ b/backends/lean/Aeneas/SimpLists/SimpLists.lean
@@ -13,6 +13,8 @@ namespace Aeneas.SimpLists
 
 open Lean Lean.Meta Lean.Parser.Tactic Lean.Elab.Tactic
 
+attribute [simp_lists_simps] add_tsub_cancel_right add_tsub_cancel_left
+
 structure Args where
   declsToUnfold : Array Name := #[]
   addSimpThms : Array Name := #[]
@@ -27,7 +29,7 @@ def simpListsTac (args : Args) (loc : Utils.Location) : TacticM Unit := do
       addSimpThms := args.addSimpThms,
       hypsToUse := args.hypsToUse,
     }
-  ScalarTac.condSimpTac "simp_lists" args addSimpThms false loc
+  ScalarTac.condSimpTac "simp_lists" {maxDischargeDepth := 2, failIfUnchanged := false, contextual := true} args addSimpThms false loc
 
 syntax (name := simp_lists) "simp_lists" ("[" (term<|>"*"),* "]")? (location)? : tactic
 

--- a/backends/lean/Aeneas/Std/Scalar/EqOrd.lean
+++ b/backends/lean/Aeneas/Std/Scalar/EqOrd.lean
@@ -322,32 +322,58 @@ def core.cmp.impls.PartialOrdIsize.ge (x y : Isize) : Bool := x.val ≥ y.val
   ge := liftFun2 core.cmp.impls.PartialOrdIsize.ge }
 
 /- Name pattern: core::cmp::impls::{core::cmp::Ord<SCALAR>}::min -/
-def core.cmp.impls.OrdU8.min (x y : U8) : U8 := if x < y then x else y
-def core.cmp.impls.OrdU16.min (x y : U16) : U16 := if x < y then x else y
-def core.cmp.impls.OrdU32.min (x y : U32) : U32 := if x < y then x else y
-def core.cmp.impls.OrdU64.min (x y : U64) : U64 := if x < y then x else y
-def core.cmp.impls.OrdU128.min (x y : U128) : U128 := if x < y then x else y
-def core.cmp.impls.OrdUsize.min (x y : Usize) : Usize := if x < y then x else y
-def core.cmp.impls.OrdI8.min (x y : I8) : I8 := if x < y then x else y
-def core.cmp.impls.OrdI16.min (x y : I16) : I16 := if x < y then x else y
-def core.cmp.impls.OrdI32.min (x y : I32) : I32 := if x < y then x else y
-def core.cmp.impls.OrdI64.min (x y : I64) : I64 := if x < y then x else y
-def core.cmp.impls.OrdI128.min (x y : I128) : I128 := if x < y then x else y
-def core.cmp.impls.OrdIsize.min (x y : Isize) : Isize := if x < y then x else y
+@[progress_pure_def] def core.cmp.impls.OrdU8.min (x y : U8) : U8 := if x < y then x else y
+@[progress_pure_def] def core.cmp.impls.OrdU16.min (x y : U16) : U16 := if x < y then x else y
+@[progress_pure_def] def core.cmp.impls.OrdU32.min (x y : U32) : U32 := if x < y then x else y
+@[progress_pure_def] def core.cmp.impls.OrdU64.min (x y : U64) : U64 := if x < y then x else y
+@[progress_pure_def] def core.cmp.impls.OrdU128.min (x y : U128) : U128 := if x < y then x else y
+@[progress_pure_def] def core.cmp.impls.OrdUsize.min (x y : Usize) : Usize := if x < y then x else y
+@[progress_pure_def] def core.cmp.impls.OrdI8.min (x y : I8) : I8 := if x < y then x else y
+@[progress_pure_def] def core.cmp.impls.OrdI16.min (x y : I16) : I16 := if x < y then x else y
+@[progress_pure_def] def core.cmp.impls.OrdI32.min (x y : I32) : I32 := if x < y then x else y
+@[progress_pure_def] def core.cmp.impls.OrdI64.min (x y : I64) : I64 := if x < y then x else y
+@[progress_pure_def] def core.cmp.impls.OrdI128.min (x y : I128) : I128 := if x < y then x else y
+@[progress_pure_def] def core.cmp.impls.OrdIsize.min (x y : Isize) : Isize := if x < y then x else y
+
+@[simp, scalar_tac_simps] theorem core.cmp.impls.OrdU8.min_val (x y : U8) : (min x y).val = Nat.min x.val y.val := by simp [min]; split <;> simp <;> omega
+@[simp, scalar_tac_simps] theorem core.cmp.impls.OrdU16.min_val (x y : U16) : (min x y).val = Nat.min x.val y.val := by simp [min]; split <;> simp <;> omega
+@[simp, scalar_tac_simps] theorem core.cmp.impls.OrdU32.min_val (x y : U32) : (min x y).val = Nat.min x.val y.val := by simp [min]; split <;> simp <;> omega
+@[simp, scalar_tac_simps] theorem core.cmp.impls.OrdU64.min_val (x y : U64) : (min x y).val = Nat.min x.val y.val := by simp [min]; split <;> simp <;> omega
+@[simp, scalar_tac_simps] theorem core.cmp.impls.OrdU128.min_val (x y : U128) : (min x y).val = Nat.min x.val y.val := by simp [min]; split <;> simp <;> omega
+@[simp, scalar_tac_simps] theorem core.cmp.impls.OrdUsize.min_val (x y : Usize) : (min x y).val = Nat.min x.val y.val := by simp [min]; split <;> simp <;> omega
+@[simp, scalar_tac_simps] theorem core.cmp.impls.OrdI8.min_val (x y : I8) : (min x y).val = Min.min x.val y.val := by simp [min]; split <;> simp <;> omega
+@[simp, scalar_tac_simps] theorem core.cmp.impls.OrdI16.min_val (x y : I16) : (min x y).val = Min.min x.val y.val := by simp [min]; split <;> simp <;> omega
+@[simp, scalar_tac_simps] theorem core.cmp.impls.OrdI32.min_val (x y : I32) : (min x y).val = Min.min x.val y.val := by simp [min]; split <;> simp <;> omega
+@[simp, scalar_tac_simps] theorem core.cmp.impls.OrdI64.min_val (x y : I64) : (min x y).val = Min.min x.val y.val := by simp [min]; split <;> simp <;> omega
+@[simp, scalar_tac_simps] theorem core.cmp.impls.OrdI128.min_val (x y : I128) : (min x y).val = Min.min x.val y.val := by simp [min]; split <;> simp <;> omega
+@[simp, scalar_tac_simps] theorem core.cmp.impls.OrdIsize.min_val (x y : Isize) : (min x y).val = Min.min x.val y.val := by simp [min]; split <;> simp <;> omega
 
 /- Name pattern: core::cmp::impls::{core::cmp::Ord<SCALAR>}::max -/
-def core.cmp.impls.OrdU8.max (x y : U8) : U8 := if x < y then y else x
-def core.cmp.impls.OrdU16.max (x y : U16) : U16 := if x < y then y else x
-def core.cmp.impls.OrdU32.max (x y : U32) : U32 := if x < y then y else x
-def core.cmp.impls.OrdU64.max (x y : U64) : U64 := if x < y then y else x
-def core.cmp.impls.OrdU128.max (x y : U128) : U128 := if x < y then y else x
-def core.cmp.impls.OrdUsize.max (x y : Usize) : Usize := if x < y then y else x
-def core.cmp.impls.OrdI8.max (x y : I8) : I8 := if x < y then y else x
-def core.cmp.impls.OrdI16.max (x y : I16) : I16 := if x < y then y else x
-def core.cmp.impls.OrdI32.max (x y : I32) : I32 := if x < y then y else x
-def core.cmp.impls.OrdI64.max (x y : I64) : I64 := if x < y then y else x
-def core.cmp.impls.OrdI128.max (x y : I128) : I128 := if x < y then y else x
-def core.cmp.impls.OrdIsize.max (x y : Isize) : Isize := if x < y then y else x
+@[progress_pure_def] def core.cmp.impls.OrdU8.max (x y : U8) : U8 := if x < y then y else x
+@[progress_pure_def] def core.cmp.impls.OrdU16.max (x y : U16) : U16 := if x < y then y else x
+@[progress_pure_def] def core.cmp.impls.OrdU32.max (x y : U32) : U32 := if x < y then y else x
+@[progress_pure_def] def core.cmp.impls.OrdU64.max (x y : U64) : U64 := if x < y then y else x
+@[progress_pure_def] def core.cmp.impls.OrdU128.max (x y : U128) : U128 := if x < y then y else x
+@[progress_pure_def] def core.cmp.impls.OrdUsize.max (x y : Usize) : Usize := if x < y then y else x
+@[progress_pure_def] def core.cmp.impls.OrdI8.max (x y : I8) : I8 := if x < y then y else x
+@[progress_pure_def] def core.cmp.impls.OrdI16.max (x y : I16) : I16 := if x < y then y else x
+@[progress_pure_def] def core.cmp.impls.OrdI32.max (x y : I32) : I32 := if x < y then y else x
+@[progress_pure_def] def core.cmp.impls.OrdI64.max (x y : I64) : I64 := if x < y then y else x
+@[progress_pure_def] def core.cmp.impls.OrdI128.max (x y : I128) : I128 := if x < y then y else x
+@[progress_pure_def] def core.cmp.impls.OrdIsize.max (x y : Isize) : Isize := if x < y then y else x
+
+@[simp, scalar_tac_simps] theorem core.cmp.impls.OrdU8.max_val (x y : U8) : (max x y).val = Nat.max x.val y.val := by simp [max]; split <;> simp <;> omega
+@[simp, scalar_tac_simps] theorem core.cmp.impls.OrdU16.max_val (x y : U16) : (max x y).val = Nat.max x.val y.val := by simp [max]; split <;> simp <;> omega
+@[simp, scalar_tac_simps] theorem core.cmp.impls.OrdU32.max_val (x y : U32) : (max x y).val = Nat.max x.val y.val := by simp [max]; split <;> simp <;> omega
+@[simp, scalar_tac_simps] theorem core.cmp.impls.OrdU64.max_val (x y : U64) : (max x y).val = Nat.max x.val y.val := by simp [max]; split <;> simp <;> omega
+@[simp, scalar_tac_simps] theorem core.cmp.impls.OrdU128.max_val (x y : U128) : (max x y).val = Nat.max x.val y.val := by simp [max]; split <;> simp <;> omega
+@[simp, scalar_tac_simps] theorem core.cmp.impls.OrdUsize.max_val (x y : Usize) : (max x y).val = Nat.max x.val y.val := by simp [max]; split <;> simp <;> omega
+@[simp, scalar_tac_simps] theorem core.cmp.impls.OrdI8.max_val (x y : I8) : (max x y).val = Max.max x.val y.val := by simp [max]; split <;> simp <;> omega
+@[simp, scalar_tac_simps] theorem core.cmp.impls.OrdI16.max_val (x y : I16) : (max x y).val = Max.max x.val y.val := by simp [max]; split <;> simp <;> omega
+@[simp, scalar_tac_simps] theorem core.cmp.impls.OrdI32.max_val (x y : I32) : (max x y).val = Max.max x.val y.val := by simp [max]; split <;> simp <;> omega
+@[simp, scalar_tac_simps] theorem core.cmp.impls.OrdI64.max_val (x y : I64) : (max x y).val = Max.max x.val y.val := by simp [max]; split <;> simp <;> omega
+@[simp, scalar_tac_simps] theorem core.cmp.impls.OrdI128.max_val (x y : I128) : (max x y).val = Max.max x.val y.val := by simp [max]; split <;> simp <;> omega
+@[simp, scalar_tac_simps] theorem core.cmp.impls.OrdIsize.max_val (x y : Isize) : (max x y).val = Max.max x.val y.val := by simp [max]; split <;> simp <;> omega
 
 /- Name pattern: core::cmp::impls::{core::cmp::Ord<SCALAR>}::clamp -/
 def UScalar.clamp {ty} (self min max : UScalar ty) : Result (UScalar ty) := do

--- a/backends/lean/Aeneas/Std/Slice.lean
+++ b/backends/lean/Aeneas/Std/Slice.lean
@@ -102,17 +102,17 @@ theorem Slice.index_usize_spec {α : Type u} [Inhabited α] (v: Slice α) (i: Us
   simp at *
   simp [*]
 
-@[simp]
+@[simp, scalar_tac_simps, simp_lists_simps]
 theorem Slice.set_val_eq {α : Type u} (v: Slice α) (i: Usize) (x: α) :
   (v.set i x) = v.val.set i.val x := by
   simp [set]
 
-@[simp]
+@[simp, scalar_tac_simps, simp_lists_simps]
 theorem Slice.set_opt_val_eq {α : Type u} (v: Slice α) (i: Usize) (x: Option α) :
   (v.set_opt i x) = v.val.set_opt i.val x := by
   simp [set_opt]
 
-@[scalar_tac_simps]
+@[simp, scalar_tac_simps, simp_lists_simps]
 theorem Slice.set_length {α : Type u} (v: Slice α) (i: Usize) (x: α) :
   (v.set i x).length = v.length := by simp
 


### PR DESCRIPTION
This PR introduces lemmas to reason about `Ord::min` and `Ord::max` (for the instances of `Ord` which operate over scalars), and improves `bvify`, `simp_ifs` and `simp_lists`.