### PR TITLE
feat: add default `clone_from` implementation in `core.clone.Clone`

### DIFF
--- a/backends/lean/Aeneas/Std/Core.lean
+++ b/backends/lean/Aeneas/Std/Core.lean
@@ -49,7 +49,8 @@ end ops -- core.ops
 /- Trait declaration: [core::clone::Clone] -/
 structure clone.Clone (Self : Type) where
   clone : Self → Result Self
-  clone_from : Self → Self → Result Self
+  clone_from : Self → Self → Result Self := fun _ => clone
+
 
 def clone.Clone.from_from.default {Self : Type} (clone : Self → Result Self)
   (_self source : Self) : Result Self :=


### PR DESCRIPTION
Fixes https://github.com/AeneasVerif/aeneas/issues/493.

The default implementation was adapted from `Std.Array`, where the first argument (the destination) is ignored.
https://github.com/AeneasVerif/aeneas/blob/d3929d5fe3cea774a2ffcec7b480fefd31f43591/backends/lean/Aeneas/Std/Array/Array.lean#L207-L215