### PR TITLE
feat: make Aeneas more resilient to errors

### DIFF
--- a/src/Errors.ml
+++ b/src/Errors.ml
@@ -140,13 +140,15 @@ let cassert_warn (file : string) (line : int) (b : bool) (span : Meta.span)
 let exec_raise = craise
 let exec_assert = cassert
 
-let silent_unwrap_opt_span (file : string) (line : int)
-    (span : Meta.span option) (x : 'a option) : 'a =
+let unwrap_opt_span (file : string) (line : int) (span : Meta.span option)
+    (x : 'a option) (msg : string) : 'a =
   match x with
   | Some x -> x
-  | None ->
-      craise_opt_span_silent file line span
-        "Internal error: please file an issue"
+  | None -> craise_opt_span_silent file line span msg
+
+let silent_unwrap_opt_span (file : string) (line : int)
+    (span : Meta.span option) (x : 'a option) : 'a =
+  unwrap_opt_span file line span x "Internal error: please file an issue"
 
 let silent_unwrap (file : string) (line : int) (span : Meta.span)
     (x : 'a option) : 'a =

--- a/src/Logging.ml
+++ b/src/Logging.ml
@@ -23,6 +23,9 @@ let regions_hierarchy_log = create_logger "RegionsHierarchy"
 (** Logger for TypesAnalysis *)
 let types_analysis_log = create_logger "TypesAnalysis"
 
+(** Logger for FunsAnalysis *)
+let funs_analysis_log = create_logger "FunsAnalysis"
+
 (** Logger for Translate *)
 let translate_log = create_logger "Translate"
 

--- a/src/extract/Extract.ml
+++ b/src/extract/Extract.ml
@@ -2668,7 +2668,7 @@ let extract_trait_impl_register_names (ctx : extraction_ctx)
     | None -> ctx_compute_trait_impl_name ctx trait_decl trait_impl
     | Some info -> info.impl_name
   in
-  ctx_add trait_decl.item_meta.span (TraitImplId trait_impl.def_id) name ctx
+  ctx_add trait_impl.item_meta.span (TraitImplId trait_impl.def_id) name ctx
 
 (** Small helper.
 

--- a/src/interp/InterpreterExpansion.ml
+++ b/src/interp/InterpreterExpansion.ml
@@ -224,7 +224,7 @@ let compute_expanded_symbolic_non_builtin_adt_value (span : Meta.span)
     (generics : generic_args) (ctx : eval_ctx) : symbolic_expansion list =
   (* Lookup the definition and check if it is an enumeration with several
    * variants *)
-  let def = ctx_lookup_type_decl ctx def_id in
+  let def = ctx_lookup_type_decl span ctx def_id in
   sanity_check __FILE__ __LINE__
     (List.length generics.regions = List.length def.generics.regions)
     span;
@@ -653,7 +653,7 @@ let greedy_expand_symbolics_with_borrows (config : config) (span : Meta.span) :
             (* {!expand_symbolic_value_no_branching} checks if there are branchings,
              * but we prefer to also check it here - this leads to cleaner messages
              * and debugging *)
-            let def = ctx_lookup_type_decl ctx def_id in
+            let def = ctx_lookup_type_decl span ctx def_id in
             begin
               match def.kind with
               | Struct _ | Enum ([] | [ _ ]) -> ()

--- a/src/interp/InterpreterExpressions.ml
+++ b/src/interp/InterpreterExpressions.ml
@@ -993,7 +993,7 @@ let eval_rvalue_aggregate (config : config) (span : Meta.span)
             (aggregated, fun e -> e)
         | TAdtId def_id ->
             (* Sanity checks *)
-            let type_decl = ctx_lookup_type_decl ctx def_id in
+            let type_decl = ctx_lookup_type_decl span ctx def_id in
             sanity_check __FILE__ __LINE__
               (List.length type_decl.generics.regions
               = List.length generics.regions)

--- a/src/interp/InterpreterPaths.ml
+++ b/src/interp/InterpreterPaths.ml
@@ -378,7 +378,7 @@ let compute_expanded_bottom_adt_value (span : Meta.span) (ctx : eval_ctx)
      should be an enumeration if and only if the projection element
      is a field projection with *some* variant id. Retrieve the list
      of fields at the same time. *)
-  let def = ctx_lookup_type_decl ctx def_id in
+  let def = ctx_lookup_type_decl span ctx def_id in
   sanity_check __FILE__ __LINE__
     (List.length generics.regions = List.length def.generics.regions)
     span;

--- a/src/interp/InterpreterStatements.ml
+++ b/src/interp/InterpreterStatements.ml
@@ -650,7 +650,7 @@ let eval_transparent_function_call_symbolic_inst (span : Meta.span)
   | FnOpRegular func -> (
       match func.func with
       | FunId (FRegular fid) ->
-          let def = ctx_lookup_fun_decl ctx fid in
+          let def = ctx_lookup_fun_decl span ctx fid in
           log#ltrace
             (lazy
               ("fun call:\n- call: " ^ call_to_string ctx call
@@ -692,7 +692,7 @@ let eval_transparent_function_call_symbolic_inst (span : Meta.span)
           match trait_ref.trait_id with
           | TraitImpl (impl_id, impl_generics) -> begin
               (* Lookup the trait impl *)
-              let trait_impl = ctx_lookup_trait_impl ctx impl_id in
+              let trait_impl = ctx_lookup_trait_impl span ctx impl_id in
               log#ltrace
                 (lazy ("trait impl: " ^ trait_impl_to_string ctx trait_impl));
               (* Lookup the method *)
@@ -703,7 +703,7 @@ let eval_transparent_function_call_symbolic_inst (span : Meta.span)
               in
               let method_id = fn_ref.fun_id in
               let generics = fn_ref.fun_generics in
-              let method_def = ctx_lookup_fun_decl ctx method_id in
+              let method_def = ctx_lookup_fun_decl span ctx method_id in
               (* Instantiate *)
               let tr_self = trait_ref.trait_id in
               let fid : fun_id = FRegular method_id in
@@ -727,7 +727,7 @@ let eval_transparent_function_call_symbolic_inst (span : Meta.span)
           | _ ->
               (* We are using a local clause - we lookup the trait decl *)
               let trait_decl =
-                ctx_lookup_trait_decl ctx trait_decl_ref.trait_decl_id
+                ctx_lookup_trait_decl span ctx trait_decl_ref.trait_decl_id
               in
               (* Lookup the method decl in the required *and* the provided methods *)
               let fn_ref =
@@ -737,7 +737,7 @@ let eval_transparent_function_call_symbolic_inst (span : Meta.span)
               in
               let method_id = fn_ref.fun_id in
               let generics = fn_ref.fun_generics in
-              let method_def = ctx_lookup_fun_decl ctx method_id in
+              let method_def = ctx_lookup_fun_decl span ctx method_id in
               log#ltrace
                 (lazy ("method:\n" ^ fun_decl_to_string ctx method_def));
               (* Instantiate *)
@@ -762,7 +762,7 @@ let eval_transparent_function_call_symbolic_inst (span : Meta.span)
 let eval_global_as_fresh_symbolic_value (span : Meta.span)
     (gref : global_decl_ref) (ctx : eval_ctx) : symbolic_value =
   let generics = gref.global_generics in
-  let global = ctx_lookup_global_decl ctx gref.global_id in
+  let global = ctx_lookup_global_decl span ctx gref.global_id in
   cassert __FILE__ __LINE__ (ty_no_regions global.ty) span
     "Const globals should not contain regions";
   (* Instantiate the type  *)
@@ -924,7 +924,7 @@ and eval_global (config : config) (span : Meta.span) (dest : place)
   | ConcreteMode ->
       (* Treat the evaluation of the global as a call to the global body *)
       let generics = gref.global_generics in
-      let global = ctx_lookup_global_decl ctx gref.global_id in
+      let global = ctx_lookup_global_decl span ctx gref.global_id in
       let func = { func = FunId (FRegular global.body); generics } in
       let call = { func = FnOpRegular func; args = []; dest } in
       eval_transparent_function_call_concrete config span global.body call ctx
@@ -1187,7 +1187,7 @@ and eval_transparent_function_call_concrete (config : config) (span : Meta.span)
          in concrete mode yet *)
       sanity_check __FILE__ __LINE__ (generics.const_generics = []) span;
       (* Retrieve the (correctly instantiated) body *)
-      let def = ctx_lookup_fun_decl ctx fid in
+      let def = ctx_lookup_fun_decl span ctx fid in
       (* We can evaluate the function call only if it is not opaque *)
       let body =
         match def.body with

--- a/src/interp/Invariants.ml
+++ b/src/interp/Invariants.ml
@@ -430,7 +430,7 @@ let check_typing_invariant_visitor span ctx (lookups : bool) =
       | VAdt av, TAdt (TAdtId def_id, generics) ->
           (* Retrieve the definition to check the variant id, the number of
            * parameters, etc. *)
-          let def = ctx_lookup_type_decl ctx def_id in
+          let def = ctx_lookup_type_decl span ctx def_id in
           (* Check the number of parameters *)
           sanity_check __FILE__ __LINE__
             (List.length generics.regions = List.length def.generics.regions)
@@ -563,7 +563,7 @@ let check_typing_invariant_visitor span ctx (lookups : bool) =
       | AAdt av, TAdt (TAdtId def_id, generics) ->
           (* Retrieve the definition to check the variant id, the number of
            * parameters, etc. *)
-          let def = ctx_lookup_type_decl ctx def_id in
+          let def = ctx_lookup_type_decl span ctx def_id in
           (* Check the number of parameters *)
           sanity_check __FILE__ __LINE__
             (List.length generics.regions = List.length def.generics.regions)

--- a/src/llbc/Contexts.ml
+++ b/src/llbc/Contexts.ml
@@ -124,21 +124,30 @@ let ctx_lookup_var_binder (span : Meta.span) (ctx : eval_ctx) (vid : VarId.id) :
     var_binder =
   fst (env_lookup_var span ctx.env vid)
 
-let ctx_lookup_type_decl (ctx : eval_ctx) (tid : TypeDeclId.id) : type_decl =
-  TypeDeclId.Map.find tid ctx.crate.type_decls
+let ctx_lookup_type_decl (span : Meta.span) (ctx : eval_ctx)
+    (tid : TypeDeclId.id) : type_decl =
+  silent_unwrap_opt_span __FILE__ __LINE__ (Some span)
+    (TypeDeclId.Map.find_opt tid ctx.crate.type_decls)
 
-let ctx_lookup_fun_decl (ctx : eval_ctx) (fid : FunDeclId.id) : fun_decl =
-  FunDeclId.Map.find fid ctx.crate.fun_decls
+let ctx_lookup_fun_decl (span : Meta.span) (ctx : eval_ctx) (fid : FunDeclId.id)
+    : fun_decl =
+  silent_unwrap_opt_span __FILE__ __LINE__ (Some span)
+    (FunDeclId.Map.find_opt fid ctx.crate.fun_decls)
 
-let ctx_lookup_global_decl (ctx : eval_ctx) (gid : GlobalDeclId.id) :
-    global_decl =
-  GlobalDeclId.Map.find gid ctx.crate.global_decls
+let ctx_lookup_global_decl (span : Meta.span) (ctx : eval_ctx)
+    (gid : GlobalDeclId.id) : global_decl =
+  silent_unwrap_opt_span __FILE__ __LINE__ (Some span)
+    (GlobalDeclId.Map.find_opt gid ctx.crate.global_decls)
 
-let ctx_lookup_trait_decl (ctx : eval_ctx) (id : TraitDeclId.id) : trait_decl =
-  TraitDeclId.Map.find id ctx.crate.trait_decls
+let ctx_lookup_trait_decl (span : Meta.span) (ctx : eval_ctx)
+    (id : TraitDeclId.id) : trait_decl =
+  silent_unwrap_opt_span __FILE__ __LINE__ (Some span)
+    (TraitDeclId.Map.find_opt id ctx.crate.trait_decls)
 
-let ctx_lookup_trait_impl (ctx : eval_ctx) (id : TraitImplId.id) : trait_impl =
-  TraitImplId.Map.find id ctx.crate.trait_impls
+let ctx_lookup_trait_impl (span : Meta.span) (ctx : eval_ctx)
+    (id : TraitImplId.id) : trait_impl =
+  silent_unwrap_opt_span __FILE__ __LINE__ (Some span)
+    (TraitImplId.Map.find_opt id ctx.crate.trait_impls)
 
 (** Retrieve a variable's value in the current frame *)
 let env_lookup_var_value (span : Meta.span) (env : env) (vid : VarId.id) :
@@ -473,10 +482,10 @@ let env_filter_abs (f : abs -> bool) (env : env) : env =
     **IMPORTANT**: this function doesn't normalize the types, you may want to
     use the [AssociatedTypes] equivalent instead.
 *)
-let ctx_type_get_instantiated_variants_fields_types (ctx : eval_ctx)
-    (def_id : TypeDeclId.id) (generics : generic_args) :
+let ctx_type_get_instantiated_variants_fields_types (span : Meta.span)
+    (ctx : eval_ctx) (def_id : TypeDeclId.id) (generics : generic_args) :
     (VariantId.id option * ty list) list =
-  let def = ctx_lookup_type_decl ctx def_id in
+  let def = ctx_lookup_type_decl span ctx def_id in
   Substitute.type_decl_get_instantiated_variants_fields_types def generics
 
 (** Return the types of the properly instantiated ADT's variant, provided a
@@ -485,10 +494,10 @@ let ctx_type_get_instantiated_variants_fields_types (ctx : eval_ctx)
     **IMPORTANT**: this function doesn't normalize the types, you may want to
     use the [AssociatedTypes] equivalent instead.
 *)
-let ctx_type_get_instantiated_field_types (ctx : eval_ctx)
+let ctx_type_get_instantiated_field_types (span : Meta.span) (ctx : eval_ctx)
     (def_id : TypeDeclId.id) (opt_variant_id : VariantId.id option)
     (generics : generic_args) : ty list =
-  let def = ctx_lookup_type_decl ctx def_id in
+  let def = ctx_lookup_type_decl span ctx def_id in
   Substitute.type_decl_get_instantiated_field_types def opt_variant_id generics
 
 (** Return the types of the properly instantiated ADT value (note that
@@ -503,7 +512,7 @@ let ctx_adt_get_instantiated_field_types (span : Meta.span) (ctx : eval_ctx)
   match id with
   | TAdtId id ->
       (* Retrieve the types of the fields *)
-      ctx_type_get_instantiated_field_types ctx id variant_id generics
+      ctx_type_get_instantiated_field_types span ctx id variant_id generics
   | TTuple ->
       cassert __FILE__ __LINE__ (variant_id = None) span
         "Tuples don't have variants";

--- a/src/llbc/RegionsHierarchy.ml
+++ b/src/llbc/RegionsHierarchy.ml
@@ -167,9 +167,11 @@ let compute_regions_hierarchy_for_sig (span : Meta.span option) (crate : crate)
     | TRawPtr (ty, _) -> explore_ty outer ty
     | TTraitType (trait_ref, _) ->
         (* The trait should reference a clause, and not an implementation
-           (otherwise it should have been normalized) *)
+           (otherwise it should have been normalized), or a special builtin
+           trait (in particular, [core::marker::DiscriminantKind]) *)
         sanity_check_opt_span __FILE__ __LINE__
-          (AssociatedTypes.trait_instance_id_is_local_clause trait_ref.trait_id)
+          (AssociatedTypes.check_non_normalizable_trait_instance_id
+             trait_ref.trait_id)
           span;
         (* We have nothing to do *)
         ()

--- a/src/llbc/RegionsHierarchy.ml
+++ b/src/llbc/RegionsHierarchy.ml
@@ -129,7 +129,10 @@ let compute_regions_hierarchy_for_sig (span : Meta.span option) (crate : crate)
         (match id with
         | TAdtId id ->
             (* Lookup the type declaration *)
-            let decl = TypeDeclId.Map.find id crate.type_decls in
+            let decl =
+              silent_unwrap_opt_span __FILE__ __LINE__ span
+                (TypeDeclId.Map.find_opt id crate.type_decls)
+            in
             (* Instantiate the predicates *)
             let subst = Subst.make_subst_from_generics decl.generics generics in
             let predicates = Subst.predicates_substitute subst decl.generics in

--- a/src/llbc/TypesAnalysis.ml
+++ b/src/llbc/TypesAnalysis.ml
@@ -451,18 +451,6 @@ let analyze_type_declaration_group (type_decls : type_decl TypeDeclId.Map.t)
   in
   analyze infos
 
-(** Compute the type information for every *type definition* in a list of
-    declarations. This type definition information is later used to easily
-    compute the information of arbitrary types.
-    
-    Rk.: pay attention to the difference between type definitions and types!
- *)
-let analyze_type_declarations (type_decls : type_decl TypeDeclId.Map.t)
-    (decls : type_declaration_group list) : type_infos =
-  List.fold_left
-    (fun infos decl -> analyze_type_declaration_group type_decls infos decl)
-    TypeDeclId.Map.empty decls
-
 (** Analyze a type to check whether it contains borrows, etc., provided
     we have already analyzed the type definitions in the context.
  *)


### PR DESCRIPTION
This PR makes Aeneas more resilient to errors, in particular when some errors lead to missing information (resulting from, e.g., `TypesAnalysis.ml` or `FunsAnalysis.ml`) or definitions.