### PR TITLE
Companion to Charon #663

### DIFF
--- a/charon-pin
+++ b/charon-pin
@@ -1,2 +1,2 @@
 # This is the commit from https://github.com/AeneasVerif/charon that should be used with this version of aeneas.
-b2d1104568425d10b0e6ce10f02b48e4aab0918a
+f1566f4c05abc7bb94b1de86b244dcda9018cbc5

--- a/flake.lock
+++ b/flake.lock
@@ -9,11 +9,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1745415006,
-        "narHash": "sha256-GpppbN7xaWpvc+nenqhYCdCQ+AJlGK2BMdXE3myShdY=",
+        "lastModified": 1745416143,
+        "narHash": "sha256-CshU6g1EJ+iysphjuNOdh6/r27vVN6PUoNLhj1qMzJo=",
         "owner": "aeneasverif",
         "repo": "charon",
-        "rev": "b2d1104568425d10b0e6ce10f02b48e4aab0918a",
+        "rev": "f1566f4c05abc7bb94b1de86b244dcda9018cbc5",
         "type": "github"
       },
       "original": {

--- a/src/extract/ExtractTypes.ml
+++ b/src/extract/ExtractTypes.ml
@@ -59,7 +59,8 @@ let extract_literal (span : Meta.span) (fmt : F.formatter) (is_pattern : bool)
         | Coq | FStar | Lean -> if b then "true" else "false"
       in
       F.pp_print_string fmt b
-  | VChar c -> (
+  | VChar c when Uchar.is_char c -> (
+      let c = Uchar.to_char c in
       match backend () with
       | HOL4 ->
           (* [#"a"] is a notation for [CHR 97] (97 is the ASCII code for 'a') *)
@@ -78,9 +79,11 @@ let extract_literal (span : Meta.span) (fmt : F.formatter) (is_pattern : bool)
           in
           F.pp_print_string fmt c;
           if inside then F.pp_print_string fmt ")")
-  | VFloat _ | VStr _ | VByteStr _ ->
+  | VChar _ | VFloat _ | VStr _ | VByteStr _ ->
       admit_raise __FILE__ __LINE__ span
-        "Float, string and byte string literals are unsupported" fmt
+        "Float, string, non-ASCII chars and byte string literals are \
+         unsupported"
+        fmt
 
 let is_single_opaque_fun_decl_group (dg : Pure.fun_decl list) : bool =
   match dg with


### PR DESCRIPTION
Handle `VChar` constants with `Uchar` (we give up for non-ASCII cases, as I do not know how these are handled in the different backends).
Companion to https://github.com/AeneasVerif/charon/pull/663