### PR TITLE
Companion to Charon #662

### DIFF
--- a/charon-pin
+++ b/charon-pin
@@ -1,2 +1,2 @@
 # This is the commit from https://github.com/AeneasVerif/charon that should be used with this version of aeneas.
-d1708f75b62d361c918e2df406c59dd639f3c6ee
+6dc07de6e169dfad6beffc4927bf26bfa2b8e295

--- a/flake.lock
+++ b/flake.lock
@@ -13,11 +13,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1744816015,
-        "narHash": "sha256-lteQjQOh6QrODUBr9oZY84xq8lP56KzmqOqPIiCbO10=",
+        "lastModified": 1745408019,
+        "narHash": "sha256-iq+pjpWhdtEQiyImEDM1LFtjpot/B7ByU/W06t0nlGs=",
         "owner": "aeneasverif",
         "repo": "charon",
-        "rev": "d1708f75b62d361c918e2df406c59dd639f3c6ee",
+        "rev": "6dc07de6e169dfad6beffc4927bf26bfa2b8e295",
         "type": "github"
       },
       "original": {

--- a/src/interp/InterpreterExpressions.ml
+++ b/src/interp/InterpreterExpressions.ml
@@ -451,6 +451,9 @@ let eval_operand_no_reorganize (config : config) (span : Meta.span)
       | CRawMemory _ ->
           craise __FILE__ __LINE__ span
             "Raw memory cannot be interpreted by the interpreter"
+      | COpaque reason ->
+          craise __FILE__ __LINE__ span
+            ("Charon failed to compile constant: " ^ reason)
     end
   | Copy p ->
       (* Access the value *)


### PR DESCRIPTION
Handle the new constant `COpaque` -- companion to https://github.com/AeneasVerif/charon/pull/662