### PR TITLE
feat: erase macro scopes for progress* generated identifiers

### DIFF
--- a/backends/lean/Aeneas/Progress/ProgressStar.lean
+++ b/backends/lean/Aeneas/Progress/ProgressStar.lean
@@ -233,7 +233,7 @@ where
       else
         trace[ProgressStar] "onBind: all preconditions solved"
       /- Update the main goal, if necessary -/
-      let ids ← getIdsFromUsedTheorem name usedTheorem
+      let ids ← getIdsFromUsedTheorem name.eraseMacroScopes usedTheorem
       trace[ProgressStar] "onBind: ids from used theorem: {ids}"
       let mainGoal ← do mainGoal.mapM fun mainGoal => do
         if ¬ ids.isEmpty then renameInaccessibles mainGoal ids -- NOTE: Taken from renameI tactic


### PR DESCRIPTION
When `progress*` encountered a function which returned a product that was destructured in its progress theorem, some hygenic names would be used as part of the identifier. This change removes the macro scopes from those names.