### PR TITLE
Register charon into the current opam switch after rebuilding it

### DIFF
--- a/scripts/check-charon-install.sh
+++ b/scripts/check-charon-install.sh
@@ -8,9 +8,9 @@ fi
 
 rebuild() {
     if which nix 2> /dev/null 1>&2; then
-        nix develop --command bash -c "make test"
+        nix develop --command bash -c "make test && opam install . -y"
     elif which rustup 2> /dev/null 1>&2; then
-        make test
+        make test && opam install . -y
     else
         echo 'Error: Neither `rustup` nor `nix` appears to be installed. Install one or the other in order to build `charon`.'
         exit 1


### PR DESCRIPTION
This should be non-destructive as `opam install` succeeds even if the library already exists.