### PR TITLE
Update charon

### DIFF
--- a/charon-pin
+++ b/charon-pin
@@ -1,2 +1,2 @@
 # This is the commit from https://github.com/AeneasVerif/charon that should be used with this version of aeneas.
-a304134920a7c951bfa7f1a68602645ae5e58dfd
+d1708f75b62d361c918e2df406c59dd639f3c6ee

--- a/flake.lock
+++ b/flake.lock
@@ -13,11 +13,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1744717180,
-        "narHash": "sha256-U4MYRszRN3uLhF0IRVwNnMLh83fznjzgRVzitqLQLCM=",
+        "lastModified": 1744816015,
+        "narHash": "sha256-lteQjQOh6QrODUBr9oZY84xq8lP56KzmqOqPIiCbO10=",
         "owner": "aeneasverif",
         "repo": "charon",
-        "rev": "a304134920a7c951bfa7f1a68602645ae5e58dfd",
+        "rev": "d1708f75b62d361c918e2df406c59dd639f3c6ee",
         "type": "github"
       },
       "original": {

--- a/src/interp/InterpreterStatements.ml
+++ b/src/interp/InterpreterStatements.ml
@@ -866,9 +866,6 @@ and eval_statement_raw (config : config) (st : statement) : stl_cm_fun =
           let cc = cc_comp cc cf_assign in
           (* Compose and apply *)
           ([ (ctx, res) ], cc_singleton __FILE__ __LINE__ st.span cc))
-  | FakeRead p ->
-      let ctx, cc = eval_fake_read config st.span p ctx in
-      ([ (ctx, Unit) ], cc_singleton __FILE__ __LINE__ st.span cc)
   | SetDiscriminant (p, variant_id) ->
       let (ctx, res), cc = set_discriminant config st.span p variant_id ctx in
       ([ (ctx, res) ], cc_singleton __FILE__ __LINE__ st.span cc)
@@ -883,7 +880,8 @@ and eval_statement_raw (config : config) (st : statement) : stl_cm_fun =
   | Return -> ([ (ctx, Return) ], cf_singleton __FILE__ __LINE__ st.span)
   | Break i -> ([ (ctx, Break i) ], cf_singleton __FILE__ __LINE__ st.span)
   | Continue i -> ([ (ctx, Continue i) ], cf_singleton __FILE__ __LINE__ st.span)
-  | Nop -> ([ (ctx, Unit) ], cf_singleton __FILE__ __LINE__ st.span)
+  | StorageLive _ | Nop ->
+      ([ (ctx, Unit) ], cf_singleton __FILE__ __LINE__ st.span)
   | Sequence (st1, st2) ->
       (* Evaluate the first statement *)
       let ctx_resl, cf_st1 = eval_statement config st1 ctx in
@@ -918,6 +916,9 @@ and eval_statement_raw (config : config) (st : statement) : stl_cm_fun =
       let eval_loop_body = eval_statement config loop_body in
       InterpreterLoops.eval_loop config st.span eval_loop_body ctx
   | Switch switch -> eval_switch config st.span switch ctx
+  | Deinit _ | StorageDead _ ->
+      craise __FILE__ __LINE__ st.span
+        "StorageDead/Deinit should have been removed in a prepass"
   | Error s -> craise __FILE__ __LINE__ st.span s
 
 and eval_global (config : config) (span : Meta.span) (dest : place)


### PR DESCRIPTION
Companion PR to https://github.com/AeneasVerif/charon/pull/655.

cc @sonmarcho to notify you that there's now `StorageLive`, `StorageDead` and `Deinit` in llbc. I merged `StorageDead` and `Deinit` into `Drop` as a pre-pass so nothing much has to change.