### PR TITLE
Introduce macros to factor out the scalar definitions and theorems

### DIFF
--- a/backends/lean/Aeneas/Std/Scalar/Bitwise.lean
+++ b/backends/lean/Aeneas/Std/Scalar/Bitwise.lean
@@ -1,11 +1,12 @@
 import Aeneas.Std.Scalar.Core
+import Aeneas.Std.Scalar.Elab
 import Aeneas.ScalarTac
 import Aeneas.Std.Core
 import Mathlib.Data.BitVec
 
 namespace Aeneas.Std
 
-open Result Error Arith
+open Result Error Arith ScalarElab
 
 /-!
 # Bitwise Operations: Definitions
@@ -169,29 +170,9 @@ theorem UScalar.ShiftRight_spec {ty0 ty1} (x : UScalar ty0) (y : UScalar ty1)
   simp only [BitVec.ushiftRight_eq, ok.injEq, _root_.exists_eq_left', val]
   simp only [HShiftRight.hShiftRight, BitVec.ushiftRight, bv_toNat, BitVec.toNat_ofNatLT, and_self]
 
-@[progress] theorem U8.ShiftRight_spec (x : U8) (y : UScalar ty1) (hy : y.val < 8) :
-  ∃ (z : U8), x >>> y = ok z ∧ z.val = x.val >>> y.val ∧ z.bv = x.bv >>> y.val
+uscalar @[progress] theorem «%S».ShiftRight_spec {ty1} (x : «%S») (y : UScalar ty1) (hy : y.val < %BitWidth) :
+  ∃ (z : «%S»), x >>> y = ok z ∧ z.val = x.val >>> y.val ∧ z.bv = x.bv >>> y.val
   := by apply UScalar.ShiftRight_spec; simp [*]
-
-@[progress] theorem U16.ShiftRight_spec (x : U16) (y : UScalar ty1) (hy : y.val < 16) :
-  ∃ (z : U16), x >>> y = ok z ∧ z.val = x.val >>> y.val ∧ z.bv = x.bv >>> y.val
-  := by apply UScalar.ShiftRight_spec; simp [*]
-
-@[progress] theorem U32.ShiftRight_spec (x : U32) (y : UScalar ty1) (hy : y.val < 32) :
-  ∃ (z : U32), x >>> y = ok z ∧ z.val = x.val >>> y.val ∧ z.bv = x.bv >>> y.val
-  := by apply UScalar.ShiftRight_spec; simp [*]
-
-@[progress] theorem U64.ShiftRight_spec (x : U64) (y : UScalar ty1) (hy : y.val < 64) :
-  ∃ (z : U64), x >>> y = ok z ∧ z.val = x.val >>> y.val ∧ z.bv = x.bv >>> y.val
-  := by apply UScalar.ShiftRight_spec; simp [*]
-
-@[progress] theorem U128.ShiftRight_spec (x : U128) (y : UScalar ty1) (hy : y.val < 128) :
-  ∃ (z : U128), x >>> y = ok z ∧ z.val = x.val >>> y.val ∧ z.bv = x.bv >>> y.val
-  := by apply UScalar.ShiftRight_spec; simp [*]
-
-@[progress] theorem Usize.ShiftRight_spec (x : Usize) (y : UScalar ty1) (hy : y.val < UScalarTy.Usize.numBits) :
-  ∃ (z : Usize), x >>> y = ok z ∧ z.val = x.val >>> y.val ∧ z.bv = x.bv >>> y.val
-  := by apply UScalar.ShiftRight_spec; simp only [*]
 
 theorem UScalar.ShiftRight_IScalar_spec {ty0 ty1} (x : UScalar ty0) (y : IScalar ty1)
   (hy0 : 0 ≤ y.val) (hy1 : y.val < ty0.numBits) :
@@ -202,29 +183,9 @@ theorem UScalar.ShiftRight_IScalar_spec {ty0 ty1} (x : UScalar ty0) (y : IScalar
   simp only [BitVec.ushiftRight_eq, ok.injEq, _root_.exists_eq_left', val, Nat.instShiftRight]
   simp only [IScalar.toNat, BitVec.toNat_ushiftRight, bv_toNat, Nat.shiftRight_eq, and_self]
 
-@[progress] theorem U8.ShiftRight_IScalar_spec (x : U8) (y : IScalar ty1) (hy0 : 0 ≤ y.val) (hy : y.val < 8) :
-  ∃ (z : U8), x >>> y = ok z ∧ z.val = x.val >>> y.toNat ∧ z.bv = x.bv >>> y.toNat
+uscalar @[progress] theorem «%S».ShiftRight_IScalar_spec {ty1} (x : «%S») (y : IScalar ty1) (hy0 : 0 ≤ y.val) (hy : y.val < %BitWidth) :
+  ∃ (z : «%S»), x >>> y = ok z ∧ z.val = x.val >>> y.toNat ∧ z.bv = x.bv >>> y.toNat
   := by apply UScalar.ShiftRight_IScalar_spec <;> simp [*]
-
-@[progress] theorem U16.ShiftRight_IScalar_spec (x : U16) (y : IScalar ty1) (hy0 : 0 ≤ y.val) (hy : y.val < 16) :
-  ∃ (z : U16), x >>> y = ok z ∧ z.val = x.val >>> y.toNat ∧ z.bv = x.bv >>> y.toNat
-  := by apply UScalar.ShiftRight_IScalar_spec <;> simp [*]
-
-@[progress] theorem U32.ShiftRight_IScalar_spec (x : U32) (y : IScalar ty1) (hy0 : 0 ≤ y.val) (hy : y.val < 32) :
-  ∃ (z : U32), x >>> y = ok z ∧ z.val = x.val >>> y.toNat ∧ z.bv = x.bv >>> y.toNat
-  := by apply UScalar.ShiftRight_IScalar_spec <;> simp [*]
-
-@[progress] theorem U64.ShiftRight_IScalar_spec (x : U64) (y : IScalar ty1) (hy0 : 0 ≤ y.val) (hy : y.val < 64) :
-  ∃ (z : U64), x >>> y = ok z ∧ z.val = x.val >>> y.toNat ∧ z.bv = x.bv >>> y.toNat
-  := by apply UScalar.ShiftRight_IScalar_spec <;> simp [*]
-
-@[progress] theorem U128.ShiftRight_IScalar_spec (x : U128) (y : IScalar ty1) (hy0 : 0 ≤ y.val) (hy : y.val < 128) :
-  ∃ (z : U128), x >>> y = ok z ∧ z.val = x.val >>> y.toNat ∧ z.bv = x.bv >>> y.toNat
-  := by apply UScalar.ShiftRight_IScalar_spec <;> simp [*]
-
-@[progress] theorem Usize.ShiftRight_IScalar_spec (x : Usize) (y : IScalar ty1) (hy0 : 0 ≤ y.val) (hy : y.val < UScalarTy.Usize.numBits) :
-  ∃ (z : Usize), x >>> y = ok z ∧ z.val = x.val >>> y.toNat ∧ z.bv = x.bv >>> y.toNat
-  := by apply UScalar.ShiftRight_IScalar_spec <;> simp only [*]
 
 theorem UScalar.ShiftLeft_spec {ty0 ty1} (x : UScalar ty0) (y : UScalar ty1) (size : Nat)
   (hy : y.val < ty0.numBits) (hsize : size = UScalar.size ty0) :
@@ -236,29 +197,9 @@ theorem UScalar.ShiftLeft_spec {ty0 ty1} (x : UScalar ty0) (y : UScalar ty1) (si
   simp only [BitVec.shiftLeft_eq, ok.injEq, _root_.exists_eq_left', val]
   simp only [bv_toNat, BitVec.toNat_shiftLeft, ShiftLeft.shiftLeft, Nat.shiftLeft_eq', and_self]
 
-@[progress] theorem U8.ShiftLeft_spec (x : U8) (y : UScalar ty1) (hy : y.val < 8) :
-  ∃ (z : U8), x <<< y = ok z ∧ z.val = (x.val <<< y.val) % U8.size ∧ z.bv = x.bv <<< y.val
+uscalar @[progress] theorem «%S».ShiftLeft_spec {ty1} (x : «%S») (y : UScalar ty1) (hy : y.val < %BitWidth) :
+  ∃ (z : «%S»), x <<< y = ok z ∧ z.val = (x.val <<< y.val) % «%S».size ∧ z.bv = x.bv <<< y.val
   := by apply UScalar.ShiftLeft_spec <;> simp [*]
-
-@[progress] theorem U16.ShiftLeft_spec (x : U16) (y : UScalar ty1) (hy : y.val < 16) :
-  ∃ (z : U16), x <<< y = ok z ∧ z.val = (x.val <<< y.val) % U16.size ∧ z.bv = x.bv <<< y.val
-  := by apply UScalar.ShiftLeft_spec <;> simp [*]
-
-@[progress] theorem U32.ShiftLeft_spec (x : U32) (y : UScalar ty1) (hy : y.val < 32) :
-  ∃ (z : U32), x <<< y = ok z ∧ z.val = (x.val <<< y.val) % U32.size ∧ z.bv = x.bv <<< y.val
-  := by apply UScalar.ShiftLeft_spec <;> simp [*]
-
-@[progress] theorem U64.ShiftLeft_spec (x : U64) (y : UScalar ty1) (hy : y.val < 64) :
-  ∃ (z : U64), x <<< y = ok z ∧ z.val = (x.val <<< y.val) % U64.size ∧ z.bv = x.bv <<< y.val
-  := by apply UScalar.ShiftLeft_spec <;> simp [*]
-
-@[progress] theorem U128.ShiftLeft_spec (x : U128) (y : UScalar ty1) (hy : y.val < 128) :
-  ∃ (z : U128), x <<< y = ok z ∧ z.val = (x.val <<< y.val) % U128.size ∧ z.bv = x.bv <<< y.val
-  := by apply UScalar.ShiftLeft_spec <;> simp [*]
-
-@[progress] theorem Usize.ShiftLeft_spec (x : Usize) (y : UScalar ty1) (hy : y.val < UScalarTy.Usize.numBits) :
-  ∃ (z : Usize), x <<< y = ok z ∧ z.val = (x.val <<< y.val) % Usize.size ∧ z.bv = x.bv <<< y.val
-  := by apply UScalar.ShiftLeft_spec <;> simp_all
 
 theorem UScalar.ShiftLeft_IScalar_spec {ty0 ty1} (x : UScalar ty0) (y : IScalar ty1) (size : Nat)
   (hy0 : 0 ≤ y.val) (hy1 : y.val < ty0.numBits) (hsize : size = UScalar.size ty0) :
@@ -272,29 +213,9 @@ theorem UScalar.ShiftLeft_IScalar_spec {ty0 ty1} (x : UScalar ty0) (y : IScalar 
   simp only [IScalar.toNat, BitVec.toNat_shiftLeft, bv_toNat, ShiftLeft.shiftLeft,
     Nat.shiftLeft_eq', and_self]
 
-@[progress] theorem U8.ShiftLeft_IScalar_spec (x : U8) (y : IScalar ty1) (hy0 : 0 ≤ y.val) (hy : y.val < 8) :
-  ∃ (z : U8), x <<< y = ok z ∧ z.val = (x.val <<< y.toNat) % U8.size ∧ z.bv = x.bv <<< y.toNat
+uscalar @[progress] theorem «%S».ShiftLeft_IScalar_spec {ty1} (x : «%S») (y : IScalar ty1) (hy0 : 0 ≤ y.val) (hy : y.val < %BitWidth) :
+  ∃ (z : «%S»), x <<< y = ok z ∧ z.val = (x.val <<< y.toNat) % «%S».size ∧ z.bv = x.bv <<< y.toNat
   := by apply UScalar.ShiftLeft_IScalar_spec <;> simp [*]
-
-@[progress] theorem U16.ShiftLeft_IScalar_spec (x : U16) (y : IScalar ty1) (hy0 : 0 ≤ y.val) (hy : y.val < 16) :
-  ∃ (z : U16), x <<< y = ok z ∧ z.val = (x.val <<< y.toNat) % U16.size ∧ z.bv = x.bv <<< y.toNat
-  := by apply UScalar.ShiftLeft_IScalar_spec <;> simp [*]
-
-@[progress] theorem U32.ShiftLeft_IScalar_spec (x : U32) (y : IScalar ty1) (hy0 : 0 ≤ y.val) (hy : y.val < 32) :
-  ∃ (z : U32), x <<< y = ok z ∧ z.val = (x.val <<< y.toNat) % U32.size ∧ z.bv = x.bv <<< y.toNat
-  := by apply UScalar.ShiftLeft_IScalar_spec <;> simp [*]
-
-@[progress] theorem U64.ShiftLeft_IScalar_spec (x : U64) (y : IScalar ty1) (hy0 : 0 ≤ y.val) (hy : y.val < 64) :
-  ∃ (z : U64), x <<< y = ok z ∧ z.val = (x.val <<< y.toNat) % U64.size ∧ z.bv = x.bv <<< y.toNat
-  := by apply UScalar.ShiftLeft_IScalar_spec <;> simp [*]
-
-@[progress] theorem U128.ShiftLeft_IScalar_spec (x : U128) (y : IScalar ty1) (hy0 : 0 ≤ y.val) (hy : y.val < 128) :
-  ∃ (z : U128), x <<< y = ok z ∧ z.val = (x.val <<< y.toNat) % U128.size ∧ z.bv = x.bv <<< y.toNat
-  := by apply UScalar.ShiftLeft_IScalar_spec <;> simp [*]
-
-@[progress] theorem Usize.ShiftLeft_IScalar_spec (x : Usize) (y : IScalar ty1) (hy0 : 0 ≤ y.val) (hy : y.val < UScalarTy.Usize.numBits) :
-  ∃ (z : Usize), x <<< y = ok z ∧ z.val = (x.val <<< y.toNat) % Usize.size ∧ z.bv = x.bv <<< y.toNat
-  := by apply UScalar.ShiftLeft_IScalar_spec <;> simp_all
 
 /-!
 ## Bitwise And, Or

--- a/backends/lean/Aeneas/Std/Scalar/Casts.lean
+++ b/backends/lean/Aeneas/Std/Scalar/Casts.lean
@@ -212,6 +212,8 @@ theorem UScalar.cast_val_eq {src_ty : UScalarTy} (tgt_ty : UScalarTy) (x : UScal
   simp only [cast, val]
   simp
 
+-- TODO: factor our the casts
+
 @[simp, scalar_tac UScalar.cast .U16 x]
 theorem U8.cast_U16_val_eq (x : U8) : (UScalar.cast .U16 x).val = x.val := by
   simp [UScalar.cast_val_eq]; scalar_tac

--- a/backends/lean/Aeneas/Std/Scalar/CheckedOps/Add.lean
+++ b/backends/lean/Aeneas/Std/Scalar/CheckedOps/Add.lean
@@ -1,8 +1,9 @@
 import Aeneas.Std.Scalar.Ops.Add
+import Aeneas.Std.Scalar.Elab
 
 namespace Aeneas.Std
 
-open Result Error Arith
+open Result Error Arith ScalarElab
 
 /-!
 # Checked Addition: Definitions
@@ -12,23 +13,13 @@ open Result Error Arith
 def core.num.checked_add_UScalar {ty} (x y : UScalar ty) : Option (UScalar ty) :=
   Option.ofResult (x + y)
 
-def U8.checked_add (x y : U8) : Option U8 := core.num.checked_add_UScalar x y
-def U16.checked_add (x y : U16) : Option U16 := core.num.checked_add_UScalar x y
-def U32.checked_add (x y : U32) : Option U32 := core.num.checked_add_UScalar x y
-def U64.checked_add (x y : U64) : Option U64 := core.num.checked_add_UScalar x y
-def U128.checked_add (x y : U128) : Option U128 := core.num.checked_add_UScalar x y
-def Usize.checked_add (x y : Usize) : Option Usize := core.num.checked_add_UScalar x y
+uscalar def «%S».checked_add (x y : «%S») : Option «%S» := core.num.checked_add_UScalar x y
 
 /- [core::num::{T}::checked_add] -/
 def core.num.checked_add_IScalar {ty} (x y : IScalar ty) : Option (IScalar ty) :=
   Option.ofResult (x + y)
 
-def I8.checked_add (x y : I8) : Option I8 := core.num.checked_add_IScalar x y
-def I16.checked_add (x y : I16) : Option I16 := core.num.checked_add_IScalar x y
-def I32.checked_add (x y : I32) : Option I32 := core.num.checked_add_IScalar x y
-def I64.checked_add (x y : I64) : Option I64 := core.num.checked_add_IScalar x y
-def I128.checked_add (x y : I128) : Option I128 := core.num.checked_add_IScalar x y
-def Isize.checked_add (x y : Isize) : Option Isize := core.num.checked_add_IScalar x y
+iscalar def «%S».checked_add (x y : «%S») : Option «%S» := core.num.checked_add_IScalar x y
 
 /-!
 # Checked Add: Theorems
@@ -48,59 +39,14 @@ theorem core.num.checked_add_UScalar_bv_spec {ty} (x y : UScalar ty) :
   (have : 0 < 2^ty.numBits := by simp) <;>
   omega
 
-@[progress_pure checked_add x y]
-theorem U8.checked_add_bv_spec (x y : U8) :
-  match U8.checked_add x y with
-  | some z => x.val + y.val ≤ U8.max ∧ z.val = x.val + y.val ∧ z.bv = x.bv + y.bv
-  | none => U8.max < x.val + y.val := by
+uscalar @[progress_pure «%S».checked_add x y]
+theorem «%S».checked_add_bv_spec (x y : «%S») :
+  match «%S».checked_add x y with
+  | some z => x.val + y.val ≤ «%S».max ∧ z.val = x.val + y.val ∧ z.bv = x.bv + y.bv
+  | none => «%S».max < x.val + y.val := by
   have := core.num.checked_add_UScalar_bv_spec x y
-  simp_all [U8.checked_add, UScalar.max, U8.bv]
-  cases h: core.num.checked_add_UScalar x y <;> simp_all [max, numBits]
-
-@[progress_pure checked_add x y]
-theorem U16.checked_add_bv_spec (x y : U16) :
-  match U16.checked_add x y with
-  | some z => x.val + y.val ≤ U16.max ∧ z.val = x.val + y.val ∧ z.bv = x.bv + y.bv
-  | none => U16.max < x.val + y.val := by
-  have := core.num.checked_add_UScalar_bv_spec x y
-  simp_all [U16.checked_add, UScalar.max, U16.bv]
-  cases h: core.num.checked_add_UScalar x y <;> simp_all [max, numBits]
-
-@[progress_pure checked_add x y]
-theorem U32.checked_add_bv_spec (x y : U32) :
-  match U32.checked_add x y with
-  | some z => x.val + y.val ≤ U32.max ∧ z.val = x.val + y.val ∧ z.bv = x.bv + y.bv
-  | none => U32.max < x.val + y.val := by
-  have := core.num.checked_add_UScalar_bv_spec x y
-  simp_all [U32.checked_add, UScalar.max, U32.bv]
-  cases h: core.num.checked_add_UScalar x y <;> simp_all [max, numBits]
-
-@[progress_pure checked_add x y]
-theorem U64.checked_add_bv_spec (x y : U64) :
-  match U64.checked_add x y with
-  | some z => x.val + y.val ≤ U64.max ∧ z.val = x.val + y.val ∧ z.bv = x.bv + y.bv
-  | none => U64.max < x.val + y.val := by
-  have := core.num.checked_add_UScalar_bv_spec x y
-  simp_all [U64.checked_add, UScalar.max, U64.bv]
-  cases h: core.num.checked_add_UScalar x y <;> simp_all [max, numBits]
-
-@[progress_pure checked_add x y]
-theorem U128.checked_add_bv_spec (x y : U128) :
-  match U128.checked_add x y with
-  | some z => x.val + y.val ≤ U128.max ∧ z.val = x.val + y.val ∧ z.bv = x.bv + y.bv
-  | none => U128.max < x.val + y.val := by
-  have := core.num.checked_add_UScalar_bv_spec x y
-  simp_all [U128.checked_add, UScalar.max, U128.bv]
-  cases h: core.num.checked_add_UScalar x y <;> simp_all [max, numBits]
-
-@[progress_pure checked_add x y]
-theorem Usize.checked_add_bv_spec (x y : Usize) :
-  match Usize.checked_add x y with
-  | some z => x.val + y.val ≤ Usize.max ∧ z.val = x.val + y.val ∧ z.bv = x.bv + y.bv
-  | none => Usize.max < x.val + y.val := by
-  have := core.num.checked_add_UScalar_bv_spec x y
-  simp_all [Usize.checked_add, UScalar.max, Usize.bv]
-  cases h: core.num.checked_add_UScalar x y <;> simp_all [max, numBits]
+  simp_all [«%S».checked_add, UScalar.max, «%S».bv]
+  cases h: core.num.checked_add_UScalar x y <;> simp_all [«%S».max, «%S».numBits]
 
 /-!
 Signed checked add
@@ -115,58 +61,13 @@ theorem core.num.checked_add_IScalar_bv_spec {ty} (x y : IScalar ty) :
   cases hEq : IScalar.add x y <;> simp_all [Option.ofResult, checked_add_IScalar, IScalar.min, IScalar.max] <;>
   omega
 
-@[progress_pure checked_add x y]
-theorem I8.checked_add_bv_spec (x y : I8) :
+iscalar @[progress_pure «%S».checked_add x y]
+theorem «%S».checked_add_bv_spec (x y : «%S») :
   match core.num.checked_add_IScalar x y with
-  | some z => I8.min ≤ x.val + y.val ∧ x.val + y.val ≤ I8.max ∧ z.val = x.val + y.val ∧ z.bv = x.bv + y.bv
-  | none => ¬ (I8.min ≤ x.val + y.val ∧ x.val + y.val ≤ I8.max) := by
+  | some z => «%S».min ≤ x.val + y.val ∧ x.val + y.val ≤ «%S».max ∧ z.val = x.val + y.val ∧ z.bv = x.bv + y.bv
+  | none => ¬ («%S».min ≤ x.val + y.val ∧ x.val + y.val ≤ «%S».max) := by
   have := core.num.checked_add_IScalar_bv_spec x y
-  simp_all only [I8.checked_add, IScalar.min, IScalar.max, I8.bv, min, max, numBits]
-  cases h: core.num.checked_add_IScalar x y <;> simp_all only [numBits] <;> simp
-
-@[progress_pure checked_add x y]
-theorem I16.checked_add_bv_spec (x y : I16) :
-  match core.num.checked_add_IScalar x y with
-  | some z => I16.min ≤ x.val + y.val ∧ x.val + y.val ≤ I16.max ∧ z.val = x.val + y.val ∧ z.bv = x.bv + y.bv
-  | none => ¬ (I16.min ≤ x.val + y.val ∧ x.val + y.val ≤ I16.max) := by
-  have := core.num.checked_add_IScalar_bv_spec x y
-  simp_all only [I16.checked_add, IScalar.min, IScalar.max, I16.bv, min, max, numBits]
-  cases h: core.num.checked_add_IScalar x y <;> simp_all only [numBits] <;> simp
-
-@[progress_pure checked_add x y]
-theorem I32.checked_add_bv_spec (x y : I32) :
-  match core.num.checked_add_IScalar x y with
-  | some z => I32.min ≤ x.val + y.val ∧ x.val + y.val ≤ I32.max ∧ z.val = x.val + y.val ∧ z.bv = x.bv + y.bv
-  | none => ¬ (I32.min ≤ x.val + y.val ∧ x.val + y.val ≤ I32.max) := by
-  have := core.num.checked_add_IScalar_bv_spec x y
-  simp_all only [I32.checked_add, IScalar.min, IScalar.max, I32.bv, min, max, numBits]
-  cases h: core.num.checked_add_IScalar x y <;> simp_all only [numBits] <;> simp
-
-@[progress_pure checked_add x y]
-theorem I64.checked_add_bv_spec (x y : I64) :
-  match core.num.checked_add_IScalar x y with
-  | some z => I64.min ≤ x.val + y.val ∧ x.val + y.val ≤ I64.max ∧ z.val = x.val + y.val ∧ z.bv = x.bv + y.bv
-  | none => ¬ (I64.min ≤ x.val + y.val ∧ x.val + y.val ≤ I64.max) := by
-  have := core.num.checked_add_IScalar_bv_spec x y
-  simp_all only [I64.checked_add, IScalar.min, IScalar.max, I64.bv, min, max, numBits]
-  cases h: core.num.checked_add_IScalar x y <;> simp_all only [numBits] <;> simp
-
-@[progress_pure checked_add x y]
-theorem I128.checked_add_bv_spec (x y : I128) :
-  match core.num.checked_add_IScalar x y with
-  | some z => I128.min ≤ x.val + y.val ∧ x.val + y.val ≤ I128.max ∧ z.val = x.val + y.val ∧ z.bv = x.bv + y.bv
-  | none => ¬ (I128.min ≤ x.val + y.val ∧ x.val + y.val ≤ I128.max) := by
-  have := core.num.checked_add_IScalar_bv_spec x y
-  simp_all only [I128.checked_add, IScalar.min, IScalar.max, I128.bv, min, max, numBits]
-  cases h: core.num.checked_add_IScalar x y <;> simp_all only [numBits] <;> simp
-
-@[progress_pure checked_add x y]
-theorem Isize.checked_add_bv_spec (x y : Isize) :
-  match core.num.checked_add_IScalar x y with
-  | some z => Isize.min ≤ x.val + y.val ∧ x.val + y.val ≤ Isize.max ∧ z.val = x.val + y.val ∧ z.bv = x.bv + y.bv
-  | none => ¬ (Isize.min ≤ x.val + y.val ∧ x.val + y.val ≤ Isize.max) := by
-  have := core.num.checked_add_IScalar_bv_spec x y
-  simp_all only [Isize.checked_add, IScalar.min, IScalar.max, Isize.bv, min, max, numBits]
-  cases h: core.num.checked_add_IScalar x y <;> simp_all only [numBits] <;> simp
+  simp_all only [«%S».checked_add, IScalar.min, IScalar.max, «%S».bv, «%S».min, «%S».max, «%S».numBits]
+  cases h: core.num.checked_add_IScalar x y <;> simp_all only [«%S».numBits] <;> simp
 
 end Aeneas.Std

--- a/backends/lean/Aeneas/Std/Scalar/CheckedOps/Div.lean
+++ b/backends/lean/Aeneas/Std/Scalar/CheckedOps/Div.lean
@@ -1,8 +1,9 @@
 import Aeneas.Std.Scalar.Ops.Div
+import Aeneas.Std.Scalar.Elab
 
 namespace Aeneas.Std
 
-open Result Error Arith
+open Result Error Arith ScalarElab
 
 /-!
 # Checked Division: Definitions
@@ -12,23 +13,13 @@ open Result Error Arith
 def core.num.checked_div_UScalar {ty} (x y : UScalar ty) : Option (UScalar ty) :=
   Option.ofResult (UScalar.div x y)
 
-def U8.checked_div (x y : U8) : Option U8 := core.num.checked_div_UScalar x y
-def U16.checked_div (x y : U16) : Option U16 := core.num.checked_div_UScalar x y
-def U32.checked_div (x y : U32) : Option U32 := core.num.checked_div_UScalar x y
-def U64.checked_div (x y : U64) : Option U64 := core.num.checked_div_UScalar x y
-def U128.checked_div (x y : U128) : Option U128 := core.num.checked_div_UScalar x y
-def Usize.checked_div (x y : Usize) : Option Usize := core.num.checked_div_UScalar x y
+uscalar def «%S».checked_div (x y : «%S») : Option «%S» := core.num.checked_div_UScalar x y
 
 /- [core::num::{T}::checked_div] -/
 def core.num.checked_div_IScalar {ty} (x y : IScalar ty) : Option (IScalar ty) :=
   Option.ofResult (IScalar.div x y)
 
-def I8.checked_div (x y : I8) : Option I8 := core.num.checked_div_IScalar x y
-def I16.checked_div (x y : I16) : Option I16 := core.num.checked_div_IScalar x y
-def I32.checked_div (x y : I32) : Option I32 := core.num.checked_div_IScalar x y
-def I64.checked_div (x y : I64) : Option I64 := core.num.checked_div_IScalar x y
-def I128.checked_div (x y : I128) : Option I128 := core.num.checked_div_IScalar x y
-def Isize.checked_div (x y : Isize) : Option Isize := core.num.checked_div_IScalar x y
+iscalar def «%S».checked_div (x y : «%S») : Option «%S» := core.num.checked_div_IScalar x y
 
 /-!
 # Checked Division: Theorems
@@ -53,58 +44,13 @@ theorem core.num.checked_div_UScalar_bv_spec {ty} (x y : UScalar ty) :
     simp [this, UScalar.div, hnz] at hz
     simp [hz, hnz']
 
-@[progress_pure checked_div x y]
-theorem U8.checked_div_bv_spec (x y : U8) :
-  match U8.checked_div x y with
+uscalar @[progress_pure «%S».checked_div x y]
+theorem «%S».checked_div_bv_spec (x y : «%S») :
+  match «%S».checked_div x y with
   | some z => y.val ≠ 0 ∧ z.val = x.val / y.val ∧ z.bv = x.bv / y.bv
   | none => y.val = 0 := by
   have := core.num.checked_div_UScalar_bv_spec x y
-  simp_all [U8.checked_div, UScalar.max, U8.bv]
-  cases h: core.num.checked_div_UScalar x y <;> simp_all
-
-@[progress_pure checked_div x y]
-theorem U16.checked_div_bv_spec (x y : U16) :
-  match U16.checked_div x y with
-  | some z => y.val ≠ 0 ∧ z.val = x.val / y.val ∧ z.bv = x.bv / y.bv
-  | none => y.val = 0 := by
-  have := core.num.checked_div_UScalar_bv_spec x y
-  simp_all [U16.checked_div, UScalar.max, U16.bv]
-  cases h: core.num.checked_div_UScalar x y <;> simp_all
-
-@[progress_pure checked_div x y]
-theorem U32.checked_div_bv_spec (x y : U32) :
-  match U32.checked_div x y with
-  | some z => y.val ≠ 0 ∧ z.val = x.val / y.val ∧ z.bv = x.bv / y.bv
-  | none => y.val = 0 := by
-  have := core.num.checked_div_UScalar_bv_spec x y
-  simp_all [U32.checked_div, UScalar.max, U32.bv]
-  cases h: core.num.checked_div_UScalar x y <;> simp_all
-
-@[progress_pure checked_div x y]
-theorem U64.checked_div_bv_spec (x y : U64) :
-  match U64.checked_div x y with
-  | some z => y.val ≠ 0 ∧ z.val = x.val / y.val ∧ z.bv = x.bv / y.bv
-  | none => y.val = 0 := by
-  have := core.num.checked_div_UScalar_bv_spec x y
-  simp_all [U64.checked_div, UScalar.max, U64.bv]
-  cases h: core.num.checked_div_UScalar x y <;> simp_all
-
-@[progress_pure checked_div x y]
-theorem U128.checked_div_bv_spec (x y : U128) :
-  match U128.checked_div x y with
-  | some z => y.val ≠ 0 ∧ z.val = x.val / y.val ∧ z.bv = x.bv / y.bv
-  | none => y.val = 0 := by
-  have := core.num.checked_div_UScalar_bv_spec x y
-  simp_all [U128.checked_div, UScalar.max, U128.bv]
-  cases h: core.num.checked_div_UScalar x y <;> simp_all
-
-@[progress_pure checked_div x y]
-theorem Usize.checked_div_bv_spec (x y : Usize) :
-  match Usize.checked_div x y with
-  | some z => y.val ≠ 0 ∧ z.val = x.val / y.val ∧ z.bv = x.bv / y.bv
-  | none => y.val = 0 := by
-  have := core.num.checked_div_UScalar_bv_spec x y
-  simp_all [Usize.checked_div, UScalar.max, Usize.bv]
+  simp_all [«%S».checked_div, UScalar.max, «%S».bv]
   cases h: core.num.checked_div_UScalar x y <;> simp_all
 
 /-!
@@ -130,58 +76,13 @@ theorem core.num.checked_div_IScalar_bv_spec {ty} (x y : IScalar ty) :
     tauto
   . simp_all
 
-@[progress_pure checked_div x y]
-theorem I8.checked_div_bv_spec (x y : I8) :
+iscalar @[progress_pure «%S».checked_div x y]
+theorem «%S».checked_div_bv_spec (x y : «%S») :
   match core.num.checked_div_IScalar x y with
-  | some z => y.val ≠ 0 ∧ ¬ (x.val = I8.min ∧ y.val = -1) ∧ z.val = Int.tdiv x.val y.val ∧ z.bv = BitVec.sdiv x.bv y.bv
-  | none => y.val = 0 ∨ (x.val = I8.min ∧ y.val = -1) := by
+  | some z => y.val ≠ 0 ∧ ¬ (x.val = «%S».min ∧ y.val = -1) ∧ z.val = Int.tdiv x.val y.val ∧ z.bv = BitVec.sdiv x.bv y.bv
+  | none => y.val = 0 ∨ (x.val = «%S».min ∧ y.val = -1) := by
   have := core.num.checked_div_IScalar_bv_spec x y
-  simp_all only [I8.checked_div, I8.bv, IScalar.min, min, max, numBits]
-  cases h: core.num.checked_div_IScalar x y <;> simp_all only [ne_eq, not_false_eq_true, and_self, this]
-
-@[progress_pure checked_div x y]
-theorem I16.checked_div_bv_spec (x y : I16) :
-  match core.num.checked_div_IScalar x y with
-  | some z => y.val ≠ 0 ∧ ¬ (x.val = I16.min ∧ y.val = -1) ∧ z.val = Int.tdiv x.val y.val ∧ z.bv = BitVec.sdiv x.bv y.bv
-  | none => y.val = 0 ∨ (x.val = I16.min ∧ y.val = -1) := by
-  have := core.num.checked_div_IScalar_bv_spec x y
-  simp_all only [I16.checked_div, I16.bv, IScalar.min, min, max, numBits]
-  cases h: core.num.checked_div_IScalar x y <;> simp_all only [ne_eq, not_false_eq_true, and_self, this]
-
-@[progress_pure checked_div x y]
-theorem I32.checked_div_bv_spec (x y : I32) :
-  match core.num.checked_div_IScalar x y with
-  | some z => y.val ≠ 0 ∧ ¬ (x.val = I32.min ∧ y.val = -1) ∧ z.val = Int.tdiv x.val y.val ∧ z.bv = BitVec.sdiv x.bv y.bv
-  | none => y.val = 0 ∨ (x.val = I32.min ∧ y.val = -1) := by
-  have := core.num.checked_div_IScalar_bv_spec x y
-  simp_all only [I32.checked_div, I32.bv, IScalar.min, min, max, numBits]
-  cases h: core.num.checked_div_IScalar x y <;> simp_all only [ne_eq, not_false_eq_true, and_self, this]
-
-@[progress_pure checked_div x y]
-theorem I64.checked_div_bv_spec (x y : I64) :
-  match core.num.checked_div_IScalar x y with
-  | some z => y.val ≠ 0 ∧ ¬ (x.val = I64.min ∧ y.val = -1) ∧ z.val = Int.tdiv x.val y.val ∧ z.bv = BitVec.sdiv x.bv y.bv
-  | none => y.val = 0 ∨ (x.val = I64.min ∧ y.val = -1) := by
-  have := core.num.checked_div_IScalar_bv_spec x y
-  simp_all only [I64.checked_div, I64.bv, IScalar.min, min, max, numBits]
-  cases h: core.num.checked_div_IScalar x y <;> simp_all only [ne_eq, not_false_eq_true, and_self, this]
-
-@[progress_pure checked_div x y]
-theorem I128.checked_div_bv_spec (x y : I128) :
-  match core.num.checked_div_IScalar x y with
-  | some z => y.val ≠ 0 ∧ ¬ (x.val = I128.min ∧ y.val = -1) ∧ z.val = Int.tdiv x.val y.val ∧ z.bv = BitVec.sdiv x.bv y.bv
-  | none => y.val = 0 ∨ (x.val = I128.min ∧ y.val = -1) := by
-  have := core.num.checked_div_IScalar_bv_spec x y
-  simp_all only [I128.checked_div, I128.bv, IScalar.min, min, max, numBits]
-  cases h: core.num.checked_div_IScalar x y <;> simp_all only [ne_eq, not_false_eq_true, and_self, this]
-
-@[progress_pure checked_div x y]
-theorem Isize.checked_div_bv_spec (x y : Isize) :
-  match core.num.checked_div_IScalar x y with
-  | some z => y.val ≠ 0 ∧ ¬ (x.val = Isize.min ∧ y.val = -1) ∧ z.val = Int.tdiv x.val y.val ∧ z.bv = BitVec.sdiv x.bv y.bv
-  | none => y.val = 0 ∨ (x.val = Isize.min ∧ y.val = -1) := by
-  have := core.num.checked_div_IScalar_bv_spec x y
-  simp_all only [Isize.checked_div, Isize.bv, IScalar.min, min, max, numBits]
+  simp_all only [«%S».checked_div, «%S».bv, IScalar.min, «%S».min, «%S».max, «%S».numBits]
   cases h: core.num.checked_div_IScalar x y <;> simp_all only [ne_eq, not_false_eq_true, and_self, this]
 
 end Aeneas.Std

--- a/backends/lean/Aeneas/Std/Scalar/CheckedOps/Mul.lean
+++ b/backends/lean/Aeneas/Std/Scalar/CheckedOps/Mul.lean
@@ -1,8 +1,9 @@
 import Aeneas.Std.Scalar.Ops.Mul
+import Aeneas.Std.Scalar.Elab
 
 namespace Aeneas.Std
 
-open Result Error Arith
+open Result Error Arith ScalarElab
 
 /-!
 # Checked Multiplication: Definitions
@@ -12,23 +13,13 @@ open Result Error Arith
 def core.num.checked_mul_UScalar {ty} (x y : UScalar ty) : Option (UScalar ty) :=
   Option.ofResult (UScalar.mul x y)
 
-def U8.checked_mul (x y : U8) : Option U8 := core.num.checked_mul_UScalar x y
-def U16.checked_mul (x y : U16) : Option U16 := core.num.checked_mul_UScalar x y
-def U32.checked_mul (x y : U32) : Option U32 := core.num.checked_mul_UScalar x y
-def U64.checked_mul (x y : U64) : Option U64 := core.num.checked_mul_UScalar x y
-def U128.checked_mul (x y : U128) : Option U128 := core.num.checked_mul_UScalar x y
-def Usize.checked_mul (x y : Usize) : Option Usize := core.num.checked_mul_UScalar x y
+uscalar def «%S».checked_mul (x y : «%S») : Option «%S» := core.num.checked_mul_UScalar x y
 
 /- [core::num::{T}::checked_mul] -/
 def core.num.checked_mul_IScalar {ty} (x y : IScalar ty) : Option (IScalar ty) :=
   Option.ofResult (IScalar.mul x y)
 
-def I8.checked_mul (x y : I8) : Option I8 := core.num.checked_mul_IScalar x y
-def I16.checked_mul (x y : I16) : Option I16 := core.num.checked_mul_IScalar x y
-def I32.checked_mul (x y : I32) : Option I32 := core.num.checked_mul_IScalar x y
-def I64.checked_mul (x y : I64) : Option I64 := core.num.checked_mul_IScalar x y
-def I128.checked_mul (x y : I128) : Option I128 := core.num.checked_mul_IScalar x y
-def Isize.checked_mul (x y : Isize) : Option Isize := core.num.checked_mul_IScalar x y
+iscalar def «%S».checked_mul (x y : «%S») : Option «%S» := core.num.checked_mul_IScalar x y
 
 /-!
 # Checked Mul: Theorems
@@ -45,58 +36,13 @@ theorem core.num.checked_mul_UScalar_bv_spec {ty} (x y : UScalar ty) :
   simp [checked_mul_UScalar]
   cases hEq : UScalar.mul x y <;> simp_all [Option.ofResult]
 
-@[progress_pure checked_mul x y]
-theorem U8.checked_mul_bv_spec (x y : U8) :
-  match U8.checked_mul x y with
-  | some z => x.val * y.val ≤ U8.max ∧ z.val = x.val * y.val ∧ z.bv = x.bv * y.bv
-  | none => U8.max < x.val * y.val := by
+uscalar @[progress_pure «%S».checked_mul x y]
+theorem «%S».checked_mul_bv_spec (x y : «%S») :
+  match «%S».checked_mul x y with
+  | some z => x.val * y.val ≤ «%S».max ∧ z.val = x.val * y.val ∧ z.bv = x.bv * y.bv
+  | none => «%S».max < x.val * y.val := by
   have := core.num.checked_mul_UScalar_bv_spec x y
-  simp_all only [U8.checked_mul, UScalar.max, U8.bv, min, max, numBits]
-  cases h: core.num.checked_mul_UScalar x y <;> simp_all only [and_self]
-
-@[progress_pure checked_mul x y]
-theorem U16.checked_mul_bv_spec (x y : U16) :
-  match U16.checked_mul x y with
-  | some z => x.val * y.val ≤ U16.max ∧ z.val = x.val * y.val ∧ z.bv = x.bv * y.bv
-  | none => U16.max < x.val * y.val := by
-  have := core.num.checked_mul_UScalar_bv_spec x y
-  simp_all only [U16.checked_mul, UScalar.max, U16.bv, min, max, numBits]
-  cases h: core.num.checked_mul_UScalar x y <;> simp_all only [and_self]
-
-@[progress_pure checked_mul x y]
-theorem U32.checked_mul_bv_spec (x y : U32) :
-  match U32.checked_mul x y with
-  | some z => x.val * y.val ≤ U32.max ∧ z.val = x.val * y.val ∧ z.bv = x.bv * y.bv
-  | none => U32.max < x.val * y.val := by
-  have := core.num.checked_mul_UScalar_bv_spec x y
-  simp_all only [U32.checked_mul, UScalar.max, U32.bv, min, max, numBits]
-  cases h: core.num.checked_mul_UScalar x y <;> simp_all only [and_self]
-
-@[progress_pure checked_mul x y]
-theorem U64.checked_mul_bv_spec (x y : U64) :
-  match U64.checked_mul x y with
-  | some z => x.val * y.val ≤ U64.max ∧ z.val = x.val * y.val ∧ z.bv = x.bv * y.bv
-  | none => U64.max < x.val * y.val := by
-  have := core.num.checked_mul_UScalar_bv_spec x y
-  simp_all only [U64.checked_mul, UScalar.max, U64.bv, min, max, numBits]
-  cases h: core.num.checked_mul_UScalar x y <;> simp_all only [and_self]
-
-@[progress_pure checked_mul x y]
-theorem U128.checked_mul_bv_spec (x y : U128) :
-  match U128.checked_mul x y with
-  | some z => x.val * y.val ≤ U128.max ∧ z.val = x.val * y.val ∧ z.bv = x.bv * y.bv
-  | none => U128.max < x.val * y.val := by
-  have := core.num.checked_mul_UScalar_bv_spec x y
-  simp_all only [U128.checked_mul, UScalar.max, U128.bv, min, max, numBits]
-  cases h: core.num.checked_mul_UScalar x y <;> simp_all only [and_self]
-
-@[progress_pure checked_mul x y]
-theorem Usize.checked_mul_bv_spec (x y : Usize) :
-  match Usize.checked_mul x y with
-  | some z => x.val * y.val ≤ Usize.max ∧ z.val = x.val * y.val ∧ z.bv = x.bv * y.bv
-  | none => Usize.max < x.val * y.val := by
-  have := core.num.checked_mul_UScalar_bv_spec x y
-  simp_all only [Usize.checked_mul, UScalar.max, Usize.bv, min, max, numBits]
+  simp_all only [«%S».checked_mul, UScalar.max, «%S».bv, min, «%S».max, «%S».numBits]
   cases h: core.num.checked_mul_UScalar x y <;> simp_all only [and_self]
 
 /-!
@@ -110,58 +56,13 @@ theorem core.num.checked_mul_IScalar_bv_spec {ty} (x y : IScalar ty) :
   simp [checked_mul_IScalar]
   cases hEq : IScalar.mul x y <;> simp_all [Option.ofResult]
 
-@[progress_pure checked_mul x y]
-theorem I8.checked_mul_bv_spec (x y : I8) :
+iscalar @[progress_pure «%S».checked_mul x y]
+theorem «%S».checked_mul_bv_spec (x y : «%S») :
   match core.num.checked_mul_IScalar x y with
-  | some z => I8.min ≤ x.val * y.val ∧ x.val * y.val ≤ I8.max ∧ z.val = x.val * y.val ∧ z.bv = x.bv * y.bv
-  | none => ¬ (I8.min ≤ x.val * y.val ∧ x.val * y.val ≤ I8.max) := by
+  | some z => «%S».min ≤ x.val * y.val ∧ x.val * y.val ≤ «%S».max ∧ z.val = x.val * y.val ∧ z.bv = x.bv * y.bv
+  | none => ¬ («%S».min ≤ x.val * y.val ∧ x.val * y.val ≤ «%S».max) := by
   have := core.num.checked_mul_IScalar_bv_spec x y
-  simp_all only [I8.checked_mul, IScalar.min, IScalar.max, I8.bv, min, max, numBits]
-  cases h: core.num.checked_mul_IScalar x y <;> simp_all only [not_false_eq_true, and_self]
-
-@[progress_pure checked_mul x y]
-theorem I16.checked_mul_bv_spec (x y : I16) :
-  match core.num.checked_mul_IScalar x y with
-  | some z => I16.min ≤ x.val * y.val ∧ x.val * y.val ≤ I16.max ∧ z.val = x.val * y.val ∧ z.bv = x.bv * y.bv
-  | none => ¬ (I16.min ≤ x.val * y.val ∧ x.val * y.val ≤ I16.max) := by
-  have := core.num.checked_mul_IScalar_bv_spec x y
-  simp_all only [I16.checked_mul, IScalar.min, IScalar.max, I16.bv, min, max, numBits]
-  cases h: core.num.checked_mul_IScalar x y <;> simp_all only [not_false_eq_true, and_self]
-
-@[progress_pure checked_mul x y]
-theorem I32.checked_mul_bv_spec (x y : I32) :
-  match core.num.checked_mul_IScalar x y with
-  | some z => I32.min ≤ x.val * y.val ∧ x.val * y.val ≤ I32.max ∧ z.val = x.val * y.val ∧ z.bv = x.bv * y.bv
-  | none => ¬ (I32.min ≤ x.val * y.val ∧ x.val * y.val ≤ I32.max) := by
-  have := core.num.checked_mul_IScalar_bv_spec x y
-  simp_all only [I32.checked_mul, IScalar.min, IScalar.max, I32.bv, min, max, numBits]
-  cases h: core.num.checked_mul_IScalar x y <;> simp_all only [not_false_eq_true, and_self]
-
-@[progress_pure checked_mul x y]
-theorem I64.checked_mul_bv_spec (x y : I64) :
-  match core.num.checked_mul_IScalar x y with
-  | some z => I64.min ≤ x.val * y.val ∧ x.val * y.val ≤ I64.max ∧ z.val = x.val * y.val ∧ z.bv = x.bv * y.bv
-  | none => ¬ (I64.min ≤ x.val * y.val ∧ x.val * y.val ≤ I64.max) := by
-  have := core.num.checked_mul_IScalar_bv_spec x y
-  simp_all only [I64.checked_mul, IScalar.min, IScalar.max, I64.bv, min, max, numBits]
-  cases h: core.num.checked_mul_IScalar x y <;> simp_all only [not_false_eq_true, and_self]
-
-@[progress_pure checked_mul x y]
-theorem I128.checked_mul_bv_spec (x y : I128) :
-  match core.num.checked_mul_IScalar x y with
-  | some z => I128.min ≤ x.val * y.val ∧ x.val * y.val ≤ I128.max ∧ z.val = x.val * y.val ∧ z.bv = x.bv * y.bv
-  | none => ¬ (I128.min ≤ x.val * y.val ∧ x.val * y.val ≤ I128.max) := by
-  have := core.num.checked_mul_IScalar_bv_spec x y
-  simp_all only [I128.checked_mul, IScalar.min, IScalar.max, I128.bv, min, max, numBits]
-  cases h: core.num.checked_mul_IScalar x y <;> simp_all only [not_false_eq_true, and_self]
-
-@[progress_pure checked_mul x y]
-theorem Isize.checked_mul_bv_spec (x y : Isize) :
-  match core.num.checked_mul_IScalar x y with
-  | some z => Isize.min ≤ x.val * y.val ∧ x.val * y.val ≤ Isize.max ∧ z.val = x.val * y.val ∧ z.bv = x.bv * y.bv
-  | none => ¬ (Isize.min ≤ x.val * y.val ∧ x.val * y.val ≤ Isize.max) := by
-  have := core.num.checked_mul_IScalar_bv_spec x y
-  simp_all only [Isize.checked_mul, IScalar.min, IScalar.max, Isize.bv, min, max, numBits]
+  simp_all only [«%S».checked_mul, IScalar.min, IScalar.max, «%S».bv, «%S».min, «%S».max, «%S».numBits]
   cases h: core.num.checked_mul_IScalar x y <;> simp_all only [not_false_eq_true, and_self]
 
 end Aeneas.Std

--- a/backends/lean/Aeneas/Std/Scalar/CheckedOps/Rem.lean
+++ b/backends/lean/Aeneas/Std/Scalar/CheckedOps/Rem.lean
@@ -1,8 +1,9 @@
 import Aeneas.Std.Scalar.Ops.Rem
+import Aeneas.Std.Scalar.Elab
 
 namespace Aeneas.Std
 
-open Result Error Arith
+open Result Error Arith ScalarElab
 
 /-!
 # Checked Remainder: Definitions
@@ -12,23 +13,13 @@ open Result Error Arith
 def core.num.checked_rem_UScalar {ty} (x y : UScalar ty) : Option (UScalar ty) :=
   Option.ofResult (UScalar.rem x y)
 
-def U8.checked_rem (x y : U8) : Option U8 := core.num.checked_rem_UScalar x y
-def U16.checked_rem (x y : U16) : Option U16 := core.num.checked_rem_UScalar x y
-def U32.checked_rem (x y : U32) : Option U32 := core.num.checked_rem_UScalar x y
-def U64.checked_rem (x y : U64) : Option U64 := core.num.checked_rem_UScalar x y
-def U128.checked_rem (x y : U128) : Option U128 := core.num.checked_rem_UScalar x y
-def Usize.checked_rem (x y : Usize) : Option Usize := core.num.checked_rem_UScalar x y
+uscalar def «%S».checked_rem (x y : «%S») : Option «%S» := core.num.checked_rem_UScalar x y
 
 /- [core::num::{T}::checked_rem] -/
 def core.num.checked_rem_IScalar {ty} (x y : IScalar ty) : Option (IScalar ty) :=
   Option.ofResult (IScalar.rem x y)
 
-def I8.checked_rem (x y : I8) : Option I8 := core.num.checked_rem_IScalar x y
-def I16.checked_rem (x y : I16) : Option I16 := core.num.checked_rem_IScalar x y
-def I32.checked_rem (x y : I32) : Option I32 := core.num.checked_rem_IScalar x y
-def I64.checked_rem (x y : I64) : Option I64 := core.num.checked_rem_IScalar x y
-def I128.checked_rem (x y : I128) : Option I128 := core.num.checked_rem_IScalar x y
-def Isize.checked_rem (x y : Isize) : Option Isize := core.num.checked_rem_IScalar x y
+iscalar def «%S».checked_rem (x y : «%S») : Option «%S» := core.num.checked_rem_IScalar x y
 
 /-!
 # Checked Remained
@@ -53,58 +44,13 @@ theorem core.num.checked_rem_UScalar_bv_spec {ty} (x y : UScalar ty) :
     simp [this, UScalar.rem, hnz] at hz
     simp [hz, hnz']
 
-@[progress_pure checked_rem x y]
-theorem U8.checked_rem_bv_spec (x y : U8) :
-  match U8.checked_rem x y with
+uscalar @[progress_pure «%S».checked_rem x y]
+theorem «%S».checked_rem_bv_spec (x y : «%S») :
+  match «%S».checked_rem x y with
   | some z => y.val ≠ 0 ∧ z.val = x.val % y.val ∧ z.bv = x.bv % y.bv
   | none => y.val = 0 := by
   have := core.num.checked_rem_UScalar_bv_spec x y
-  simp_all [U8.checked_rem, UScalar.max, U8.bv]
-  cases h: core.num.checked_rem_UScalar x y <;> simp_all
-
-@[progress_pure checked_rem x y]
-theorem U16.checked_rem_bv_spec (x y : U16) :
-  match U16.checked_rem x y with
-  | some z => y.val ≠ 0 ∧ z.val = x.val % y.val ∧ z.bv = x.bv % y.bv
-  | none => y.val = 0 := by
-  have := core.num.checked_rem_UScalar_bv_spec x y
-  simp_all [U16.checked_rem, UScalar.max, U16.bv]
-  cases h: core.num.checked_rem_UScalar x y <;> simp_all
-
-@[progress_pure checked_rem x y]
-theorem U32.checked_rem_bv_spec (x y : U32) :
-  match U32.checked_rem x y with
-  | some z => y.val ≠ 0 ∧ z.val = x.val % y.val ∧ z.bv = x.bv % y.bv
-  | none => y.val = 0 := by
-  have := core.num.checked_rem_UScalar_bv_spec x y
-  simp_all [U32.checked_rem, UScalar.max, U32.bv]
-  cases h: core.num.checked_rem_UScalar x y <;> simp_all
-
-@[progress_pure checked_rem x y]
-theorem U64.checked_rem_bv_spec (x y : U64) :
-  match U64.checked_rem x y with
-  | some z => y.val ≠ 0 ∧ z.val = x.val % y.val ∧ z.bv = x.bv % y.bv
-  | none => y.val = 0 := by
-  have := core.num.checked_rem_UScalar_bv_spec x y
-  simp_all [U64.checked_rem, UScalar.max, U64.bv]
-  cases h: core.num.checked_rem_UScalar x y <;> simp_all
-
-@[progress_pure checked_rem x y]
-theorem U128.checked_rem_bv_spec (x y : U128) :
-  match U128.checked_rem x y with
-  | some z => y.val ≠ 0 ∧ z.val = x.val % y.val ∧ z.bv = x.bv % y.bv
-  | none => y.val = 0 := by
-  have := core.num.checked_rem_UScalar_bv_spec x y
-  simp_all [U128.checked_rem, UScalar.max, U128.bv]
-  cases h: core.num.checked_rem_UScalar x y <;> simp_all
-
-@[progress_pure checked_rem x y]
-theorem Usize.checked_rem_bv_spec (x y : Usize) :
-  match Usize.checked_rem x y with
-  | some z => y.val ≠ 0 ∧ z.val = x.val % y.val ∧ z.bv = x.bv % y.bv
-  | none => y.val = 0 := by
-  have := core.num.checked_rem_UScalar_bv_spec x y
-  simp_all [Usize.checked_rem, UScalar.max, Usize.bv]
+  simp_all [«%S».checked_rem, UScalar.max, «%S».bv]
   cases h: core.num.checked_rem_UScalar x y <;> simp_all
 
 /-!
@@ -126,58 +72,13 @@ theorem core.num.checked_rem_IScalar_bv_spec {ty} (x y : IScalar ty) :
     simp [this, IScalar.rem, hnz] at hz
     simp [*]
 
-@[progress_pure checked_rem x y]
-theorem I8.checked_rem_bv_spec (x y : I8) :
+iscalar @[progress_pure «%S».checked_rem x y]
+theorem «%S».checked_rem_bv_spec (x y : «%S») :
   match core.num.checked_rem_IScalar x y with
   | some z => y.val ≠ 0 ∧ z.val = Int.tmod x.val y.val ∧ z.bv = BitVec.srem x.bv y.bv
   | none => y.val = 0 := by
   have := core.num.checked_rem_IScalar_bv_spec x y
-  simp_all only [I8.checked_rem, I8.bv, IScalar.min]
-  cases h: core.num.checked_rem_IScalar x y <;> simp_all
-
-@[progress_pure checked_rem x y]
-theorem I16.checked_rem_bv_spec (x y : I16) :
-  match core.num.checked_rem_IScalar x y with
-  | some z => y.val ≠ 0 ∧ z.val = Int.tmod x.val y.val ∧ z.bv = BitVec.srem x.bv y.bv
-  | none => y.val = 0 := by
-  have := core.num.checked_rem_IScalar_bv_spec x y
-  simp_all only [I16.checked_rem, I16.bv, IScalar.min]
-  cases h: core.num.checked_rem_IScalar x y <;> simp_all
-
-@[progress_pure checked_rem x y]
-theorem I32.checked_rem_bv_spec (x y : I32) :
-  match core.num.checked_rem_IScalar x y with
-  | some z => y.val ≠ 0 ∧ z.val = Int.tmod x.val y.val ∧ z.bv = BitVec.srem x.bv y.bv
-  | none => y.val = 0 := by
-  have := core.num.checked_rem_IScalar_bv_spec x y
-  simp_all only [I32.checked_rem, I32.bv, IScalar.min]
-  cases h: core.num.checked_rem_IScalar x y <;> simp_all
-
-@[progress_pure checked_rem x y]
-theorem I64.checked_rem_bv_spec (x y : I64) :
-  match core.num.checked_rem_IScalar x y with
-  | some z => y.val ≠ 0 ∧ z.val = Int.tmod x.val y.val ∧ z.bv = BitVec.srem x.bv y.bv
-  | none => y.val = 0 := by
-  have := core.num.checked_rem_IScalar_bv_spec x y
-  simp_all only [I64.checked_rem, I64.bv, IScalar.min]
-  cases h: core.num.checked_rem_IScalar x y <;> simp_all
-
-@[progress_pure checked_rem x y]
-theorem I128.checked_rem_bv_spec (x y : I128) :
-  match core.num.checked_rem_IScalar x y with
-  | some z => y.val ≠ 0 ∧ z.val = Int.tmod x.val y.val ∧ z.bv = BitVec.srem x.bv y.bv
-  | none => y.val = 0 := by
-  have := core.num.checked_rem_IScalar_bv_spec x y
-  simp_all only [I128.checked_rem, I128.bv, IScalar.min]
-  cases h: core.num.checked_rem_IScalar x y <;> simp_all
-
-@[progress_pure checked_rem x y]
-theorem Isize.checked_rem_bv_spec (x y : Isize) :
-  match core.num.checked_rem_IScalar x y with
-  | some z => y.val ≠ 0 ∧ z.val = Int.tmod x.val y.val ∧ z.bv = BitVec.srem x.bv y.bv
-  | none => y.val = 0 := by
-  have := core.num.checked_rem_IScalar_bv_spec x y
-  simp_all only [Isize.checked_rem, Isize.bv, IScalar.min]
+  simp_all only [«%S».checked_rem, «%S».bv, IScalar.min]
   cases h: core.num.checked_rem_IScalar x y <;> simp_all
 
 end Aeneas.Std

--- a/backends/lean/Aeneas/Std/Scalar/CheckedOps/Sub.lean
+++ b/backends/lean/Aeneas/Std/Scalar/CheckedOps/Sub.lean
@@ -1,8 +1,9 @@
 import Aeneas.Std.Scalar.Ops.Sub
+import Aeneas.Std.Scalar.Elab
 
 namespace Aeneas.Std
 
-open Result Error Arith
+open Result Error Arith ScalarElab
 
 /-!
 # Checked Subtraction: Definitions
@@ -12,23 +13,13 @@ open Result Error Arith
 def core.num.checked_sub_UScalar {ty} (x y : UScalar ty) : Option (UScalar ty) :=
   Option.ofResult (x - y)
 
-def U8.checked_sub (x y : U8) : Option U8 := core.num.checked_sub_UScalar x y
-def U16.checked_sub (x y : U16) : Option U16 := core.num.checked_sub_UScalar x y
-def U32.checked_sub (x y : U32) : Option U32 := core.num.checked_sub_UScalar x y
-def U64.checked_sub (x y : U64) : Option U64 := core.num.checked_sub_UScalar x y
-def U128.checked_sub (x y : U128) : Option U128 := core.num.checked_sub_UScalar x y
-def Usize.checked_sub (x y : Usize) : Option Usize := core.num.checked_sub_UScalar x y
+uscalar def «%S».checked_sub (x y : «%S») : Option «%S» := core.num.checked_sub_UScalar x y
 
 /- [core::num::{T}::checked_sub] -/
 def core.num.checked_sub_IScalar {ty} (x y : IScalar ty) : Option (IScalar ty) :=
   Option.ofResult (x - y)
 
-def I8.checked_sub (x y : I8) : Option I8 := core.num.checked_sub_IScalar x y
-def I16.checked_sub (x y : I16) : Option I16 := core.num.checked_sub_IScalar x y
-def I32.checked_sub (x y : I32) : Option I32 := core.num.checked_sub_IScalar x y
-def I64.checked_sub (x y : I64) : Option I64 := core.num.checked_sub_IScalar x y
-def I128.checked_sub (x y : I128) : Option I128 := core.num.checked_sub_IScalar x y
-def Isize.checked_sub (x y : Isize) : Option Isize := core.num.checked_sub_IScalar x y
+iscalar def «%S».checked_sub (x y : «%S») : Option «%S» := core.num.checked_sub_IScalar x y
 
 /-!
 # Checked Sub: Theorems
@@ -46,57 +37,13 @@ theorem core.num.checked_sub_UScalar_bv_spec {ty} (x y : UScalar ty) :
   rw [hsub] at h
   cases hEq : UScalar.sub x y <;> simp_all [Option.ofResult, checked_sub_UScalar]
 
-@[progress_pure checked_sub x y]
-theorem U8.checked_sub_bv_spec (x y : U8) :
-  match U8.checked_sub x y with
+uscalar @[progress_pure «%S».checked_sub x y]
+theorem «%S».checked_sub_bv_spec (x y : «%S») :
+  match «%S».checked_sub x y with
   | some z => y.val ≤ x.val ∧ z.val = x.val - y.val ∧ z.bv = x.bv - y.bv
   | none => x.val < y.val := by
   have := core.num.checked_sub_UScalar_bv_spec x y
-  simp_all [U8.checked_sub, UScalar.max, U8.bv]
-  cases h: core.num.checked_sub_UScalar x y <;> simp_all
-
-@[progress_pure checked_sub x y]
-theorem U16.checked_sub_bv_spec (x y : U16) :
-  match U16.checked_sub x y with
-  | some z => y.val ≤ x.val ∧ z.val = x.val - y.val ∧ z.bv = x.bv - y.bv
-  | none => x.val < y.val := by
-  have := core.num.checked_sub_UScalar_bv_spec x y
-  simp_all [U16.checked_sub, UScalar.max, U16.bv]
-  cases h: core.num.checked_sub_UScalar x y <;> simp_all
-
-@[progress_pure checked_sub x y]
-theorem U32.checked_sub_bv_spec (x y : U32) :
-  match U32.checked_sub x y with
-  | some z => y.val ≤ x.val ∧ z.val = x.val - y.val ∧ z.bv = x.bv - y.bv
-  | none => x.val < y.val := by
-  have := core.num.checked_sub_UScalar_bv_spec x y
-  simp_all [U32.checked_sub, UScalar.max, U32.bv]
-  cases h: core.num.checked_sub_UScalar x y <;> simp_all
-
-@[progress_pure checked_sub x y]
-theorem U64.checked_sub_bv_spec (x y : U64) :
-  match U64.checked_sub x y with
-  | some z => y.val ≤ x.val ∧ z.val = x.val - y.val ∧ z.bv = x.bv - y.bv
-  | none => x.val < y.val := by
-  have := core.num.checked_sub_UScalar_bv_spec x y
-  simp_all [U64.checked_sub, UScalar.max, U64.bv]
-  cases h: core.num.checked_sub_UScalar x y <;> simp_all
-
-@[progress_pure checked_sub x y]
-theorem U128.checked_sub_bv_spec (x y : U128) :
-  match U128.checked_sub x y with
-  | some z => y.val ≤ x.val ∧ z.val = x.val - y.val ∧ z.bv = x.bv - y.bv
-  | none => x.val < y.val := by
-  have := core.num.checked_sub_UScalar_bv_spec x y
-  simp_all [U128.checked_sub, UScalar.max, U128.bv]
-  cases h: core.num.checked_sub_UScalar x y <;> simp_all
-
-theorem Usize.checked_sub_bv_spec (x y : Usize) :
-  match Usize.checked_sub x y with
-  | some z => y.val ≤ x.val ∧ z.val = x.val - y.val ∧ z.bv = x.bv - y.bv
-  | none => x.val < y.val := by
-  have := core.num.checked_sub_UScalar_bv_spec x y
-  simp_all [Usize.checked_sub, UScalar.max, Usize.bv]
+  simp_all [«%S».checked_sub, UScalar.max, «%S».bv]
   cases h: core.num.checked_sub_UScalar x y <;> simp_all
 
 /-!
@@ -113,58 +60,13 @@ theorem core.num.checked_sub_IScalar_bv_spec {ty} (x y : IScalar ty) :
   (have : 0 < 2^ty.numBits := by simp) <;>
   omega
 
-@[progress_pure checked_sub x y]
-theorem I8.checked_sub_bv_spec (x y : I8) :
+iscalar @[progress_pure «%S».checked_sub x y]
+theorem «%S».checked_sub_bv_spec (x y : «%S») :
   match core.num.checked_sub_IScalar x y with
-  | some z => I8.min ≤ x.val - y.val ∧ x.val - y.val ≤ I8.max ∧ z.val = x.val - y.val ∧ z.bv = x.bv - y.bv
-  | none => ¬ (I8.min ≤ x.val - y.val ∧ x.val - y.val ≤ I8.max) := by
+  | some z => «%S».min ≤ x.val - y.val ∧ x.val - y.val ≤ «%S».max ∧ z.val = x.val - y.val ∧ z.bv = x.bv - y.bv
+  | none => ¬ («%S».min ≤ x.val - y.val ∧ x.val - y.val ≤ «%S».max) := by
   have := core.num.checked_sub_IScalar_bv_spec x y
-  simp_all only [I8.checked_sub, IScalar.min, IScalar.max, I8.bv, min, max, numBits]
-  cases h: core.num.checked_sub_IScalar x y <;> simp_all only <;> simp
-
-@[progress_pure checked_sub x y]
-theorem I16.checked_sub_bv_spec (x y : I16) :
-  match core.num.checked_sub_IScalar x y with
-  | some z => I16.min ≤ x.val - y.val ∧ x.val - y.val ≤ I16.max ∧ z.val = x.val - y.val ∧ z.bv = x.bv - y.bv
-  | none => ¬ (I16.min ≤ x.val - y.val ∧ x.val - y.val ≤ I16.max) := by
-  have := core.num.checked_sub_IScalar_bv_spec x y
-  simp_all only [I16.checked_sub, IScalar.min, IScalar.max, I16.bv, min, max, numBits]
-  cases h: core.num.checked_sub_IScalar x y <;> simp_all only <;> simp
-
-@[progress_pure checked_sub x y]
-theorem I32.checked_sub_bv_spec (x y : I32) :
-  match core.num.checked_sub_IScalar x y with
-  | some z => I32.min ≤ x.val - y.val ∧ x.val - y.val ≤ I32.max ∧ z.val = x.val - y.val ∧ z.bv = x.bv - y.bv
-  | none => ¬ (I32.min ≤ x.val - y.val ∧ x.val - y.val ≤ I32.max) := by
-  have := core.num.checked_sub_IScalar_bv_spec x y
-  simp_all only [I32.checked_sub, IScalar.min, IScalar.max, I32.bv, min, max, numBits]
-  cases h: core.num.checked_sub_IScalar x y <;> simp_all only <;> simp
-
-@[progress_pure checked_sub x y]
-theorem I64.checked_sub_bv_spec (x y : I64) :
-  match core.num.checked_sub_IScalar x y with
-  | some z => I64.min ≤ x.val - y.val ∧ x.val - y.val ≤ I64.max ∧ z.val = x.val - y.val ∧ z.bv = x.bv - y.bv
-  | none => ¬ (I64.min ≤ x.val - y.val ∧ x.val - y.val ≤ I64.max) := by
-  have := core.num.checked_sub_IScalar_bv_spec x y
-  simp_all only [I64.checked_sub, IScalar.min, IScalar.max, I64.bv, min, max, numBits]
-  cases h: core.num.checked_sub_IScalar x y <;> simp_all only <;> simp
-
-@[progress_pure checked_sub x y]
-theorem I128.checked_sub_bv_spec (x y : I128) :
-  match core.num.checked_sub_IScalar x y with
-  | some z => I128.min ≤ x.val - y.val ∧ x.val - y.val ≤ I128.max ∧ z.val = x.val - y.val ∧ z.bv = x.bv - y.bv
-  | none => ¬ (I128.min ≤ x.val - y.val ∧ x.val - y.val ≤ I128.max) := by
-  have := core.num.checked_sub_IScalar_bv_spec x y
-  simp_all only [I128.checked_sub, IScalar.min, IScalar.max, I128.bv, min, max, numBits]
-  cases h: core.num.checked_sub_IScalar x y <;> simp_all only <;> simp
-
-@[progress_pure checked_sub x y]
-theorem Isize.checked_sub_bv_spec (x y : Isize) :
-  match core.num.checked_sub_IScalar x y with
-  | some z => Isize.min ≤ x.val - y.val ∧ x.val - y.val ≤ Isize.max ∧ z.val = x.val - y.val ∧ z.bv = x.bv - y.bv
-  | none => ¬ (Isize.min ≤ x.val - y.val ∧ x.val - y.val ≤ Isize.max) := by
-  have := core.num.checked_sub_IScalar_bv_spec x y
-  simp_all only [Isize.checked_sub, IScalar.min, IScalar.max, Isize.bv, min, max, numBits]
+  simp_all only [«%S».checked_sub, IScalar.min, IScalar.max, «%S».bv, «%S».min, «%S».max, «%S».numBits]
   cases h: core.num.checked_sub_IScalar x y <;> simp_all only <;> simp
 
 end Aeneas.Std

--- a/backends/lean/Aeneas/Std/Scalar/CloneCopy.lean
+++ b/backends/lean/Aeneas/Std/Scalar/CloneCopy.lean
@@ -1,147 +1,36 @@
 import Aeneas.Std.Scalar.Core
+import Aeneas.Std.Scalar.Elab
 
 namespace Aeneas.Std
 
-open Result Error
+open Result Error ScalarElab
 
 /-!
 # Clone and Copy
 -/
 
-@[reducible, simp] def core.clone.impls.CloneUsize.clone (x : Usize) : Usize := x
-@[reducible, simp] def core.clone.impls.CloneU8.clone (x : U8) : U8 := x
-@[reducible, simp] def core.clone.impls.CloneU16.clone (x : U16) : U16 := x
-@[reducible, simp] def core.clone.impls.CloneU32.clone (x : U32) : U32 := x
-@[reducible, simp] def core.clone.impls.CloneU64.clone (x : U64) : U64 := x
-@[reducible, simp] def core.clone.impls.CloneU128.clone (x : U128) : U128 := x
+-- Remark: the command `uscalar` turns the name `Clone'S` into `CloneU8`, `CloneU16`, etc.
+uscalar @[reducible, simp] def core.clone.impls.Clone'S.clone (x : «%S») : «%S» := x
+uscalar @[reducible, simp] def core.clone.impls.Clone'S.clone_from (_ x : «%S») : «%S» := x
+iscalar @[reducible, simp] def core.clone.impls.Clone'S.clone (x : «%S») : «%S» := x
+iscalar @[reducible, simp] def core.clone.impls.Clone'S.clone_from (_ x : «%S») : «%S» := x
 
-@[reducible, simp] def core.clone.impls.CloneUsize.clone_from (_ x : Usize) : Usize := x
-@[reducible, simp] def core.clone.impls.CloneU8.clone_from (_ x : U8) : U8 := x
-@[reducible, simp] def core.clone.impls.CloneU16.clone_from (_ x : U16) : U16 := x
-@[reducible, simp] def core.clone.impls.CloneU32.clone_from (_ x : U32) : U32 := x
-@[reducible, simp] def core.clone.impls.CloneU64.clone_from (_ x : U64) : U64 := x
-@[reducible, simp] def core.clone.impls.CloneU128.clone_from (_ x : U128) : U128 := x
+uscalar @[reducible] def core.clone.Clone'S : core.clone.Clone «%S» := {
+  clone := liftFun1 core.clone.impls.Clone'S.clone
+  clone_from := liftFun2 core.clone.impls.Clone'S.clone_from }
 
-@[reducible, simp] def core.clone.impls.CloneIsize.clone (x : Isize) : Isize := x
-@[reducible, simp] def core.clone.impls.CloneI8.clone (x : I8) : I8 := x
-@[reducible, simp] def core.clone.impls.CloneI16.clone (x : I16) : I16 := x
-@[reducible, simp] def core.clone.impls.CloneI32.clone (x : I32) : I32 := x
-@[reducible, simp] def core.clone.impls.CloneI64.clone (x : I64) : I64 := x
-@[reducible, simp] def core.clone.impls.CloneI128.clone (x : I128) : I128 := x
+iscalar @[reducible] def core.clone.Clone'S : core.clone.Clone «%S» := {
+  clone := liftFun1 core.clone.impls.Clone'S.clone
+  clone_from := liftFun2 core.clone.impls.Clone'S.clone_from }
 
-@[reducible, simp] def core.clone.impls.CloneIsize.clone_from (_ x : Isize) : Isize := x
-@[reducible, simp] def core.clone.impls.CloneI8.clone_from (_ x : I8) : I8 := x
-@[reducible, simp] def core.clone.impls.CloneI16.clone_from (_ x : I16) : I16 := x
-@[reducible, simp] def core.clone.impls.CloneI32.clone_from (_ x : I32) : I32 := x
-@[reducible, simp] def core.clone.impls.CloneI64.clone_from (_ x : I64) : I64 := x
-@[reducible, simp] def core.clone.impls.CloneI128.clone_from (_ x : I128) : I128 := x
-
-@[reducible] def core.clone.CloneU8 : core.clone.Clone U8 := {
-  clone := liftFun1 core.clone.impls.CloneU8.clone
-  clone_from := liftFun2 core.clone.impls.CloneU8.clone_from }
-
-@[reducible] def core.clone.CloneU16 : core.clone.Clone U16 := {
-  clone := liftFun1 core.clone.impls.CloneU16.clone
-  clone_from := liftFun2 core.clone.impls.CloneU16.clone_from }
-
-@[reducible] def core.clone.CloneU32 : core.clone.Clone U32 := {
-  clone := liftFun1 core.clone.impls.CloneU32.clone
-  clone_from := liftFun2 core.clone.impls.CloneU32.clone_from }
-
-@[reducible] def core.clone.CloneU64 : core.clone.Clone U64 := {
-  clone := liftFun1 core.clone.impls.CloneU64.clone
-  clone_from := liftFun2 core.clone.impls.CloneU64.clone_from }
-
-@[reducible] def core.clone.CloneU128 : core.clone.Clone U128 := {
-  clone := liftFun1 core.clone.impls.CloneU128.clone
-  clone_from := liftFun2 core.clone.impls.CloneU128.clone_from }
-
-@[reducible] def core.clone.CloneUsize : core.clone.Clone Usize := {
-  clone := liftFun1 core.clone.impls.CloneUsize.clone
-  clone_from := liftFun2 core.clone.impls.CloneUsize.clone_from }
-
-@[reducible] def core.clone.CloneI8 : core.clone.Clone I8 := {
-  clone := liftFun1 core.clone.impls.CloneI8.clone
-  clone_from := liftFun2 core.clone.impls.CloneI8.clone_from }
-
-@[reducible] def core.clone.CloneI16 : core.clone.Clone I16 := {
-  clone := liftFun1 core.clone.impls.CloneI16.clone
-  clone_from := liftFun2 core.clone.impls.CloneI16.clone_from }
-
-@[reducible] def core.clone.CloneI32 : core.clone.Clone I32 := {
-  clone := liftFun1 core.clone.impls.CloneI32.clone
-  clone_from := liftFun2 core.clone.impls.CloneI32.clone_from }
-
-@[reducible] def core.clone.CloneI64 : core.clone.Clone I64 := {
-  clone := liftFun1 core.clone.impls.CloneI64.clone
-  clone_from := liftFun2 core.clone.impls.CloneI64.clone_from }
-
-@[reducible] def core.clone.CloneI128 : core.clone.Clone I128 := {
-  clone := liftFun1 core.clone.impls.CloneI128.clone
-  clone_from := liftFun2 core.clone.impls.CloneI128.clone_from }
-
-@[reducible] def core.clone.CloneIsize : core.clone.Clone Isize := {
-  clone := liftFun1 core.clone.impls.CloneIsize.clone
-  clone_from := liftFun2 core.clone.impls.CloneIsize.clone_from }
-
-@[reducible]
-def core.marker.CopyU8 : core.marker.Copy U8 := {
-  cloneInst := core.clone.CloneU8
+uscalar @[reducible]
+def core.marker.Copy'S : core.marker.Copy «%S» := {
+  cloneInst := core.clone.Clone'S
 }
 
-@[reducible]
-def core.marker.CopyU16 : core.marker.Copy U16 := {
-  cloneInst := core.clone.CloneU16
-}
-
-@[reducible]
-def core.marker.CopyU32 : core.marker.Copy U32 := {
-  cloneInst := core.clone.CloneU32
-}
-
-@[reducible]
-def core.marker.CopyU64 : core.marker.Copy U64 := {
-  cloneInst := core.clone.CloneU64
-}
-
-@[reducible]
-def core.marker.CopyU128 : core.marker.Copy U128 := {
-  cloneInst := core.clone.CloneU128
-}
-
-@[reducible]
-def core.marker.CopyUsize : core.marker.Copy Usize := {
-  cloneInst := core.clone.CloneUsize
-}
-
-@[reducible]
-def core.marker.CopyI8 : core.marker.Copy I8 := {
-  cloneInst := core.clone.CloneI8
-}
-
-@[reducible]
-def core.marker.CopyI16 : core.marker.Copy I16 := {
-  cloneInst := core.clone.CloneI16
-}
-
-@[reducible]
-def core.marker.CopyI32 : core.marker.Copy I32 := {
-  cloneInst := core.clone.CloneI32
-}
-
-@[reducible]
-def core.marker.CopyI64 : core.marker.Copy I64 := {
-  cloneInst := core.clone.CloneI64
-}
-
-@[reducible]
-def core.marker.CopyI128 : core.marker.Copy I128 := {
-  cloneInst := core.clone.CloneI128
-}
-
-@[reducible]
-def core.marker.CopyIsize : core.marker.Copy Isize := {
-  cloneInst := core.clone.CloneIsize
+iscalar @[reducible]
+def core.marker.Copy'S : core.marker.Copy «%S» := {
+  cloneInst := core.clone.Clone'S
 }
 
 end Aeneas.Std

--- a/backends/lean/Aeneas/Std/Scalar/CoreConvertNum.lean
+++ b/backends/lean/Aeneas/Std/Scalar/CoreConvertNum.lean
@@ -4,6 +4,7 @@ import Init.Data.List.Basic
 import Mathlib.Tactic.Linarith
 import Aeneas.Std.Scalar.Core
 import Aeneas.Std.Scalar.Notations
+import Aeneas.Std.Scalar.Elab
 import Aeneas.Std.Array.Array
 import Aeneas.ScalarTac
 import Aeneas.Progress.Init
@@ -14,7 +15,7 @@ namespace Aeneas
 
 namespace Std
 
-open Result Error
+open Result Error ScalarElab
 
 namespace core.convert
 
@@ -577,207 +578,62 @@ def FromI128I128 : core.convert.From I128 I128 := {
 
 end core.convert
 
+open ScalarElab
+
 /-!
 # To Little-Endian
 -/
-def core.num.U8.to_le_bytes (x : U8) : Array U8 1#usize := ⟨ x.bv.toLEBytes.map UScalar.mk, by simp ⟩
-def core.num.U16.to_le_bytes (x : U16) : Array U8 2#usize := ⟨ x.bv.toLEBytes.map UScalar.mk, by simp ⟩
-def core.num.U32.to_le_bytes (x : U32) : Array U8 4#usize := ⟨ x.bv.toLEBytes.map UScalar.mk, by simp ⟩
-def core.num.U64.to_le_bytes (x : U64) : Array U8 8#usize := ⟨ x.bv.toLEBytes.map UScalar.mk, by simp ⟩
-def core.num.U128.to_le_bytes (x : U128) : Array U8 16#usize := ⟨ x.bv.toLEBytes.map UScalar.mk, by simp ⟩
-
-def core.num.I8.to_le_bytes (x : I8) : Array I8 1#usize := ⟨ x.bv.toLEBytes.map IScalar.mk, by simp ⟩
-def core.num.I16.to_le_bytes (x : I16) : Array I8 2#usize := ⟨ x.bv.toLEBytes.map IScalar.mk, by simp ⟩
-def core.num.I32.to_le_bytes (x : I32) : Array I8 4#usize := ⟨ x.bv.toLEBytes.map IScalar.mk, by simp ⟩
-def core.num.I64.to_le_bytes (x : I64) : Array I8 8#usize := ⟨ x.bv.toLEBytes.map IScalar.mk, by simp ⟩
-def core.num.I128.to_le_bytes (x : I128) : Array I8 16#usize := ⟨ x.bv.toLEBytes.map IScalar.mk, by simp ⟩
-
+uscalar_no_usize def core.num.«%S».to_le_bytes (x : «%S») : Array U8 (%Size)#usize := ⟨ x.bv.toLEBytes.map UScalar.mk, by simp ⟩
+iscalar_no_isize def core.num.«%S».to_le_bytes (x : «%S») : Array I8 (%Size)#usize := ⟨ x.bv.toLEBytes.map IScalar.mk, by simp ⟩
 
 /-!
 # To Big-Endian
 -/
-def core.num.U8.to_be_bytes (x : U8) : Array U8 1#usize := ⟨ x.bv.toBEBytes.map UScalar.mk, by simp ⟩
-def core.num.U16.to_be_bytes (x : U16) : Array U8 2#usize := ⟨ x.bv.toBEBytes.map UScalar.mk, by simp ⟩
-def core.num.U32.to_be_bytes (x : U32) : Array U8 4#usize := ⟨ x.bv.toBEBytes.map UScalar.mk, by simp ⟩
-def core.num.U64.to_be_bytes (x : U64) : Array U8 8#usize := ⟨ x.bv.toBEBytes.map UScalar.mk, by simp ⟩
-def core.num.U128.to_be_bytes (x : U128) : Array U8 16#usize := ⟨ x.bv.toBEBytes.map UScalar.mk, by simp ⟩
-
-def core.num.I8.to_be_bytes (x : I8) : Array I8 1#usize := ⟨ x.bv.toBEBytes.map IScalar.mk, by simp ⟩
-def core.num.I16.to_be_bytes (x : I16) : Array I8 2#usize := ⟨ x.bv.toBEBytes.map IScalar.mk, by simp ⟩
-def core.num.I32.to_be_bytes (x : I32) : Array I8 4#usize := ⟨ x.bv.toBEBytes.map IScalar.mk, by simp ⟩
-def core.num.I64.to_be_bytes (x : I64) : Array I8 8#usize := ⟨ x.bv.toBEBytes.map IScalar.mk, by simp ⟩
-def core.num.I128.to_be_bytes (x : I128) : Array I8 16#usize := ⟨ x.bv.toBEBytes.map IScalar.mk, by simp ⟩
+uscalar_no_usize def core.num.«%S».to_be_bytes (x : «%S») : Array U8 (%Size)#usize := ⟨ x.bv.toBEBytes.map UScalar.mk, by simp ⟩
+iscalar_no_isize def core.num.«%S».to_be_bytes (x : «%S») : Array I8 (%Size)#usize := ⟨ x.bv.toBEBytes.map IScalar.mk, by simp ⟩
 
 /-!
 # From Little-Endian
 -/
-def core.num.U8.from_le_bytes (a : Array U8 1#usize) : U8 :=
+uscalar_no_usize def core.num.«%S».from_le_bytes (a : Array U8 (%Size)#usize) : «%S» :=
   ⟨ (BitVec.fromLEBytes (List.map U8.bv a.val)).cast (by simp) ⟩
 
-def core.num.U16.from_le_bytes (a : Array U8 2#usize) : U16 :=
-  ⟨ (BitVec.fromLEBytes (List.map U8.bv a.val)).cast (by simp) ⟩
-
-def core.num.U32.from_le_bytes (a : Array U8 4#usize) : U32 :=
-  ⟨ (BitVec.fromLEBytes (List.map U8.bv a.val)).cast (by simp) ⟩
-
-def core.num.U64.from_le_bytes (a : Array U8 8#usize) : U64 :=
-  ⟨ (BitVec.fromLEBytes (List.map U8.bv a.val)).cast (by simp) ⟩
-
-def core.num.U128.from_le_bytes (a : Array U8 16#usize) : U128 :=
-  ⟨ (BitVec.fromLEBytes (List.map U8.bv a.val)).cast (by simp) ⟩
-
-def core.num.I8.from_le_bytes (a : Array I8 1#usize) : I8 :=
-  ⟨ (BitVec.fromLEBytes (List.map I8.bv a.val)).cast (by simp) ⟩
-
-def core.num.I16.from_le_bytes (a : Array I8 2#usize) : I16 :=
-  ⟨ (BitVec.fromLEBytes (List.map I8.bv a.val)).cast (by simp) ⟩
-
-def core.num.I32.from_le_bytes (a : Array I8 4#usize) : I32 :=
-  ⟨ (BitVec.fromLEBytes (List.map I8.bv a.val)).cast (by simp) ⟩
-
-def core.num.I64.from_le_bytes (a : Array I8 8#usize) : I64 :=
-  ⟨ (BitVec.fromLEBytes (List.map I8.bv a.val)).cast (by simp) ⟩
-
-def core.num.I128.from_le_bytes (a : Array I8 16#usize) : I128 :=
+iscalar_no_isize def core.num.«%S».from_le_bytes (a : Array I8 (%Size)#usize) : «%S» :=
   ⟨ (BitVec.fromLEBytes (List.map I8.bv a.val)).cast (by simp) ⟩
 
 /-!
 # From Big-Endian
 -/
-def core.num.U8.from_be_bytes (a : Array U8 1#usize) : U8 :=
+uscalar_no_usize def core.num.«%S».from_be_bytes (a : Array U8 (%Size)#usize) : «%S» :=
   ⟨ (BitVec.fromBEBytes (List.map U8.bv a.val)).cast (by simp) ⟩
 
-def core.num.U16.from_be_bytes (a : Array U8 2#usize) : U16 :=
-  ⟨ (BitVec.fromBEBytes (List.map U8.bv a.val)).cast (by simp) ⟩
-
-def core.num.U32.from_be_bytes (a : Array U8 4#usize) : U32 :=
-  ⟨ (BitVec.fromBEBytes (List.map U8.bv a.val)).cast (by simp) ⟩
-
-def core.num.U64.from_be_bytes (a : Array U8 8#usize) : U64 :=
-  ⟨ (BitVec.fromBEBytes (List.map U8.bv a.val)).cast (by simp) ⟩
-
-def core.num.U128.from_be_bytes (a : Array U8 16#usize) : U128 :=
-  ⟨ (BitVec.fromBEBytes (List.map U8.bv a.val)).cast (by simp) ⟩
-
-def core.num.I8.from_be_bytes (a : Array I8 1#usize) : I8 :=
-  ⟨ (BitVec.fromBEBytes (List.map I8.bv a.val)).cast (by simp) ⟩
-
-def core.num.I16.from_be_bytes (a : Array I8 2#usize) : I16 :=
-  ⟨ (BitVec.fromBEBytes (List.map I8.bv a.val)).cast (by simp) ⟩
-
-def core.num.I32.from_be_bytes (a : Array I8 4#usize) : I32 :=
-  ⟨ (BitVec.fromBEBytes (List.map I8.bv a.val)).cast (by simp) ⟩
-
-def core.num.I64.from_be_bytes (a : Array I8 8#usize) : I64 :=
-  ⟨ (BitVec.fromBEBytes (List.map I8.bv a.val)).cast (by simp) ⟩
-
-def core.num.I128.from_be_bytes (a : Array I8 16#usize) : I128 :=
+iscalar_no_isize def core.num.«%S».from_be_bytes (a : Array I8 (%Size)#usize) : «%S» :=
   ⟨ (BitVec.fromBEBytes (List.map I8.bv a.val)).cast (by simp) ⟩
 
 /-!
 # Progress theorems: To Little-Endian
 -/
-@[progress]
-theorem core.num.U8.to_le_bytes.progress_spec (x : U8) :
-  ∃ y, toResult (core.num.U8.to_le_bytes x) = ok y ∧ y.val = x.bv.toLEBytes.map (@UScalar.mk UScalarTy.U8) := by
+uscalar_no_usize @[progress]
+theorem core.num.«%S».to_le_bytes.progress_spec (x : «%S») :
+  ∃ y, toResult (core.num.«%S».to_le_bytes x) = ok y ∧ y.val = x.bv.toLEBytes.map (@UScalar.mk UScalarTy.U8) := by
   simp only [id_eq, toResult, to_le_bytes, UScalarTy.U8_numBits_eq, ok.injEq, exists_eq_left']
 
-@[progress]
-theorem core.num.U16.to_le_bytes.progress_spec (x : U16) :
-  ∃ y, toResult (core.num.U16.to_le_bytes x) = ok y ∧ y.val = x.bv.toLEBytes.map (@UScalar.mk UScalarTy.U8) := by
-  simp only [id_eq, toResult, to_le_bytes, UScalarTy.U16_numBits_eq, ok.injEq, exists_eq_left']
-
-@[progress]
-theorem core.num.U32.to_le_bytes.progress_spec (x : U32) :
-  ∃ y, toResult (core.num.U32.to_le_bytes x) = ok y ∧ y.val = x.bv.toLEBytes.map (@UScalar.mk UScalarTy.U8) := by
-  simp only [id_eq, toResult, to_le_bytes, UScalarTy.U32_numBits_eq, ok.injEq, exists_eq_left']
-
-@[progress]
-theorem core.num.U64.to_le_bytes.progress_spec (x : U64) :
-  ∃ y, toResult (core.num.U64.to_le_bytes x) = ok y ∧ y.val = x.bv.toLEBytes.map (@UScalar.mk UScalarTy.U8) := by
-  simp only [id_eq, toResult, to_le_bytes, UScalarTy.U64_numBits_eq, ok.injEq, exists_eq_left']
-
-@[progress]
-theorem core.num.U128.to_le_bytes.progress_spec (x : U128) :
-  ∃ y, toResult (core.num.U128.to_le_bytes x) = ok y ∧ y.val = x.bv.toLEBytes.map (@UScalar.mk UScalarTy.U8) := by
-  simp only [id_eq, toResult, to_le_bytes, UScalarTy.U128_numBits_eq, ok.injEq, exists_eq_left']
-
-@[progress]
-theorem core.num.I8.to_le_bytes.progress_spec (x : I8) :
-  ∃ y, toResult (core.num.I8.to_le_bytes x) = ok y ∧ y.val = x.bv.toLEBytes.map (@IScalar.mk IScalarTy.I8) := by
+iscalar_no_isize @[progress]
+theorem core.num.«%S».to_le_bytes.progress_spec (x : «%S») :
+  ∃ y, toResult (core.num.«%S».to_le_bytes x) = ok y ∧ y.val = x.bv.toLEBytes.map (@IScalar.mk IScalarTy.I8) := by
   simp only [id_eq, toResult, to_le_bytes, IScalarTy.I8_numBits_eq, ok.injEq, exists_eq_left']
-
-@[progress]
-theorem core.num.I16.to_le_bytes.progress_spec (x : I16) :
-  ∃ y, toResult (core.num.I16.to_le_bytes x) = ok y ∧ y.val = x.bv.toLEBytes.map (@IScalar.mk IScalarTy.I8) := by
-  simp only [id_eq, toResult, to_le_bytes, IScalarTy.I16_numBits_eq, ok.injEq, exists_eq_left']
-
-@[progress]
-theorem core.num.I32.to_le_bytes.progress_spec (x : I32) :
-  ∃ y, toResult (core.num.I32.to_le_bytes x) = ok y ∧ y.val = x.bv.toLEBytes.map (@IScalar.mk IScalarTy.I8) := by
-  simp only [id_eq, toResult, to_le_bytes, IScalarTy.I32_numBits_eq, ok.injEq, exists_eq_left']
-
-@[progress]
-theorem core.num.I64.to_le_bytes.progress_spec (x : I64) :
-  ∃ y, toResult (core.num.I64.to_le_bytes x) = ok y ∧ y.val = x.bv.toLEBytes.map (@IScalar.mk IScalarTy.I8) := by
-  simp only [id_eq, toResult, to_le_bytes, IScalarTy.I64_numBits_eq, ok.injEq, exists_eq_left']
-
-@[progress]
-theorem core.num.I128.to_le_bytes.progress_spec (x : I128) :
-  ∃ y, toResult (core.num.I128.to_le_bytes x) = ok y ∧ y.val = x.bv.toLEBytes.map (@IScalar.mk IScalarTy.I8) := by
-  simp only [id_eq, toResult, to_le_bytes, IScalarTy.I128_numBits_eq, ok.injEq, exists_eq_left']
 
 /-!
 # Progress theorems: From Little-Endian
 -/
-@[progress]
-theorem core.num.U8.from_le_bytes.progress_spec (x : Array U8 1#usize) :
-  ∃ y, toResult (core.num.U8.from_le_bytes x) = ok y ∧ y.bv = (BitVec.fromLEBytes (x.val.map U8.bv)).cast (by simp) := by
+uscalar_no_usize @[progress]
+theorem core.num.«%S».from_le_bytes.progress_spec (x : Array U8 (%Size)#usize) :
+  ∃ y, toResult (core.num.«%S».from_le_bytes x) = ok y ∧ y.bv = (BitVec.fromLEBytes (x.val.map U8.bv)).cast (by simp) := by
   simp only [toResult, from_le_bytes, UScalarTy.U8_numBits_eq, ok.injEq, id_eq, exists_eq_left']
 
-@[progress]
-theorem core.num.U16.from_le_bytes.progress_spec (x : Array U8 2#usize) :
-  ∃ y, toResult (core.num.U16.from_le_bytes x) = ok y ∧ y.bv = (BitVec.fromLEBytes (x.val.map U8.bv)).cast (by simp) := by
-  simp only [toResult, from_le_bytes, UScalarTy.U8_numBits_eq, ok.injEq, id_eq, exists_eq_left']
-
-@[progress]
-theorem core.num.U32.from_le_bytes.progress_spec (x : Array U8 4#usize) :
-  ∃ y, toResult (core.num.U32.from_le_bytes x) = ok y ∧ y.bv = (BitVec.fromLEBytes (x.val.map U8.bv)).cast (by simp) := by
-  simp only [toResult, from_le_bytes, UScalarTy.U8_numBits_eq, ok.injEq, id_eq, exists_eq_left']
-
-@[progress]
-theorem core.num.U64.from_le_bytes.progress_spec (x : Array U8 8#usize) :
-  ∃ y, toResult (core.num.U64.from_le_bytes x) = ok y ∧ y.bv = (BitVec.fromLEBytes (x.val.map U8.bv)).cast (by simp) := by
-  simp only [toResult, from_le_bytes, UScalarTy.U8_numBits_eq, ok.injEq, id_eq, exists_eq_left']
-
-@[progress]
-theorem core.num.U128.from_le_bytes.progress_spec (x : Array U8 16#usize) :
-  ∃ y, toResult (core.num.U128.from_le_bytes x) = ok y ∧ y.bv = (BitVec.fromLEBytes (x.val.map U8.bv)).cast (by simp) := by
-  simp only [toResult, from_le_bytes, UScalarTy.U8_numBits_eq, ok.injEq, id_eq, exists_eq_left']
-
-@[progress]
-theorem core.num.I8.from_le_bytes.progress_spec (x : Array I8 1#usize) :
-  ∃ y, toResult (core.num.I8.from_le_bytes x) = ok y ∧ y.bv = (BitVec.fromLEBytes (x.val.map I8.bv)).cast (by simp) := by
-  simp only [toResult, from_le_bytes, IScalarTy.I8_numBits_eq, ok.injEq, id_eq, exists_eq_left']
-
-@[progress]
-theorem core.num.I16.from_le_bytes.progress_spec (x : Array I8 2#usize) :
-  ∃ y, toResult (core.num.I16.from_le_bytes x) = ok y ∧ y.bv = (BitVec.fromLEBytes (x.val.map I8.bv)).cast (by simp) := by
-  simp only [toResult, from_le_bytes, IScalarTy.I8_numBits_eq, ok.injEq, id_eq, exists_eq_left']
-
-@[progress]
-theorem core.num.I32.from_le_bytes.progress_spec (x : Array I8 4#usize) :
-  ∃ y, toResult (core.num.I32.from_le_bytes x) = ok y ∧ y.bv = (BitVec.fromLEBytes (x.val.map I8.bv)).cast (by simp) := by
-  simp only [toResult, from_le_bytes, IScalarTy.I8_numBits_eq, ok.injEq, id_eq, exists_eq_left']
-
-@[progress]
-theorem core.num.I64.from_le_bytes.progress_spec (x : Array I8 8#usize) :
-  ∃ y, toResult (core.num.I64.from_le_bytes x) = ok y ∧ y.bv = (BitVec.fromLEBytes (x.val.map I8.bv)).cast (by simp) := by
-  simp only [toResult, from_le_bytes, IScalarTy.I8_numBits_eq, ok.injEq, id_eq, exists_eq_left']
-
-@[progress]
-theorem core.num.I128.from_le_bytes.progress_spec (x : Array I8 16#usize) :
-  ∃ y, toResult (core.num.I128.from_le_bytes x) = ok y ∧ y.bv = (BitVec.fromLEBytes (x.val.map I8.bv)).cast (by simp) := by
+iscalar_no_isize @[progress]
+theorem core.num.«%S».from_le_bytes.progress_spec (x : Array I8 (%Size)#usize) :
+  ∃ y, toResult (core.num.«%S».from_le_bytes x) = ok y ∧ y.bv = (BitVec.fromLEBytes (x.val.map I8.bv)).cast (by simp) := by
   simp only [toResult, from_le_bytes, IScalarTy.I8_numBits_eq, ok.injEq, id_eq, exists_eq_left']
 
 end Std

--- a/backends/lean/Aeneas/Std/Scalar/Default.lean
+++ b/backends/lean/Aeneas/Std/Scalar/Default.lean
@@ -1,66 +1,22 @@
 import Aeneas.Std.Scalar.Core
+import Aeneas.Std.Scalar.Elab
 import Aeneas.Std.Default
 import Aeneas.Std.Scalar.Notations
 
 namespace Aeneas.Std
 
-open Result
+open Result ScalarElab
 
 /- [core::default::{core::default::Default for u32}::default]:
    Source: '/rustc/library/core/src/default.rs', lines 156:12-156:30
    Name pattern: [core::default::{core::default::Default<u32>}::default] -/
-@[simp, scalar_tac_simps] def core.default.DefaultU8.default : U8 := 0#u8
-@[simp, scalar_tac_simps] def core.default.DefaultU16.default : U16 := 0#u16
-@[simp, scalar_tac_simps] def core.default.DefaultU32.default : U32 := 0#u32
-@[simp, scalar_tac_simps] def core.default.DefaultU64.default : U64 := 0#u64
-@[simp, scalar_tac_simps] def core.default.DefaultU128.default : U128 := 0#u128
-@[simp, scalar_tac_simps] def core.default.DefaultUsize.default : Usize := 0#usize
-
-@[simp, scalar_tac_simps] def core.default.DefaultI8.default : I8 := 0#i8
-@[simp, scalar_tac_simps] def core.default.DefaultI16.default : I16 := 0#i16
-@[simp, scalar_tac_simps] def core.default.DefaultI32.default : I32 := 0#i32
-@[simp, scalar_tac_simps] def core.default.DefaultI64.default : I64 := 0#i64
-@[simp, scalar_tac_simps] def core.default.DefaultI128.default : I128 := 0#i128
-@[simp, scalar_tac_simps] def core.default.DefaultIsize.default : Isize := 0#isize
+uscalar @[simp, scalar_tac_simps] def core.default.Default'S.default : «%S» := ⟨ 0, by scalar_tac ⟩
+iscalar @[simp, scalar_tac_simps] def core.default.Default'S.default : «%S» := ⟨ 0, by scalar_tac ⟩
 
 /- Trait implementation: [core::default::{core::default::Default for u32}#7]
    Source: '/rustc/library/core/src/default.rs', lines 153:8-153:27
    Name pattern: [core::default::Default<u32>] -/
-@[reducible] def core.default.DefaultU8 : core.default.Default U8 := {
-  default := ok core.default.DefaultU8.default }
-
-@[reducible] def core.default.DefaultU16 : core.default.Default U16 := {
-  default := ok core.default.DefaultU16.default }
-
-@[reducible] def core.default.DefaultU32 : core.default.Default U32 := {
-  default := ok core.default.DefaultU32.default }
-
-@[reducible] def core.default.DefaultU64 : core.default.Default U64 := {
-  default := ok core.default.DefaultU64.default }
-
-@[reducible] def core.default.DefaultU128 : core.default.Default U128 := {
-  default := ok core.default.DefaultU128.default }
-
-@[reducible] def core.default.DefaultUsize : core.default.Default Usize := {
-  default := ok core.default.DefaultUsize.default }
-
-@[reducible] def core.default.DefaultI8 : core.default.Default I8 := {
-  default := ok core.default.DefaultI8.default }
-
-@[reducible] def core.default.DefaultI16 : core.default.Default I16 := {
-  default := ok core.default.DefaultI16.default }
-
-@[reducible] def core.default.DefaultI32 : core.default.Default I32 := {
-  default := ok core.default.DefaultI32.default }
-
-@[reducible] def core.default.DefaultI64 : core.default.Default I64 := {
-  default := ok core.default.DefaultI64.default }
-
-@[reducible] def core.default.DefaultI128 : core.default.Default I128 := {
-  default := ok core.default.DefaultI128.default }
-
-@[reducible] def core.default.DefaultIsize : core.default.Default Isize := {
-  default := ok core.default.DefaultIsize.default }
-
+scalar @[reducible] def core.default.Default'S : core.default.Default «%S» := {
+  default := ok core.default.Default'S.default }
 
 end Aeneas.Std

--- a/backends/lean/Aeneas/Std/Scalar/Elab.lean
+++ b/backends/lean/Aeneas/Std/Scalar/Elab.lean
@@ -1,0 +1,287 @@
+import Lean
+
+namespace Aeneas.Std.ElabScalar
+
+open Lean Elab Command Term Meta
+
+/- Generic scalar term -/
+declare_syntax_cat gscalar_ident
+scoped syntax ident : gscalar_ident
+scoped syntax "%S" : gscalar_ident
+scoped syntax gscalar_ident "." ident : gscalar_ident
+
+/- Using the same precedences as in `Lean.Notation` -/
+declare_syntax_cat gscalar_term
+scoped syntax num : gscalar_term
+scoped syntax:max "-" gscalar_term : gscalar_term
+scoped syntax:65 gscalar_term:65 " + " gscalar_term:66 : gscalar_term
+scoped syntax:65 gscalar_term:65 " - " gscalar_term:66 : gscalar_term
+scoped syntax:65 gscalar_term:65 " * " gscalar_term:66 : gscalar_term
+scoped syntax:65 gscalar_term:65 " / " gscalar_term:66 : gscalar_term
+scoped syntax:65 gscalar_term:65 " % " gscalar_term:66 : gscalar_term
+scoped syntax:1024 gscalar_term:50 " = " gscalar_term:50 : gscalar_term
+scoped syntax:50 gscalar_term:50 " ≤ " gscalar_term:50 : gscalar_term
+scoped syntax:50 gscalar_term:50 " < " gscalar_term:50 : gscalar_term
+scoped syntax:50 gscalar_term:50 " ≥ " gscalar_term:50 : gscalar_term
+scoped syntax:50 gscalar_term:50 " > " gscalar_term:50 : gscalar_term
+scoped syntax:35 gscalar_term:36 " ∧ " gscalar_term:35 : gscalar_term
+scoped syntax:30 gscalar_term:31 " ∨ " gscalar_term:50 : gscalar_term
+scoped syntax:max "¬ " gscalar_term : gscalar_term
+
+declare_syntax_cat gscalar_arg
+scoped syntax gscalar_ident : gscalar_arg
+scoped syntax num : gscalar_arg
+scoped syntax "(" gscalar_term ")" : gscalar_arg
+
+--scoped syntax gscalar_term gscalar_arg : gscalar_term
+-- TODO: what is the precedence of function application?
+scoped syntax:100 gscalar_term:100 gscalar_term:101 : gscalar_term
+
+-- For now we harcode a specific kind of matches
+scoped syntax "match" gscalar_term "with" "|" term "=>" gscalar_term "|" term "=>" gscalar_term : gscalar_term
+
+scoped syntax gscalar_ident : gscalar_term
+
+declare_syntax_cat gscalar_param
+scoped syntax "(" ident+ ":" gscalar_term ")" : gscalar_param
+scoped syntax "{" ident+ ":" gscalar_term "}" : gscalar_param
+
+partial def elabGScalarIdent (scalarTy : Name) (stx : TSyntax `gscalar_ident) : CommandElabM Name := do
+  println! "elabGScalarIdent: {stx}"
+  match stx with
+  | `(gscalar_ident|%S) => pure scalarTy
+  | `(gscalar_ident|$id:ident) => pure id.getId
+  | `(gscalar_ident| $id0 . $id1:ident) => do
+    let id0 ← elabGScalarIdent scalarTy id0
+    pure (id0 ++ id1.getId)
+  | _ => throwUnsupportedSyntax
+
+mutual
+partial def elabGScalarTerm (scalarTy : Name) (stx : TSyntax `gscalar_term) : CommandElabM (TSyntax `term) := do
+  println! "elabGScalarTerm: {stx}"
+  let elabTerm := elabGScalarTerm scalarTy
+  match stx with
+  | `(gscalar_term| $x $y) => `(term| $(← elabTerm x) $(← elabTerm y))
+  | `(gscalar_term| $x:num) => `(term| $x)
+  | `(gscalar_term| - $x) => `(term| - $(← elabTerm x))
+  | `(gscalar_term| $x + $y) => `(term| $(← elabTerm x) + $(← elabTerm y))
+  | `(gscalar_term| $x - $y) => `(term| $(← elabTerm x) - $(← elabTerm y))
+  | `(gscalar_term| $x * $y) => `(term| $(← elabTerm x) * $(← elabTerm y))
+  | `(gscalar_term| $x / $y) => `(term| $(← elabTerm x) / $(← elabTerm y))
+  | `(gscalar_term| $x % $y) => `(term| $(← elabTerm x) % $(← elabTerm y))
+  | `(gscalar_term| $x = $y) => `(term| $(← elabTerm x) = $(← elabTerm y))
+  | `(gscalar_term| $x ≤ $y) => `(term| $(← elabTerm x) ≤ $(← elabTerm y))
+  | `(gscalar_term| $x < $y) => `(term| $(← elabTerm x) < $(← elabTerm y))
+  | `(gscalar_term| $x ≥ $y) => `(term| $(← elabTerm x) ≥ $(← elabTerm y))
+  | `(gscalar_term| $x > $y) => `(term| $(← elabTerm x) > $(← elabTerm y))
+  | `(gscalar_term| $x ∧ $y) => `(term| $(← elabTerm x) ∧ $(← elabTerm y))
+  | `(gscalar_term| ¬ $x) => `(term| ¬ $(← elabTerm x))
+  | `(gscalar_term| match $scrut with | $y => $e1 | $z => $e2 ) => do
+    -- We only support a specific kind of matches
+    println! "elabGScalarTerm: match: y: {y}"
+    let y: TSyntax `ident ← match y with
+      | `(some $y:ident) => pure y
+      | _ => throwUnsupportedSyntax
+    println! "elabGScalarTerm: match: z: {z}"
+    let _ ← match z with
+      | `(none) => pure ()
+      | _ => throwUnsupportedSyntax
+    println! "elabGScalarTerm: match: e1: {e1}"
+    let e1 ← elabTerm e1
+    println! "elabGScalarTerm: match: e2: {e2}"
+    let e2 ← elabTerm e2
+    println! "elabGScalarTerm: match: scrut: {scrut}"
+    let scrut ← elabTerm scrut
+    `(term| match $scrut:term with | some $y => $e1 | none => $e2)
+  | `($_) => do
+    -- Should be an ident
+    println! "elabGScalarTerm: ident: {stx}"
+    let id ← elabGScalarIdent scalarTy ⟨stx.raw[0]!⟩
+    pure (mkIdent id)
+
+
+partial def elabGScalarArg (scalarTy : Name) (stx : TSyntax `gscalar_arg) : CommandElabM (TSyntax `term) := do
+  println! "elabGScalarArg: {stx}"
+  let elabTerm := elabGScalarTerm scalarTy
+  match stx with
+  | `(gscalar_arg|$x:num) => `(term|$x)
+  | `(gscalar_arg|($x)) => `(term|($(← elabTerm x)))
+  | `($_) =>
+    -- Should be an ident
+    println! "elabGScalarArg: ident: {stx}"
+    let id ← elabGScalarIdent scalarTy ⟨stx.raw[0]!⟩
+    pure (mkIdent id)
+
+end
+
+partial def elabGScalarParams (scalarTy : Name) (stx : TSyntax `gscalar_param) :
+  CommandElabM (TSyntax `Lean.Parser.Term.bracketedBinder) := do
+  match stx with
+  | `(gscalar_param| ($ids* : $ty)) =>
+    let ty ← elabGScalarTerm scalarTy ty
+    `(bracketedBinder|($(ids)* : $ty))
+  | `(gscalar_param| {$ids* : $ty}) =>
+    let ty ← elabGScalarTerm scalarTy ty
+    `(bracketedBinder|{$(ids)* : $ty})
+  | _ => throwUnsupportedSyntax
+
+syntax (name := uscalar_def1) "#uscalar_def1" ident "(" gscalar_term ")" term : command
+
+@[command_elab uscalar_def1]
+def uscalarDef1Impl : CommandElab := fun stx => do
+  logInfo ("#uscalar_def (stx): " ++ stx)
+  match stx with
+  | `(#uscalar_def1 $id ($args) $body) =>
+    logInfo m!"#uscalar_def: {id} {body}"
+    let args ← elabGScalarTerm ``U8 args
+    let stx : TSyntax `command ← `(def $id := $args)
+    elabDeclaration stx
+  | _ => throwUnsupportedSyntax
+
+syntax (name := uscalarDef) "uscalar_def" gscalar_ident gscalar_param+ ":" gscalar_term ":=" term : command
+syntax (name := uscalarThm) "uscalar_theorem" gscalar_ident gscalar_param+ ":" gscalar_term ":=" term : command
+--syntax (name := uscalarThmBy) "uscalar_theorem" gscalar_ident gscalar_param+ ":" gscalar_term ":=" "by" tactic : command
+
+@[command_elab uscalarDef]
+def uscalarDefImpl : CommandElab := fun stx => do
+  logInfo ("uscalar_def (stx): " ++ stx)
+  match stx with
+  | `(uscalarDef| uscalar_def $id $args* : $ty := $body) =>
+    logInfo m!"uscalar_def: {id} {args} : {ty} := {body}"
+    let scalarTy := `U8
+    let id ← elabGScalarIdent scalarTy id
+    let args ← args.mapM (elabGScalarParams scalarTy)
+    let ty ← elabGScalarTerm scalarTy ty
+    let stx : TSyntax `command ← `(def $(mkIdent id) $(args)* : $ty := $body)
+    elabDeclaration stx
+  | _ => throwUnsupportedSyntax
+
+/-@[command_elab uscalarThm]
+def uscalarThmImpl : CommandElab := fun stx => do
+  logInfo ("uscalar_thm (stx): " ++ stx)
+  match stx with
+  | `(uscalarThm| uscalar_theorem $id $args* : $ty := $body) =>
+    logInfo m!"uscalar_thm: {id} {args} : {ty} := {body}"
+    let scalarTy := `U8
+    let id ← elabGScalarIdent scalarTy id
+    let args ← args.mapM (elabGScalarParams scalarTy)
+    let ty ← elabGScalarTerm scalarTy ty
+    let stx : TSyntax `command ← `(theorem $(mkIdent id) $(args)* : $ty := $body)
+    logInfo m!"Final declaration:\n{stx}"
+    elabDeclaration stx
+  | _ => throwUnsupportedSyntax-/
+
+@[command_elab uscalarThm]
+def uscalarThmByImpl : CommandElab := fun stx => do
+  logInfo ("uscalar_thm (stx): " ++ stx)
+  match stx with
+  | `(uscalarThm| uscalar_theorem $id $args* : $ty := by $body) =>
+    logInfo m!"uscalar_thm: {id} {args} : {ty} := {body}"
+    let scalarTy := `U8
+    let id ← elabGScalarIdent scalarTy id
+    let args ← args.mapM (elabGScalarParams scalarTy)
+    let ty ← elabGScalarTerm scalarTy ty
+    let stx : TSyntax `command ← `(theorem $(mkIdent id) $(args)* : $ty := by $body)
+    logInfo m!"Final declaration:\n{stx}"
+    elabDeclaration stx
+  | _ => throwUnsupportedSyntax
+
+/-
+--@[progress_pure checked_add x y]
+uscalar_theorem %S.checked_add_bv_spec' (x y : %S) :
+  match %S.checked_add x y with
+  | some z => x.val + y.val ≤ %S.max ∧ z.val = x.val + y.val ∧ z.bv = x.bv + y.bv
+  | none => %S.max < x.val + y.val
+  := by
+  have := core.num.checked_add_UScalar_bv_spec x y
+  simp_all [U8.checked_add, UScalar.max, U8.bv]
+  cases h: core.num.checked_add_UScalar x y <;> simp_all [U8.max, U8.numBits] -- TODO: remove U8
+-/
+--«%S»
+
+def elabSpecialName (ty : String) (n : Name) : CommandElabM Name := do
+  logInfo m!"elabSpecialName: {n}"
+  match n with
+  | .anonymous => pure .anonymous
+  | .str pre str =>
+    logInfo m!"elabSpecialName: str case: {str}"
+    let str := if str == "%S" then ty else str
+    pure (.str (← elabSpecialName ty pre) str)
+  | .num pre i => pure (.num (← elabSpecialName ty pre) i)
+
+partial def elabSpecial (ty : String) (stx : Syntax) : CommandElabM Syntax := do
+  match stx with
+  | .missing => pure .missing
+  | .node info kind args =>
+    let args ← args.mapM (elabSpecial ty)
+    pure (.node info kind args)
+  | .atom info val => pure (.atom info val)
+  | .ident info rawVal val preresolved =>
+    let val ← elabSpecialName ty val
+    pure (.ident info rawVal val preresolved)
+
+syntax (name := uscalarCommand) "uscalar" command : command
+
+@[command_elab uscalarCommand]
+def uscalarCommandImpl : CommandElab := fun stx => do
+  logInfo ("uscalar_command (stx): " ++ stx)
+  match stx with
+  | `(uscalarCommand| uscalar $cmd) =>
+    logInfo m!"uscalar_command: {cmd}"
+    let elabOne (ty : String) := do
+      let cmd ← elabSpecial ty cmd
+      logInfo m!"Final declaration:\n{cmd}"
+      elabDeclaration cmd
+    for ty in ["U8", "U16", "U32", "U64", "U128", "Usize"] do
+      elabOne ty
+  | _ => throwUnsupportedSyntax
+
+
+--syntax (name := uscalarThm) "uscalar_theorem'"  : command
+
+def C : U8 := ⟨ 0, by simp ⟩
+
+#uscalar_def1 test_def1 (%S.max) (32 : Nat)
+#print test_def1
+
+#uscalar_def1 test_def2 (C) (32 : Nat)
+#print test_def2
+
+#uscalar_def1 test_def3 (%S.max + %S.max) (32 : Nat)
+#print test_def3
+
+#uscalar_def1 test_def4 (
+  match some C with
+  | some z => z.val ≤ 3
+  | none => false) (32 : Nat)
+#print test_def4
+
+#check U8.max
+
+def test_def' :=
+  let S := U8
+  fun (x y : S) (z : ℕ) (h : x.val < 32) => (by scalar_tac : x.val + y.val < 300)
+
+#check test_def'
+
+uscalar_def %S.test1 (x y : %S) : Result %S := x + y
+
+#print U8.test1
+
+/-
+
+uscalar @[progress_pure «%S».checked_add x y] theorem «%S».checked_add_bv_spec'' (x y : «%S») :
+  match «%S».checked_add x y with
+  | some z => x.val + y.val ≤ «%S».max ∧ z.val = x.val + y.val ∧ z.bv = x.bv + y.bv
+  | none => «%S».max < x.val + y.val := by
+  have := core.num.checked_add_UScalar_bv_spec x y
+  simp_all [«%S».checked_add, UScalar.max, «%S».bv]
+  cases h: core.num.checked_add_UScalar x y <;> simp_all [«%S».max, «%S».numBits]
+
+#check U8.checked_add_bv_spec''
+#check U16.checked_add_bv_spec''
+
+
+-/
+
+end Aeneas.Std.ElabScalar

--- a/backends/lean/Aeneas/Std/Scalar/Elab.lean
+++ b/backends/lean/Aeneas/Std/Scalar/Elab.lean
@@ -1,13 +1,16 @@
 import Lean
 
-namespace Aeneas.Std.ElabScalar
+namespace Aeneas.Std.ScalarElab
 
 open Lean Elab Command Term Meta
 
-initialize registerTraceClass `ElabScalar
+
+initialize registerTraceClass `ScalarElabSubst
+initialize registerTraceClass `ScalarElab
 
 /-!
 
+# Generic Scalar Definitions/Theorems
 The following defines elaborators to factor out scalar definitions and theorems.
 We do this because we often need to write a lot of very similar definitions for
 all the scalars kinds. For instance:
@@ -38,66 +41,213 @@ which triggers an elaboration by which, for each scalar type, we recursively exp
 syntax of the command, and generate a command where we replaced all the name segments "%S"
 with either "U8", or "U16", etc.
 
+# Keywords
+- `«%S»`: identifier to be replaced with a scalar name (e.g., `U8`, `U16`, etc.)
+- `'S`: string to be replaced with a scalar name (e.g., `Clone'S ~> CloneU8`, etc.)
+- `%BitWidth`: term to be replaced with a scalar bitwidth (e.g., `8`, `16`, ..., `System.Platform.numBits`)
+- `%Size`: term to be replaced with a size (in bytes)
+
 -/
 
+/- The following contains private definitions copy-pasted from `Lean.Elab.Command` -/
+namespace Declaration
+  /-- Return `true` if `stx` is a `Command.declaration`, and it is a definition that always has a name. -/
+  private def isNamedDef (stx : Syntax) : Bool :=
+    if !stx.isOfKind ``Lean.Parser.Command.declaration then
+      false
+    else
+      let decl := stx[1]
+      let k := decl.getKind
+      k == ``Lean.Parser.Command.abbrev ||
+      k == ``Lean.Parser.Command.definition ||
+      k == ``Lean.Parser.Command.theorem ||
+      k == ``Lean.Parser.Command.opaque ||
+      k == ``Lean.Parser.Command.axiom ||
+      k == ``Lean.Parser.Command.inductive ||
+      k == ``Lean.Parser.Command.classInductive ||
+      k == ``Lean.Parser.Command.structure
+
+  /-- Return `true` if `stx` is an `instance` declaration command -/
+  private def isInstanceDef (stx : Syntax) : Bool :=
+    stx.isOfKind ``Lean.Parser.Command.declaration &&
+    stx[1].getKind == ``Lean.Parser.Command.instance
+
+  /-- Return `some name` if `stx` is a definition named `name` -/
+  def getDefName? (stx : Syntax) : Option Name := do
+    if isNamedDef stx then
+      let (id, _) := expandDeclIdCore stx[1][1]
+      some id
+    else if isInstanceDef stx then
+      let optDeclId := stx[1][3]
+      if optDeclId.isNone then none
+      else
+        let (id, _) := expandDeclIdCore optDeclId[0]
+        some id
+    else
+      none
+end Declaration
+
+def isSubstring (sub str : List Char) : Option (List Char) :=
+  match sub, str with
+  | [], _ => some str
+  | hd :: sub, hd' :: str =>
+    if hd == hd' then isSubstring sub str
+    else none
+  | _, _ => none
+
+partial def elabString (ty : String) (str : String) : String :=
+  let rec replace (str : List Char) :=
+    match isSubstring "'S".data str with
+    | some str => ty.data ++ replace str
+    | none =>
+      match str with
+      | [] => []
+      | c :: str => c :: replace str
+  ⟨ replace str.data ⟩
+
 def elabSpecialName (ty : String) (n : Name) : CommandElabM Name := do
-  trace[ElabScalar] "elabSpecialName: {n}"
+  trace[ScalarElabSubst] "elabSpecialName: {n}"
   match n with
   | .anonymous => pure .anonymous
   | .str pre str =>
-    trace[ElabScalar] "elabSpecialName: str case: {str}"
-    let str := if str == "%S" then ty else str
+    trace[ScalarElabSubst] "elabSpecialName: str case: {str}"
+    let str := if str == "%S" then ty else elabString ty str
     pure (.str (← elabSpecialName ty pre) str)
   | .num pre i => pure (.num (← elabSpecialName ty pre) i)
 
-partial def elabSpecial (ty : String) (stx : Syntax) : CommandElabM Syntax := do
+def elabSource (info : SourceInfo) : SourceInfo := info
+  /-match info with
+  | .original _leading pos _trailing endPos =>
+    .synthetic pos endPos true
+  | _ => info-/
+
+partial def elabSpecial (ty : String) (bw size : Syntax) (stx : Syntax) : CommandElabM Syntax := do
+  trace[ScalarElabSubst] "elabSpecial: stx: {stx}"
   match stx with
   | .missing => pure .missing
+  -- Special case for %BitWidth
+  | .node _ _ #[.atom _ "%BitWidth"] =>
+    pure bw
+  | .node _ _ #[.atom _ "%Size"] =>
+    pure size
   | .node info kind args =>
-    let args ← args.mapM (elabSpecial ty)
+    trace[ScalarElabSubst] "elabSpecial: node: {stx}"
+    let info := elabSource info
+    let args ← args.mapM (elabSpecial ty bw size)
     pure (.node info kind args)
-  | .atom info val => pure (.atom info val)
+  | .atom info val =>
+    trace[ScalarElabSubst] "elabSpecial: atom: {val}"
+    let info := elabSource info
+    if val == "%BitWidth" then
+      trace[ScalarElabSubst] "elabSpecial: replaced `%BitWidth`"
+      pure bw
+    else pure (.atom info val)
   | .ident info rawVal val preresolved =>
+    trace[ScalarElabSubst] "elabSpecial: ident: {stx}"
+    let info := elabSource info
     let val ← elabSpecialName ty val
     pure (.ident info rawVal val preresolved)
 
-def elabCommand (tys : List String) (cmd : Syntax) : CommandElabM Unit := do
-  let elabOne (ty : String) := do
-    let cmd ← elabSpecial ty cmd
-    trace[ElabScalar] "Final declaration for {ty}:\n{cmd}"
-    elabDeclaration cmd
-  for ty in tys do
-    elabOne ty
+def elabCommand (tysBws : List (String × Syntax × Syntax)) (stx : Syntax) (cmd : TSyntax `command) : CommandElabM Unit := do
+  let elabOne (tyBw : String × Syntax × Syntax) : CommandElabM (TSyntax `command) := do
+    let (ty, bw, size) := tyBw
+    ---let cmd0 := cmd
+    let cmd ← elabSpecial ty bw size cmd
+    trace[ScalarElab] "Final declaration for {ty}:\n{cmd}"
+    let cmd ← liftMacroM (expandNamespacedDeclaration cmd)
+    --let cmd : TSyntax `Command := { cmd1 with raw := cmd }
+    pure ⟨ cmd ⟩
+    /-
+    --elabCommandTopLevel cmd
+    Command.elabCommand cmd
+    --Lean.Elab.Command.elabDeclaration cmd
+    /- For some reason, the goto definition doesn't work if the command defines a theorem -/
+    trace[ScalarElab] "stx range: {Option.isSome (← Lean.Elab.getDeclarationRange? stx)}"
+    trace[ScalarElab] "cmd range: {Option.isSome (← Lean.Elab.getDeclarationRange? cmd0)}"
+    --let some range ← Lean.Elab.getDeclarationRange? stx
+    -- | throwError "Unreachable"
+    /-trace[ScalarElab] "{range.pos}"
+    if let some name := Declaration.getDefName? cmd1 then do
+      -- Note that the name retrieved from the syntax is not the full name: we still need to resolve it
+      if let some e ← liftTermElabM (Term.resolveId? (← `(ident|$(mkIdent name))) (withInfo := true)) then
+        let name := e.constName!
+        trace[ScalarElab] "Add declaration range for name: {name}"
+        addDeclarationRangesFromSyntax name stx[0]
+      else throwError "Unreachable"
+    else throwError "Unrechable"-/ -/
+  --for ty in tys do
+  --  elabOne ty
+  --
+  let cmdl ← tysBws.mapM elabOne
+  let cmdl := cmdl.reverse
+  match cmdl with
+  | cmd :: cmdl =>
+    let cmd ← List.foldlM (fun cmd0 cmd1 => `($cmd0:command $cmd1:command)) cmd cmdl
+    Command.elabCommand cmd
+  | _ => throwError "Unreachable"
 
-syntax (name := uscalarCommand) "uscalar" command : command
+scoped syntax "%BitWidth" : term
+scoped syntax "%Size" : term
+
+scoped syntax (name := uscalarCommand) "uscalar" command : command
 
 @[command_elab uscalarCommand]
 def uscalarCommandImpl : CommandElab := fun stx => do
-  trace[ElabScalar] "uscalar_command (stx): {stx}"
+  trace[ScalarElab] "uscalar_command (stx): {stx}"
   match stx with
   | `(uscalarCommand| uscalar $cmd) =>
-    elabCommand ["U8", "U16", "U32", "U64", "U128", "Usize"] cmd
+    elabCommand [("U8", ←`(8), ←`(1)), ("U16", ←`(16), ←`(2)), ("U32", ←`(32), ←`(4)),
+                 ("U64", ←`(64), ←`(8)), ("U128", ←`(128), ←`(16)),
+                 ("Usize", ←`(System.Platform.numBits), ←`(System.Platform.numBits/8))] stx cmd
   | _ => throwUnsupportedSyntax
 
-syntax (name := iscalarCommand) "iscalar" command : command
+scoped syntax (name := uscalarNoUsizeCommand) "uscalar_no_usize" command : command
+
+@[command_elab uscalarNoUsizeCommand]
+def uscalarNoUsizeCommandImpl : CommandElab := fun stx => do
+  trace[ScalarElab] "uscalar_no_usize_command (stx): {stx}"
+  match stx with
+  | `(uscalarNoUsizeCommand| uscalar_no_usize $cmd) =>
+    elabCommand [("U8", ←`(8), ←`(1)), ("U16", ←`(16), ←`(2)), ("U32", ←`(32), ←`(4)),
+                 ("U64", ←`(64), ←`(8)), ("U128", ←`(128), ←`(16))] stx cmd
+  | _ => throwUnsupportedSyntax
+
+scoped syntax (name := iscalarCommand) "iscalar" command : command
 
 @[command_elab iscalarCommand]
 def iscalarCommandImpl : CommandElab := fun stx => do
-  trace[ElabScalar] "iscalar_command (stx): {stx}"
+  trace[ScalarElab] "iscalar_command (stx): {stx}"
   match stx with
   | `(iscalarCommand| iscalar $cmd) =>
-    elabCommand ["I8", "I16", "I32", "I64", "I128", "Isize"] cmd
+    elabCommand [("I8", ←`(8), ←`(1)), ("I16", ←`(16), ←`(2)), ("I32", ←`(32), ←`(4)),
+                 ("I64", ←`(64), ←`(8)), ("I128", ←`(128), ←`(16)),
+                 ("Isize", ←`(System.Platform.numBits), ←`(System.Platform.numBits/8))] stx cmd
   | _ => throwUnsupportedSyntax
 
-syntax (name := scalarCommand) "scalar" command : command
+scoped syntax (name := iscalarNoIsizeCommand) "iscalar_no_isize" command : command
+
+@[command_elab iscalarNoIsizeCommand]
+def iscalarNoIsizeNoIsizeCommandImpl : CommandElab := fun stx => do
+  trace[ScalarElab] "iscalar_no_usize_command (stx): {stx}"
+  match stx with
+  | `(iscalarNoIsizeCommand| iscalar_no_isize $cmd) =>
+    elabCommand [("I8", ←`(8), ←`(1)), ("I16", ←`(16), ←`(2)), ("I32", ←`(32), ←`(4)),
+                 ("I64", ←`(64), ←`(8)), ("I128", ←`(128), ←`(16))] stx cmd
+  | _ => throwUnsupportedSyntax
+
+scoped syntax (name := scalarCommand) "scalar" command : command
 
 @[command_elab scalarCommand]
 def scalarCommandImpl : CommandElab := fun stx => do
-  trace[ElabScalar] "scalar_command (stx): {stx}"
+  trace[ScalarElab] "scalar_command (stx): {stx}"
   match stx with
   | `(scalarCommand| scalar $cmd) =>
-    elabCommand ["U8", "U16", "U32", "U64", "U128", "Usize",
-                 "I8", "I16", "I32", "I64", "I128", "Isize"] cmd
+    elabCommand [("U8", ←`(8), ←`(1)), ("U16", ←`(16), ←`(2)), ("U32", ←`(32), ←`(4)),
+                 ("U64", ←`(64), ←`(8)), ("U128", ←`(128), ←`(16)),
+                 ("Usize", ←`(System.Platform.numBits), ←`(System.Platform.numBits/8)),
+                 ("I8", ←`(8), ←`(1)), ("I16", ←`(16), ←`(2)), ("I32", ←`(32), ←`(4)),
+                 ("I64", ←`(64), ←`(8)), ("I128", ←`(128), ←`(16)),
+                 ("Isize", ←`(System.Platform.numBits), ←`(System.Platform.numBits/8))] stx cmd
   | _ => throwUnsupportedSyntax
 
-end Aeneas.Std.ElabScalar
+end Aeneas.Std.ScalarElab

--- a/backends/lean/Aeneas/Std/Scalar/Elab.lean
+++ b/backends/lean/Aeneas/Std/Scalar/Elab.lean
@@ -4,207 +4,48 @@ namespace Aeneas.Std.ElabScalar
 
 open Lean Elab Command Term Meta
 
-/- Generic scalar term -/
-declare_syntax_cat gscalar_ident
-scoped syntax ident : gscalar_ident
-scoped syntax "%S" : gscalar_ident
-scoped syntax gscalar_ident "." ident : gscalar_ident
+initialize registerTraceClass `ElabScalar
 
-/- Using the same precedences as in `Lean.Notation` -/
-declare_syntax_cat gscalar_term
-scoped syntax num : gscalar_term
-scoped syntax:max "-" gscalar_term : gscalar_term
-scoped syntax:65 gscalar_term:65 " + " gscalar_term:66 : gscalar_term
-scoped syntax:65 gscalar_term:65 " - " gscalar_term:66 : gscalar_term
-scoped syntax:65 gscalar_term:65 " * " gscalar_term:66 : gscalar_term
-scoped syntax:65 gscalar_term:65 " / " gscalar_term:66 : gscalar_term
-scoped syntax:65 gscalar_term:65 " % " gscalar_term:66 : gscalar_term
-scoped syntax:1024 gscalar_term:50 " = " gscalar_term:50 : gscalar_term
-scoped syntax:50 gscalar_term:50 " ≤ " gscalar_term:50 : gscalar_term
-scoped syntax:50 gscalar_term:50 " < " gscalar_term:50 : gscalar_term
-scoped syntax:50 gscalar_term:50 " ≥ " gscalar_term:50 : gscalar_term
-scoped syntax:50 gscalar_term:50 " > " gscalar_term:50 : gscalar_term
-scoped syntax:35 gscalar_term:36 " ∧ " gscalar_term:35 : gscalar_term
-scoped syntax:30 gscalar_term:31 " ∨ " gscalar_term:50 : gscalar_term
-scoped syntax:max "¬ " gscalar_term : gscalar_term
+/-!
 
-declare_syntax_cat gscalar_arg
-scoped syntax gscalar_ident : gscalar_arg
-scoped syntax num : gscalar_arg
-scoped syntax "(" gscalar_term ")" : gscalar_arg
+The following defines elaborators to factor out scalar definitions and theorems.
+We do this because we often need to write a lot of very similar definitions for
+all the scalars kinds. For instance:
 
---scoped syntax gscalar_term gscalar_arg : gscalar_term
--- TODO: what is the precedence of function application?
-scoped syntax:100 gscalar_term:100 gscalar_term:101 : gscalar_term
+```
+theorem U8.add_bv_spec {x y : U8} (hmax : x.val + y.val ≤ U8.max) :
+  ∃ z, x + y = ok z ∧ (↑z : Nat) = ↑x + ↑y ∧ z.bv = x.bv + y.bv :=
+  UScalar.add_bv_spec (by scalar_tac)
 
--- For now we harcode a specific kind of matches
-scoped syntax "match" gscalar_term "with" "|" term "=>" gscalar_term "|" term "=>" gscalar_term : gscalar_term
+theorem U16.add_bv_spec {x y : U16} (hmax : x.val + y.val ≤ U16.max) :
+  ∃ z, x + y = ok z ∧ (↑z : Nat) = ↑x + ↑y ∧ z.bv = x.bv + y.bv :=
+  UScalar.add_bv_spec (by scalar_tac)
 
-scoped syntax gscalar_ident : gscalar_term
+... -- etc.
+```
 
-declare_syntax_cat gscalar_param
-scoped syntax "(" ident+ ":" gscalar_term ")" : gscalar_param
-scoped syntax "{" ident+ ":" gscalar_term "}" : gscalar_param
+Instead, we want to write something like this:
+```
+uscalar theorem «%S».add_bv_spec {x y : «%S»} (hmax : x.val + y.val ≤ «%S».max) :
+  ∃ z, x + y = ok z ∧ (↑z : Nat) = ↑x + ↑y ∧ z.bv = x.bv + y.bv :=
+  UScalar.add_bv_spec (by scalar_tac)
+```
 
-partial def elabGScalarIdent (scalarTy : Name) (stx : TSyntax `gscalar_ident) : CommandElabM Name := do
-  println! "elabGScalarIdent: {stx}"
-  match stx with
-  | `(gscalar_ident|%S) => pure scalarTy
-  | `(gscalar_ident|$id:ident) => pure id.getId
-  | `(gscalar_ident| $id0 . $id1:ident) => do
-    let id0 ← elabGScalarIdent scalarTy id0
-    pure (id0 ++ id1.getId)
-  | _ => throwUnsupportedSyntax
+and have all the theorems generated at once.
 
-mutual
-partial def elabGScalarTerm (scalarTy : Name) (stx : TSyntax `gscalar_term) : CommandElabM (TSyntax `term) := do
-  println! "elabGScalarTerm: {stx}"
-  let elabTerm := elabGScalarTerm scalarTy
-  match stx with
-  | `(gscalar_term| $x $y) => `(term| $(← elabTerm x) $(← elabTerm y))
-  | `(gscalar_term| $x:num) => `(term| $x)
-  | `(gscalar_term| - $x) => `(term| - $(← elabTerm x))
-  | `(gscalar_term| $x + $y) => `(term| $(← elabTerm x) + $(← elabTerm y))
-  | `(gscalar_term| $x - $y) => `(term| $(← elabTerm x) - $(← elabTerm y))
-  | `(gscalar_term| $x * $y) => `(term| $(← elabTerm x) * $(← elabTerm y))
-  | `(gscalar_term| $x / $y) => `(term| $(← elabTerm x) / $(← elabTerm y))
-  | `(gscalar_term| $x % $y) => `(term| $(← elabTerm x) % $(← elabTerm y))
-  | `(gscalar_term| $x = $y) => `(term| $(← elabTerm x) = $(← elabTerm y))
-  | `(gscalar_term| $x ≤ $y) => `(term| $(← elabTerm x) ≤ $(← elabTerm y))
-  | `(gscalar_term| $x < $y) => `(term| $(← elabTerm x) < $(← elabTerm y))
-  | `(gscalar_term| $x ≥ $y) => `(term| $(← elabTerm x) ≥ $(← elabTerm y))
-  | `(gscalar_term| $x > $y) => `(term| $(← elabTerm x) > $(← elabTerm y))
-  | `(gscalar_term| $x ∧ $y) => `(term| $(← elabTerm x) ∧ $(← elabTerm y))
-  | `(gscalar_term| ¬ $x) => `(term| ¬ $(← elabTerm x))
-  | `(gscalar_term| match $scrut with | $y => $e1 | $z => $e2 ) => do
-    -- We only support a specific kind of matches
-    println! "elabGScalarTerm: match: y: {y}"
-    let y: TSyntax `ident ← match y with
-      | `(some $y:ident) => pure y
-      | _ => throwUnsupportedSyntax
-    println! "elabGScalarTerm: match: z: {z}"
-    let _ ← match z with
-      | `(none) => pure ()
-      | _ => throwUnsupportedSyntax
-    println! "elabGScalarTerm: match: e1: {e1}"
-    let e1 ← elabTerm e1
-    println! "elabGScalarTerm: match: e2: {e2}"
-    let e2 ← elabTerm e2
-    println! "elabGScalarTerm: match: scrut: {scrut}"
-    let scrut ← elabTerm scrut
-    `(term| match $scrut:term with | some $y => $e1 | none => $e2)
-  | `($_) => do
-    -- Should be an ident
-    println! "elabGScalarTerm: ident: {stx}"
-    let id ← elabGScalarIdent scalarTy ⟨stx.raw[0]!⟩
-    pure (mkIdent id)
+The way we make it work is extremely simple: we simply define a syntax `uscalar command`
+which triggers an elaboration by which, for each scalar type, we recursively explore the
+syntax of the command, and generate a command where we replaced all the name segments "%S"
+with either "U8", or "U16", etc.
 
-
-partial def elabGScalarArg (scalarTy : Name) (stx : TSyntax `gscalar_arg) : CommandElabM (TSyntax `term) := do
-  println! "elabGScalarArg: {stx}"
-  let elabTerm := elabGScalarTerm scalarTy
-  match stx with
-  | `(gscalar_arg|$x:num) => `(term|$x)
-  | `(gscalar_arg|($x)) => `(term|($(← elabTerm x)))
-  | `($_) =>
-    -- Should be an ident
-    println! "elabGScalarArg: ident: {stx}"
-    let id ← elabGScalarIdent scalarTy ⟨stx.raw[0]!⟩
-    pure (mkIdent id)
-
-end
-
-partial def elabGScalarParams (scalarTy : Name) (stx : TSyntax `gscalar_param) :
-  CommandElabM (TSyntax `Lean.Parser.Term.bracketedBinder) := do
-  match stx with
-  | `(gscalar_param| ($ids* : $ty)) =>
-    let ty ← elabGScalarTerm scalarTy ty
-    `(bracketedBinder|($(ids)* : $ty))
-  | `(gscalar_param| {$ids* : $ty}) =>
-    let ty ← elabGScalarTerm scalarTy ty
-    `(bracketedBinder|{$(ids)* : $ty})
-  | _ => throwUnsupportedSyntax
-
-syntax (name := uscalar_def1) "#uscalar_def1" ident "(" gscalar_term ")" term : command
-
-@[command_elab uscalar_def1]
-def uscalarDef1Impl : CommandElab := fun stx => do
-  logInfo ("#uscalar_def (stx): " ++ stx)
-  match stx with
-  | `(#uscalar_def1 $id ($args) $body) =>
-    logInfo m!"#uscalar_def: {id} {body}"
-    let args ← elabGScalarTerm ``U8 args
-    let stx : TSyntax `command ← `(def $id := $args)
-    elabDeclaration stx
-  | _ => throwUnsupportedSyntax
-
-syntax (name := uscalarDef) "uscalar_def" gscalar_ident gscalar_param+ ":" gscalar_term ":=" term : command
-syntax (name := uscalarThm) "uscalar_theorem" gscalar_ident gscalar_param+ ":" gscalar_term ":=" term : command
---syntax (name := uscalarThmBy) "uscalar_theorem" gscalar_ident gscalar_param+ ":" gscalar_term ":=" "by" tactic : command
-
-@[command_elab uscalarDef]
-def uscalarDefImpl : CommandElab := fun stx => do
-  logInfo ("uscalar_def (stx): " ++ stx)
-  match stx with
-  | `(uscalarDef| uscalar_def $id $args* : $ty := $body) =>
-    logInfo m!"uscalar_def: {id} {args} : {ty} := {body}"
-    let scalarTy := `U8
-    let id ← elabGScalarIdent scalarTy id
-    let args ← args.mapM (elabGScalarParams scalarTy)
-    let ty ← elabGScalarTerm scalarTy ty
-    let stx : TSyntax `command ← `(def $(mkIdent id) $(args)* : $ty := $body)
-    elabDeclaration stx
-  | _ => throwUnsupportedSyntax
-
-/-@[command_elab uscalarThm]
-def uscalarThmImpl : CommandElab := fun stx => do
-  logInfo ("uscalar_thm (stx): " ++ stx)
-  match stx with
-  | `(uscalarThm| uscalar_theorem $id $args* : $ty := $body) =>
-    logInfo m!"uscalar_thm: {id} {args} : {ty} := {body}"
-    let scalarTy := `U8
-    let id ← elabGScalarIdent scalarTy id
-    let args ← args.mapM (elabGScalarParams scalarTy)
-    let ty ← elabGScalarTerm scalarTy ty
-    let stx : TSyntax `command ← `(theorem $(mkIdent id) $(args)* : $ty := $body)
-    logInfo m!"Final declaration:\n{stx}"
-    elabDeclaration stx
-  | _ => throwUnsupportedSyntax-/
-
-@[command_elab uscalarThm]
-def uscalarThmByImpl : CommandElab := fun stx => do
-  logInfo ("uscalar_thm (stx): " ++ stx)
-  match stx with
-  | `(uscalarThm| uscalar_theorem $id $args* : $ty := by $body) =>
-    logInfo m!"uscalar_thm: {id} {args} : {ty} := {body}"
-    let scalarTy := `U8
-    let id ← elabGScalarIdent scalarTy id
-    let args ← args.mapM (elabGScalarParams scalarTy)
-    let ty ← elabGScalarTerm scalarTy ty
-    let stx : TSyntax `command ← `(theorem $(mkIdent id) $(args)* : $ty := by $body)
-    logInfo m!"Final declaration:\n{stx}"
-    elabDeclaration stx
-  | _ => throwUnsupportedSyntax
-
-/-
---@[progress_pure checked_add x y]
-uscalar_theorem %S.checked_add_bv_spec' (x y : %S) :
-  match %S.checked_add x y with
-  | some z => x.val + y.val ≤ %S.max ∧ z.val = x.val + y.val ∧ z.bv = x.bv + y.bv
-  | none => %S.max < x.val + y.val
-  := by
-  have := core.num.checked_add_UScalar_bv_spec x y
-  simp_all [U8.checked_add, UScalar.max, U8.bv]
-  cases h: core.num.checked_add_UScalar x y <;> simp_all [U8.max, U8.numBits] -- TODO: remove U8
 -/
---«%S»
 
 def elabSpecialName (ty : String) (n : Name) : CommandElabM Name := do
-  logInfo m!"elabSpecialName: {n}"
+  trace[ElabScalar] "elabSpecialName: {n}"
   match n with
   | .anonymous => pure .anonymous
   | .str pre str =>
-    logInfo m!"elabSpecialName: str case: {str}"
+    trace[ElabScalar] "elabSpecialName: str case: {str}"
     let str := if str == "%S" then ty else str
     pure (.str (← elabSpecialName ty pre) str)
   | .num pre i => pure (.num (← elabSpecialName ty pre) i)
@@ -220,68 +61,43 @@ partial def elabSpecial (ty : String) (stx : Syntax) : CommandElabM Syntax := do
     let val ← elabSpecialName ty val
     pure (.ident info rawVal val preresolved)
 
+def elabCommand (tys : List String) (cmd : Syntax) : CommandElabM Unit := do
+  let elabOne (ty : String) := do
+    let cmd ← elabSpecial ty cmd
+    trace[ElabScalar] "Final declaration for {ty}:\n{cmd}"
+    elabDeclaration cmd
+  for ty in tys do
+    elabOne ty
+
 syntax (name := uscalarCommand) "uscalar" command : command
 
 @[command_elab uscalarCommand]
 def uscalarCommandImpl : CommandElab := fun stx => do
-  logInfo ("uscalar_command (stx): " ++ stx)
+  trace[ElabScalar] "uscalar_command (stx): {stx}"
   match stx with
   | `(uscalarCommand| uscalar $cmd) =>
-    logInfo m!"uscalar_command: {cmd}"
-    let elabOne (ty : String) := do
-      let cmd ← elabSpecial ty cmd
-      logInfo m!"Final declaration:\n{cmd}"
-      elabDeclaration cmd
-    for ty in ["U8", "U16", "U32", "U64", "U128", "Usize"] do
-      elabOne ty
+    elabCommand ["U8", "U16", "U32", "U64", "U128", "Usize"] cmd
   | _ => throwUnsupportedSyntax
 
+syntax (name := iscalarCommand) "iscalar" command : command
 
---syntax (name := uscalarThm) "uscalar_theorem'"  : command
+@[command_elab iscalarCommand]
+def iscalarCommandImpl : CommandElab := fun stx => do
+  trace[ElabScalar] "iscalar_command (stx): {stx}"
+  match stx with
+  | `(iscalarCommand| iscalar $cmd) =>
+    elabCommand ["I8", "I16", "I32", "I64", "I128", "Isize"] cmd
+  | _ => throwUnsupportedSyntax
 
-def C : U8 := ⟨ 0, by simp ⟩
+syntax (name := scalarCommand) "scalar" command : command
 
-#uscalar_def1 test_def1 (%S.max) (32 : Nat)
-#print test_def1
-
-#uscalar_def1 test_def2 (C) (32 : Nat)
-#print test_def2
-
-#uscalar_def1 test_def3 (%S.max + %S.max) (32 : Nat)
-#print test_def3
-
-#uscalar_def1 test_def4 (
-  match some C with
-  | some z => z.val ≤ 3
-  | none => false) (32 : Nat)
-#print test_def4
-
-#check U8.max
-
-def test_def' :=
-  let S := U8
-  fun (x y : S) (z : ℕ) (h : x.val < 32) => (by scalar_tac : x.val + y.val < 300)
-
-#check test_def'
-
-uscalar_def %S.test1 (x y : %S) : Result %S := x + y
-
-#print U8.test1
-
-/-
-
-uscalar @[progress_pure «%S».checked_add x y] theorem «%S».checked_add_bv_spec'' (x y : «%S») :
-  match «%S».checked_add x y with
-  | some z => x.val + y.val ≤ «%S».max ∧ z.val = x.val + y.val ∧ z.bv = x.bv + y.bv
-  | none => «%S».max < x.val + y.val := by
-  have := core.num.checked_add_UScalar_bv_spec x y
-  simp_all [«%S».checked_add, UScalar.max, «%S».bv]
-  cases h: core.num.checked_add_UScalar x y <;> simp_all [«%S».max, «%S».numBits]
-
-#check U8.checked_add_bv_spec''
-#check U16.checked_add_bv_spec''
-
-
--/
+@[command_elab scalarCommand]
+def scalarCommandImpl : CommandElab := fun stx => do
+  trace[ElabScalar] "scalar_command (stx): {stx}"
+  match stx with
+  | `(scalarCommand| scalar $cmd) =>
+    elabCommand ["U8", "U16", "U32", "U64", "U128", "Usize",
+                 "I8", "I16", "I32", "I64", "I128", "Isize"] cmd
+  | _ => throwUnsupportedSyntax
 
 end Aeneas.Std.ElabScalar

--- a/backends/lean/Aeneas/Std/Scalar/EqOrd.lean
+++ b/backends/lean/Aeneas/Std/Scalar/EqOrd.lean
@@ -1,8 +1,9 @@
 import Aeneas.Std.Scalar.Core
+import Aeneas.Std.Scalar.Elab
 
 namespace Aeneas.Std
 
-open Result
+open Result ScalarElab
 
 /-!
 # PartialEq, Eq, PartialOrd, Ord
@@ -10,370 +11,64 @@ open Result
 
 /- [core::cmp::impls::{core::cmp::PartialEq<u8> for u8}::eq]:
    Name pattern: core::cmp::impls::{core::cmp::PartialEq<u8, u8>}::eq -/
-@[simp] abbrev core.cmp.impls.PartialEqU8.eq (x y : U8) : Bool := x = y
-@[simp] abbrev core.cmp.impls.PartialEqU16.eq (x y : U16) : Bool := x = y
-@[simp] abbrev core.cmp.impls.PartialEqU32.eq (x y : U32) : Bool := x = y
-@[simp] abbrev core.cmp.impls.PartialEqU64.eq (x y : U64) : Bool := x = y
-@[simp] abbrev core.cmp.impls.PartialEqU128.eq (x y : U128) : Bool := x = y
-@[simp] abbrev core.cmp.impls.PartialEqUsize.eq (x y : Usize) : Bool := x = y
+scalar @[simp] abbrev core.cmp.impls.PartialEq'S.eq (x y : «%S») : Bool := x = y
 
-@[simp] abbrev core.cmp.impls.PartialEqI8.eq (x y : I8) : Bool := x = y
-@[simp] abbrev core.cmp.impls.PartialEqI16.eq (x y : I16) : Bool := x = y
-@[simp] abbrev core.cmp.impls.PartialEqI32.eq (x y : I32) : Bool := x = y
-@[simp] abbrev core.cmp.impls.PartialEqI64.eq (x y : I64) : Bool := x = y
-@[simp] abbrev core.cmp.impls.PartialEqI128.eq (x y : I128) : Bool := x = y
-@[simp] abbrev core.cmp.impls.PartialEqIsize.eq (x y : Isize) : Bool := x = y
-
-@[simp] abbrev core.cmp.impls.PartialEqU8.ne (x y : U8) : Bool := ¬ x = y
-@[simp] abbrev core.cmp.impls.PartialEqU16.ne (x y : U16) : Bool := ¬ x = y
-@[simp] abbrev core.cmp.impls.PartialEqU32.ne (x y : U32) : Bool := ¬ x = y
-@[simp] abbrev core.cmp.impls.PartialEqU64.ne (x y : U64) : Bool := ¬ x = y
-@[simp] abbrev core.cmp.impls.PartialEqU128.ne (x y : U128) : Bool := ¬ x = y
-@[simp] abbrev core.cmp.impls.PartialEqUsize.ne (x y : Usize) : Bool := ¬ x = y
-
-@[simp] abbrev core.cmp.impls.PartialEqI8.ne (x y : I8) : Bool := ¬ x = y
-@[simp] abbrev core.cmp.impls.PartialEqI16.ne (x y : I16) : Bool := ¬ x = y
-@[simp] abbrev core.cmp.impls.PartialEqI32.ne (x y : I32) : Bool := ¬ x = y
-@[simp] abbrev core.cmp.impls.PartialEqI64.ne (x y : I64) : Bool := ¬ x = y
-@[simp] abbrev core.cmp.impls.PartialEqI128.ne (x y : I128) : Bool := ¬ x = y
-@[simp] abbrev core.cmp.impls.PartialEqIsize.ne (x y : Isize) : Bool := ¬ x = y
+scalar @[simp] abbrev core.cmp.impls.PartialEq'S.ne (x y : «%S») : Bool := ¬ x = y
 
 /- Trait implementation: [core::cmp::impls::{core::cmp::PartialEq<u8> for u8}]
    Name pattern: core::cmp::PartialEq<u8, u8> -/
-@[reducible] def core.cmp.PartialEqU8 : core.cmp.PartialEq U8 U8 := {
-  eq := liftFun2 core.cmp.impls.PartialEqU8.eq
-  ne := liftFun2 core.cmp.impls.PartialEqU8.ne }
-
-
-@[reducible] def core.cmp.PartialEqU16 : core.cmp.PartialEq U16 U16 := {
-  eq := liftFun2 core.cmp.impls.PartialEqU16.eq
-  ne := liftFun2 core.cmp.impls.PartialEqU16.ne }
-
-@[reducible] def core.cmp.PartialEqU32 : core.cmp.PartialEq U32 U32 := {
-  eq := liftFun2 core.cmp.impls.PartialEqU32.eq
-  ne := liftFun2 core.cmp.impls.PartialEqU32.ne }
-
-@[reducible] def core.cmp.PartialEqU64 : core.cmp.PartialEq U64 U64 := {
-  eq := liftFun2 core.cmp.impls.PartialEqU64.eq
-  ne := liftFun2 core.cmp.impls.PartialEqU64.ne }
-
-@[reducible] def core.cmp.PartialEqU128 : core.cmp.PartialEq U128 U128 := {
-  eq := liftFun2 core.cmp.impls.PartialEqU128.eq
-  ne := liftFun2 core.cmp.impls.PartialEqU128.ne }
-
-@[reducible] def core.cmp.PartialEqUsize : core.cmp.PartialEq Usize Usize := {
-  eq := liftFun2 core.cmp.impls.PartialEqUsize.eq
-  ne := liftFun2 core.cmp.impls.PartialEqUsize.ne }
-
-@[reducible] def core.cmp.PartialEqI8 : core.cmp.PartialEq I8 I8 := {
-  eq := liftFun2 core.cmp.impls.PartialEqI8.eq
-  ne := liftFun2 core.cmp.impls.PartialEqI8.ne }
-
-@[reducible] def core.cmp.PartialEqI16 : core.cmp.PartialEq I16 I16 := {
-  eq := liftFun2 core.cmp.impls.PartialEqI16.eq
-  ne := liftFun2 core.cmp.impls.PartialEqI16.ne }
-
-@[reducible] def core.cmp.PartialEqI32 : core.cmp.PartialEq I32 I32 := {
-  eq := liftFun2 core.cmp.impls.PartialEqI32.eq
-  ne := liftFun2 core.cmp.impls.PartialEqI32.ne }
-
-@[reducible] def core.cmp.PartialEqI64 : core.cmp.PartialEq I64 I64 := {
-  eq := liftFun2 core.cmp.impls.PartialEqI64.eq
-  ne := liftFun2 core.cmp.impls.PartialEqI64.ne }
-
-@[reducible] def core.cmp.PartialEqI128 : core.cmp.PartialEq I128 I128 := {
-  eq := liftFun2 core.cmp.impls.PartialEqI128.eq
-  ne := liftFun2 core.cmp.impls.PartialEqI128.ne }
-
-@[reducible] def core.cmp.PartialEqIsize : core.cmp.PartialEq Isize Isize := {
-  eq := liftFun2 core.cmp.impls.PartialEqIsize.eq
-  ne := liftFun2 core.cmp.impls.PartialEqIsize.ne }
+scalar @[reducible] def core.cmp.PartialEq'S : core.cmp.PartialEq «%S» «%S» := {
+  eq := liftFun2 core.cmp.impls.PartialEq'S.eq
+  ne := liftFun2 core.cmp.impls.PartialEq'S.ne }
 
 /- Trait implementation: [core::cmp::impls::{core::cmp::Eq for u8}]
    Name pattern: core::cmp::Eq<u8> -/
-@[reducible] def core.cmp.EqU8 : core.cmp.Eq U8 := {
-  partialEqInst := core.cmp.PartialEqU8 }
-
-@[reducible] def core.cmp.EqU16 : core.cmp.Eq U16 := {
-  partialEqInst := core.cmp.PartialEqU16 }
-
-@[reducible] def core.cmp.EqU32 : core.cmp.Eq U32 := {
-  partialEqInst := core.cmp.PartialEqU32 }
-
-@[reducible] def core.cmp.EqU64 : core.cmp.Eq U64 := {
-  partialEqInst := core.cmp.PartialEqU64 }
-
-@[reducible] def core.cmp.EqU128 : core.cmp.Eq U128 := {
-  partialEqInst := core.cmp.PartialEqU128 }
-
-@[reducible] def core.cmp.EqUsize : core.cmp.Eq Usize := {
-  partialEqInst := core.cmp.PartialEqUsize }
-
-@[reducible] def core.cmp.EqI8 : core.cmp.Eq I8 := {
-  partialEqInst := core.cmp.PartialEqI8 }
-
-@[reducible] def core.cmp.EqI16 : core.cmp.Eq I16 := {
-  partialEqInst := core.cmp.PartialEqI16 }
-
-@[reducible] def core.cmp.EqI32 : core.cmp.Eq I32 := {
-  partialEqInst := core.cmp.PartialEqI32 }
-
-@[reducible] def core.cmp.EqI64 : core.cmp.Eq I64 := {
-  partialEqInst := core.cmp.PartialEqI64 }
-
-@[reducible] def core.cmp.EqI128 : core.cmp.Eq I128 := {
-  partialEqInst := core.cmp.PartialEqI128 }
-
-@[reducible] def core.cmp.EqIsize : core.cmp.Eq Isize := {
-  partialEqInst := core.cmp.PartialEqIsize }
+scalar @[reducible] def core.cmp.Eq'S : core.cmp.Eq «%S» := {
+  partialEqInst := core.cmp.PartialEq'S }
 
 /- [core::cmp::impls::{core::cmp::PartialOrd<u8> for u8}::partial_cmp]:
    Name pattern: core::cmp::impls::{core::cmp::PartialOrd<u8, u8>}::partial_cmp -/
-def core.cmp.impls.PartialOrdU8.partial_cmp (x y : U8) : Option Ordering := some (compare x.val y.val)
-def core.cmp.impls.PartialOrdU16.partial_cmp (x y : U16) : Option Ordering := some (compare x.val y.val)
-def core.cmp.impls.PartialOrdU32.partial_cmp (x y : U32) : Option Ordering := some (compare x.val y.val)
-def core.cmp.impls.PartialOrdU64.partial_cmp (x y : U64) : Option Ordering := some (compare x.val y.val)
-def core.cmp.impls.PartialOrdU128.partial_cmp (x y : U128) : Option Ordering := some (compare x.val y.val)
-def core.cmp.impls.PartialOrdUsize.partial_cmp (x y : Usize) : Option Ordering := some (compare x.val y.val)
-
-def core.cmp.impls.PartialOrdI8.partial_cmp (x y : I8) : Option Ordering := some (compare x.val y.val)
-def core.cmp.impls.PartialOrdI16.partial_cmp (x y : I16) : Option Ordering := some (compare x.val y.val)
-def core.cmp.impls.PartialOrdI32.partial_cmp (x y : I32) : Option Ordering := some (compare x.val y.val)
-def core.cmp.impls.PartialOrdI64.partial_cmp (x y : I64) : Option Ordering := some (compare x.val y.val)
-def core.cmp.impls.PartialOrdI128.partial_cmp (x y : I128) : Option Ordering := some (compare x.val y.val)
-def core.cmp.impls.PartialOrdIsize.partial_cmp (x y : Isize) : Option Ordering := some (compare x.val y.val)
+scalar def core.cmp.impls.PartialOrd'S.partial_cmp (x y : «%S») : Option Ordering := some (compare x.val y.val)
 
 /- [core::cmp::impls::{core::cmp::Ord for u8}::cmp]:
    Name pattern: core::cmp::impls::{core::cmp::Ord<u8>}::cmp -/
-@[simp] abbrev core.cmp.impls.OrdU8.cmp (x y : U8) : Ordering := compare x.val y.val
-@[simp] abbrev core.cmp.impls.OrdU16.cmp (x y : U16) : Ordering := compare x.val y.val
-@[simp] abbrev core.cmp.impls.OrdU32.cmp (x y : U32) : Ordering := compare x.val y.val
-@[simp] abbrev core.cmp.impls.OrdU64.cmp (x y : U64) : Ordering := compare x.val y.val
-@[simp] abbrev core.cmp.impls.OrdU128.cmp (x y : U128) : Ordering := compare x.val y.val
-@[simp] abbrev core.cmp.impls.OrdUsize.cmp (x y : Usize) : Ordering := compare x.val y.val
-
-@[simp] abbrev core.cmp.impls.OrdI8.cmp (x y : I8) : Ordering := compare x.val y.val
-@[simp] abbrev core.cmp.impls.OrdI16.cmp (x y : I16) : Ordering := compare x.val y.val
-@[simp] abbrev core.cmp.impls.OrdI32.cmp (x y : I32) : Ordering := compare x.val y.val
-@[simp] abbrev core.cmp.impls.OrdI64.cmp (x y : I64) : Ordering := compare x.val y.val
-@[simp] abbrev core.cmp.impls.OrdI128.cmp (x y : I128) : Ordering := compare x.val y.val
-@[simp] abbrev core.cmp.impls.OrdIsize.cmp (x y : Isize) : Ordering := compare x.val y.val
+scalar @[simp] abbrev core.cmp.impls.Ord'S.cmp (x y : «%S») : Ordering := compare x.val y.val
 
 /- [core::cmp::impls::{core::cmp::PartialOrd<u8> for u8}::lt]:
    Name pattern: core::cmp::impls::{core::cmp::PartialOrd<u8, u8>}::lt -/
-def core.cmp.impls.PartialOrdU8.lt (x y : U8) : Bool := x.val < y.val
-def core.cmp.impls.PartialOrdU16.lt (x y : U16) : Bool := x.val < y.val
-def core.cmp.impls.PartialOrdU32.lt (x y : U32) : Bool := x.val < y.val
-def core.cmp.impls.PartialOrdU64.lt (x y : U64) : Bool := x.val < y.val
-def core.cmp.impls.PartialOrdU128.lt (x y : U128) : Bool := x.val < y.val
-def core.cmp.impls.PartialOrdUsize.lt (x y : Usize) : Bool := x.val < y.val
-
-def core.cmp.impls.PartialOrdI8.lt (x y : I8) : Bool := x.val < y.val
-def core.cmp.impls.PartialOrdI16.lt (x y : I16) : Bool := x.val < y.val
-def core.cmp.impls.PartialOrdI32.lt (x y : I32) : Bool := x.val < y.val
-def core.cmp.impls.PartialOrdI64.lt (x y : I64) : Bool := x.val < y.val
-def core.cmp.impls.PartialOrdI128.lt (x y : I128) : Bool := x.val < y.val
-def core.cmp.impls.PartialOrdIsize.lt (x y : Isize) : Bool := x.val < y.val
+scalar def core.cmp.impls.PartialOrd'S.lt (x y : «%S») : Bool := x.val < y.val
 
 /- [core::cmp::impls::{core::cmp::PartialOrd<u8> for u8}::le]:
    Name pattern: core::cmp::impls::{core::cmp::PartialOrd<u8, u8>}::le -/
-def core.cmp.impls.PartialOrdU8.le (x y : U8) : Bool := x.val ≤ y.val
-def core.cmp.impls.PartialOrdU16.le (x y : U16) : Bool := x.val ≤ y.val
-def core.cmp.impls.PartialOrdU32.le (x y : U32) : Bool := x.val ≤ y.val
-def core.cmp.impls.PartialOrdU64.le (x y : U64) : Bool := x.val ≤ y.val
-def core.cmp.impls.PartialOrdU128.le (x y : U128) : Bool := x.val ≤ y.val
-def core.cmp.impls.PartialOrdUsize.le (x y : Usize) : Bool := x.val ≤ y.val
-
-def core.cmp.impls.PartialOrdI8.le (x y : I8) : Bool := x.val ≤ y.val
-def core.cmp.impls.PartialOrdI16.le (x y : I16) : Bool := x.val ≤ y.val
-def core.cmp.impls.PartialOrdI32.le (x y : I32) : Bool := x.val ≤ y.val
-def core.cmp.impls.PartialOrdI64.le (x y : I64) : Bool := x.val ≤ y.val
-def core.cmp.impls.PartialOrdI128.le (x y : I128) : Bool := x.val ≤ y.val
-def core.cmp.impls.PartialOrdIsize.le (x y : Isize) : Bool := x.val ≤ y.val
+scalar def core.cmp.impls.PartialOrd'S.le (x y : «%S») : Bool := x.val ≤ y.val
 
 /- [core::cmp::impls::{core::cmp::PartialOrd<u8> for u8}::gt]:
    Name pattern: core::cmp::impls::{core::cmp::PartialOrd<u8, u8>}::gt -/
-def core.cmp.impls.PartialOrdU8.gt (x y : U8) : Bool := x.val > y.val
-def core.cmp.impls.PartialOrdU16.gt (x y : U16) : Bool := x.val > y.val
-def core.cmp.impls.PartialOrdU32.gt (x y : U32) : Bool := x.val > y.val
-def core.cmp.impls.PartialOrdU64.gt (x y : U64) : Bool := x.val > y.val
-def core.cmp.impls.PartialOrdU128.gt (x y : U128) : Bool := x.val > y.val
-def core.cmp.impls.PartialOrdUsize.gt (x y : Usize) : Bool := x.val > y.val
-
-def core.cmp.impls.PartialOrdI8.gt (x y : I8) : Bool := x.val > y.val
-def core.cmp.impls.PartialOrdI16.gt (x y : I16) : Bool := x.val > y.val
-def core.cmp.impls.PartialOrdI32.gt (x y : I32) : Bool := x.val > y.val
-def core.cmp.impls.PartialOrdI64.gt (x y : I64) : Bool := x.val > y.val
-def core.cmp.impls.PartialOrdI128.gt (x y : I128) : Bool := x.val > y.val
-def core.cmp.impls.PartialOrdIsize.gt (x y : Isize) : Bool := x.val > y.val
+scalar def core.cmp.impls.PartialOrd'S.gt (x y : «%S») : Bool := x.val > y.val
 
 /- [core::cmp::impls::{core::cmp::PartialOrd<u8> for u8}::ge]:
    Name pattern: core::cmp::impls::{core::cmp::PartialOrd<u8, u8>}::ge -/
-def core.cmp.impls.PartialOrdU8.ge (x y : U8) : Bool := x.val ≥ y.val
-def core.cmp.impls.PartialOrdU16.ge (x y : U16) : Bool := x.val ≥ y.val
-def core.cmp.impls.PartialOrdU32.ge (x y : U32) : Bool := x.val ≥ y.val
-def core.cmp.impls.PartialOrdU64.ge (x y : U64) : Bool := x.val ≥ y.val
-def core.cmp.impls.PartialOrdU128.ge (x y : U128) : Bool := x.val ≥ y.val
-def core.cmp.impls.PartialOrdUsize.ge (x y : Usize) : Bool := x.val ≥ y.val
-
-def core.cmp.impls.PartialOrdI8.ge (x y : I8) : Bool := x.val ≥ y.val
-def core.cmp.impls.PartialOrdI16.ge (x y : I16) : Bool := x.val ≥ y.val
-def core.cmp.impls.PartialOrdI32.ge (x y : I32) : Bool := x.val ≥ y.val
-def core.cmp.impls.PartialOrdI64.ge (x y : I64) : Bool := x.val ≥ y.val
-def core.cmp.impls.PartialOrdI128.ge (x y : I128) : Bool := x.val ≥ y.val
-def core.cmp.impls.PartialOrdIsize.ge (x y : Isize) : Bool := x.val ≥ y.val
+scalar def core.cmp.impls.PartialOrd'S.ge (x y : «%S») : Bool := x.val ≥ y.val
 
 /- Trait implementation: [core::cmp::impls::{core::cmp::PartialOrd<u8> for u8}]
    Name pattern: core::cmp::PartialOrd<u8, u8> -/
-@[reducible] def core.cmp.PartialOrdU8 : core.cmp.PartialOrd U8 U8 := {
-  partialEqInst := core.cmp.PartialEqU8
-  partial_cmp := liftFun2 core.cmp.impls.PartialOrdU8.partial_cmp
-  lt := liftFun2 core.cmp.impls.PartialOrdU8.lt
-  le := liftFun2 core.cmp.impls.PartialOrdU8.le
-  gt := liftFun2 core.cmp.impls.PartialOrdU8.gt
-  ge := liftFun2 core.cmp.impls.PartialOrdU8.ge }
-
-@[reducible] def core.cmp.PartialOrdU16 : core.cmp.PartialOrd U16 U16 := {
-  partialEqInst := core.cmp.PartialEqU16
-  partial_cmp := liftFun2 core.cmp.impls.PartialOrdU16.partial_cmp
-  lt := liftFun2 core.cmp.impls.PartialOrdU16.lt
-  le := liftFun2 core.cmp.impls.PartialOrdU16.le
-  gt := liftFun2 core.cmp.impls.PartialOrdU16.gt
-  ge := liftFun2 core.cmp.impls.PartialOrdU16.ge }
-
-@[reducible] def core.cmp.PartialOrdU32 : core.cmp.PartialOrd U32 U32 := {
-  partialEqInst := core.cmp.PartialEqU32
-  partial_cmp := liftFun2 core.cmp.impls.PartialOrdU32.partial_cmp
-  lt := liftFun2 core.cmp.impls.PartialOrdU32.lt
-  le := liftFun2 core.cmp.impls.PartialOrdU32.le
-  gt := liftFun2 core.cmp.impls.PartialOrdU32.gt
-  ge := liftFun2 core.cmp.impls.PartialOrdU32.ge }
-
-@[reducible] def core.cmp.PartialOrdU64 : core.cmp.PartialOrd U64 U64 := {
-  partialEqInst := core.cmp.PartialEqU64
-  partial_cmp := liftFun2 core.cmp.impls.PartialOrdU64.partial_cmp
-  lt := liftFun2 core.cmp.impls.PartialOrdU64.lt
-  le := liftFun2 core.cmp.impls.PartialOrdU64.le
-  gt := liftFun2 core.cmp.impls.PartialOrdU64.gt
-  ge := liftFun2 core.cmp.impls.PartialOrdU64.ge }
-
-@[reducible] def core.cmp.PartialOrdU128 : core.cmp.PartialOrd U128 U128 := {
-  partialEqInst := core.cmp.PartialEqU128
-  partial_cmp := liftFun2 core.cmp.impls.PartialOrdU128.partial_cmp
-  lt := liftFun2 core.cmp.impls.PartialOrdU128.lt
-  le := liftFun2 core.cmp.impls.PartialOrdU128.le
-  gt := liftFun2 core.cmp.impls.PartialOrdU128.gt
-  ge := liftFun2 core.cmp.impls.PartialOrdU128.ge }
-
-@[reducible] def core.cmp.PartialOrdUsize : core.cmp.PartialOrd Usize Usize := {
-  partialEqInst := core.cmp.PartialEqUsize
-  partial_cmp := liftFun2 core.cmp.impls.PartialOrdUsize.partial_cmp
-  lt := liftFun2 core.cmp.impls.PartialOrdUsize.lt
-  le := liftFun2 core.cmp.impls.PartialOrdUsize.le
-  gt := liftFun2 core.cmp.impls.PartialOrdUsize.gt
-  ge := liftFun2 core.cmp.impls.PartialOrdUsize.ge }
-
-@[reducible] def core.cmp.PartialOrdI8 : core.cmp.PartialOrd I8 I8 := {
-  partialEqInst := core.cmp.PartialEqI8
-  partial_cmp := liftFun2 core.cmp.impls.PartialOrdI8.partial_cmp
-  lt := liftFun2 core.cmp.impls.PartialOrdI8.lt
-  le := liftFun2 core.cmp.impls.PartialOrdI8.le
-  gt := liftFun2 core.cmp.impls.PartialOrdI8.gt
-  ge := liftFun2 core.cmp.impls.PartialOrdI8.ge }
-
-@[reducible] def core.cmp.PartialOrdI16 : core.cmp.PartialOrd I16 I16 := {
-  partialEqInst := core.cmp.PartialEqI16
-  partial_cmp := liftFun2 core.cmp.impls.PartialOrdI16.partial_cmp
-  lt := liftFun2 core.cmp.impls.PartialOrdI16.lt
-  le := liftFun2 core.cmp.impls.PartialOrdI16.le
-  gt := liftFun2 core.cmp.impls.PartialOrdI16.gt
-  ge := liftFun2 core.cmp.impls.PartialOrdI16.ge }
-
-@[reducible] def core.cmp.PartialOrdI32 : core.cmp.PartialOrd I32 I32 := {
-  partialEqInst := core.cmp.PartialEqI32
-  partial_cmp := liftFun2 core.cmp.impls.PartialOrdI32.partial_cmp
-  lt := liftFun2 core.cmp.impls.PartialOrdI32.lt
-  le := liftFun2 core.cmp.impls.PartialOrdI32.le
-  gt := liftFun2 core.cmp.impls.PartialOrdI32.gt
-  ge := liftFun2 core.cmp.impls.PartialOrdI32.ge }
-
-@[reducible] def core.cmp.PartialOrdI64 : core.cmp.PartialOrd I64 I64 := {
-  partialEqInst := core.cmp.PartialEqI64
-  partial_cmp := liftFun2 core.cmp.impls.PartialOrdI64.partial_cmp
-  lt := liftFun2 core.cmp.impls.PartialOrdI64.lt
-  le := liftFun2 core.cmp.impls.PartialOrdI64.le
-  gt := liftFun2 core.cmp.impls.PartialOrdI64.gt
-  ge := liftFun2 core.cmp.impls.PartialOrdI64.ge }
-
-@[reducible] def core.cmp.PartialOrdI128 : core.cmp.PartialOrd I128 I128 := {
-  partialEqInst := core.cmp.PartialEqI128
-  partial_cmp := liftFun2 core.cmp.impls.PartialOrdI128.partial_cmp
-  lt := liftFun2 core.cmp.impls.PartialOrdI128.lt
-  le := liftFun2 core.cmp.impls.PartialOrdI128.le
-  gt := liftFun2 core.cmp.impls.PartialOrdI128.gt
-  ge := liftFun2 core.cmp.impls.PartialOrdI128.ge }
-
-@[reducible] def core.cmp.PartialOrdIsize : core.cmp.PartialOrd Isize Isize := {
-  partialEqInst := core.cmp.PartialEqIsize
-  partial_cmp := liftFun2 core.cmp.impls.PartialOrdIsize.partial_cmp
-  lt := liftFun2 core.cmp.impls.PartialOrdIsize.lt
-  le := liftFun2 core.cmp.impls.PartialOrdIsize.le
-  gt := liftFun2 core.cmp.impls.PartialOrdIsize.gt
-  ge := liftFun2 core.cmp.impls.PartialOrdIsize.ge }
+scalar @[reducible] def core.cmp.PartialOrd'S : core.cmp.PartialOrd «%S» «%S» := {
+  partialEqInst := core.cmp.PartialEq'S
+  partial_cmp := liftFun2 core.cmp.impls.PartialOrd'S.partial_cmp
+  lt := liftFun2 core.cmp.impls.PartialOrd'S.lt
+  le := liftFun2 core.cmp.impls.PartialOrd'S.le
+  gt := liftFun2 core.cmp.impls.PartialOrd'S.gt
+  ge := liftFun2 core.cmp.impls.PartialOrd'S.ge }
 
 /- Name pattern: core::cmp::impls::{core::cmp::Ord<SCALAR>}::min -/
-@[progress_pure_def] def core.cmp.impls.OrdU8.min (x y : U8) : U8 := if x < y then x else y
-@[progress_pure_def] def core.cmp.impls.OrdU16.min (x y : U16) : U16 := if x < y then x else y
-@[progress_pure_def] def core.cmp.impls.OrdU32.min (x y : U32) : U32 := if x < y then x else y
-@[progress_pure_def] def core.cmp.impls.OrdU64.min (x y : U64) : U64 := if x < y then x else y
-@[progress_pure_def] def core.cmp.impls.OrdU128.min (x y : U128) : U128 := if x < y then x else y
-@[progress_pure_def] def core.cmp.impls.OrdUsize.min (x y : Usize) : Usize := if x < y then x else y
-@[progress_pure_def] def core.cmp.impls.OrdI8.min (x y : I8) : I8 := if x < y then x else y
-@[progress_pure_def] def core.cmp.impls.OrdI16.min (x y : I16) : I16 := if x < y then x else y
-@[progress_pure_def] def core.cmp.impls.OrdI32.min (x y : I32) : I32 := if x < y then x else y
-@[progress_pure_def] def core.cmp.impls.OrdI64.min (x y : I64) : I64 := if x < y then x else y
-@[progress_pure_def] def core.cmp.impls.OrdI128.min (x y : I128) : I128 := if x < y then x else y
-@[progress_pure_def] def core.cmp.impls.OrdIsize.min (x y : Isize) : Isize := if x < y then x else y
+scalar @[progress_pure_def] def core.cmp.impls.Ord'S.min (x y : «%S») : «%S» := if x < y then x else y
 
-@[simp, scalar_tac_simps] theorem core.cmp.impls.OrdU8.min_val (x y : U8) : (min x y).val = Nat.min x.val y.val := by simp [min]; split <;> simp <;> omega
-@[simp, scalar_tac_simps] theorem core.cmp.impls.OrdU16.min_val (x y : U16) : (min x y).val = Nat.min x.val y.val := by simp [min]; split <;> simp <;> omega
-@[simp, scalar_tac_simps] theorem core.cmp.impls.OrdU32.min_val (x y : U32) : (min x y).val = Nat.min x.val y.val := by simp [min]; split <;> simp <;> omega
-@[simp, scalar_tac_simps] theorem core.cmp.impls.OrdU64.min_val (x y : U64) : (min x y).val = Nat.min x.val y.val := by simp [min]; split <;> simp <;> omega
-@[simp, scalar_tac_simps] theorem core.cmp.impls.OrdU128.min_val (x y : U128) : (min x y).val = Nat.min x.val y.val := by simp [min]; split <;> simp <;> omega
-@[simp, scalar_tac_simps] theorem core.cmp.impls.OrdUsize.min_val (x y : Usize) : (min x y).val = Nat.min x.val y.val := by simp [min]; split <;> simp <;> omega
-@[simp, scalar_tac_simps] theorem core.cmp.impls.OrdI8.min_val (x y : I8) : (min x y).val = Min.min x.val y.val := by simp [min]; split <;> simp <;> omega
-@[simp, scalar_tac_simps] theorem core.cmp.impls.OrdI16.min_val (x y : I16) : (min x y).val = Min.min x.val y.val := by simp [min]; split <;> simp <;> omega
-@[simp, scalar_tac_simps] theorem core.cmp.impls.OrdI32.min_val (x y : I32) : (min x y).val = Min.min x.val y.val := by simp [min]; split <;> simp <;> omega
-@[simp, scalar_tac_simps] theorem core.cmp.impls.OrdI64.min_val (x y : I64) : (min x y).val = Min.min x.val y.val := by simp [min]; split <;> simp <;> omega
-@[simp, scalar_tac_simps] theorem core.cmp.impls.OrdI128.min_val (x y : I128) : (min x y).val = Min.min x.val y.val := by simp [min]; split <;> simp <;> omega
-@[simp, scalar_tac_simps] theorem core.cmp.impls.OrdIsize.min_val (x y : Isize) : (min x y).val = Min.min x.val y.val := by simp [min]; split <;> simp <;> omega
+scalar @[simp, scalar_tac_simps] theorem core.cmp.impls.Ord'S.min_val (x y : «%S») : (min x y).val = Min.min x.val y.val := by simp [min]; split <;> simp <;> omega
 
 /- Name pattern: core::cmp::impls::{core::cmp::Ord<SCALAR>}::max -/
-@[progress_pure_def] def core.cmp.impls.OrdU8.max (x y : U8) : U8 := if x < y then y else x
-@[progress_pure_def] def core.cmp.impls.OrdU16.max (x y : U16) : U16 := if x < y then y else x
-@[progress_pure_def] def core.cmp.impls.OrdU32.max (x y : U32) : U32 := if x < y then y else x
-@[progress_pure_def] def core.cmp.impls.OrdU64.max (x y : U64) : U64 := if x < y then y else x
-@[progress_pure_def] def core.cmp.impls.OrdU128.max (x y : U128) : U128 := if x < y then y else x
-@[progress_pure_def] def core.cmp.impls.OrdUsize.max (x y : Usize) : Usize := if x < y then y else x
-@[progress_pure_def] def core.cmp.impls.OrdI8.max (x y : I8) : I8 := if x < y then y else x
-@[progress_pure_def] def core.cmp.impls.OrdI16.max (x y : I16) : I16 := if x < y then y else x
-@[progress_pure_def] def core.cmp.impls.OrdI32.max (x y : I32) : I32 := if x < y then y else x
-@[progress_pure_def] def core.cmp.impls.OrdI64.max (x y : I64) : I64 := if x < y then y else x
-@[progress_pure_def] def core.cmp.impls.OrdI128.max (x y : I128) : I128 := if x < y then y else x
-@[progress_pure_def] def core.cmp.impls.OrdIsize.max (x y : Isize) : Isize := if x < y then y else x
+scalar @[progress_pure_def] def core.cmp.impls.Ord'S.max (x y : «%S») : «%S» := if x < y then y else x
 
-@[simp, scalar_tac_simps] theorem core.cmp.impls.OrdU8.max_val (x y : U8) : (max x y).val = Nat.max x.val y.val := by simp [max]; split <;> simp <;> omega
-@[simp, scalar_tac_simps] theorem core.cmp.impls.OrdU16.max_val (x y : U16) : (max x y).val = Nat.max x.val y.val := by simp [max]; split <;> simp <;> omega
-@[simp, scalar_tac_simps] theorem core.cmp.impls.OrdU32.max_val (x y : U32) : (max x y).val = Nat.max x.val y.val := by simp [max]; split <;> simp <;> omega
-@[simp, scalar_tac_simps] theorem core.cmp.impls.OrdU64.max_val (x y : U64) : (max x y).val = Nat.max x.val y.val := by simp [max]; split <;> simp <;> omega
-@[simp, scalar_tac_simps] theorem core.cmp.impls.OrdU128.max_val (x y : U128) : (max x y).val = Nat.max x.val y.val := by simp [max]; split <;> simp <;> omega
-@[simp, scalar_tac_simps] theorem core.cmp.impls.OrdUsize.max_val (x y : Usize) : (max x y).val = Nat.max x.val y.val := by simp [max]; split <;> simp <;> omega
-@[simp, scalar_tac_simps] theorem core.cmp.impls.OrdI8.max_val (x y : I8) : (max x y).val = Max.max x.val y.val := by simp [max]; split <;> simp <;> omega
-@[simp, scalar_tac_simps] theorem core.cmp.impls.OrdI16.max_val (x y : I16) : (max x y).val = Max.max x.val y.val := by simp [max]; split <;> simp <;> omega
-@[simp, scalar_tac_simps] theorem core.cmp.impls.OrdI32.max_val (x y : I32) : (max x y).val = Max.max x.val y.val := by simp [max]; split <;> simp <;> omega
-@[simp, scalar_tac_simps] theorem core.cmp.impls.OrdI64.max_val (x y : I64) : (max x y).val = Max.max x.val y.val := by simp [max]; split <;> simp <;> omega
-@[simp, scalar_tac_simps] theorem core.cmp.impls.OrdI128.max_val (x y : I128) : (max x y).val = Max.max x.val y.val := by simp [max]; split <;> simp <;> omega
-@[simp, scalar_tac_simps] theorem core.cmp.impls.OrdIsize.max_val (x y : Isize) : (max x y).val = Max.max x.val y.val := by simp [max]; split <;> simp <;> omega
+scalar @[simp, scalar_tac_simps] theorem core.cmp.impls.Ord'S.max_val (x y : «%S») : (max x y).val = Max.max x.val y.val := by simp [max]; split <;> simp <;> omega
 
 /- Name pattern: core::cmp::impls::{core::cmp::Ord<SCALAR>}::clamp -/
 def UScalar.clamp {ty} (self min max : UScalar ty) : Result (UScalar ty) := do
@@ -388,115 +83,17 @@ def IScalar.clamp {ty} (self min max : IScalar ty) : Result (IScalar ty) := do
   else if self.val > max.val then ok max
   else ok self
 
-def core.cmp.impls.OrdU8.clamp (self min max : U8) : Result U8 := UScalar.clamp self min max
-def core.cmp.impls.OrdU16.clamp (self min max : U16) : Result U16 := UScalar.clamp self min max
-def core.cmp.impls.OrdU32.clamp (self min max : U32) : Result U32 := UScalar.clamp self min max
-def core.cmp.impls.OrdU64.clamp (self min max : U64) : Result U64 := UScalar.clamp self min max
-def core.cmp.impls.OrdU128.clamp (self min max : U128) : Result U128 := UScalar.clamp self min max
-def core.cmp.impls.OrdUsize.clamp (self min max : Usize) : Result Usize := UScalar.clamp self min max
-def core.cmp.impls.OrdI8.clamp (self min max : I8) : Result I8 := IScalar.clamp self min max
-def core.cmp.impls.OrdI16.clamp (self min max : I16) : Result I16 := IScalar.clamp self min max
-def core.cmp.impls.OrdI32.clamp (self min max : I32) : Result I32 := IScalar.clamp self min max
-def core.cmp.impls.OrdI64.clamp (self min max : I64) : Result I64 := IScalar.clamp self min max
-def core.cmp.impls.OrdI128.clamp (self min max : I128) : Result I128 := IScalar.clamp self min max
-def core.cmp.impls.OrdIsize.clamp (self min max : Isize) : Result Isize := IScalar.clamp self min max
+uscalar def core.cmp.impls.Ord'S.clamp (self min max : «%S») : Result «%S» := UScalar.clamp self min max
+iscalar def core.cmp.impls.Ord'S.clamp (self min max : «%S») : Result «%S» := IScalar.clamp self min max
 
 /- Trait implementation: [core::cmp::impls::{core::cmp::Ord for u8}]
    Name pattern: core::cmp::Ord<u8> -/
-@[reducible] def core.cmp.OrdU8 : core.cmp.Ord U8 := {
-  eqInst := core.cmp.EqU8
-  partialOrdInst := core.cmp.PartialOrdU8
-  cmp := liftFun2 core.cmp.impls.OrdU8.cmp
-  max := liftFun2 core.cmp.impls.OrdU8.max
-  min := liftFun2 core.cmp.impls.OrdU8.min
-  clamp := core.cmp.impls.OrdU8.clamp }
-
-@[reducible] def core.cmp.OrdU16 : core.cmp.Ord U16 := {
-  eqInst := core.cmp.EqU16
-  partialOrdInst := core.cmp.PartialOrdU16
-  cmp := liftFun2 core.cmp.impls.OrdU16.cmp
-  max := liftFun2 core.cmp.impls.OrdU16.max
-  min := liftFun2 core.cmp.impls.OrdU16.min
-  clamp := core.cmp.impls.OrdU16.clamp }
-
-@[reducible] def core.cmp.OrdU32 : core.cmp.Ord U32 := {
-  eqInst := core.cmp.EqU32
-  partialOrdInst := core.cmp.PartialOrdU32
-  cmp := liftFun2 core.cmp.impls.OrdU32.cmp
-  max := liftFun2 core.cmp.impls.OrdU32.max
-  min := liftFun2 core.cmp.impls.OrdU32.min
-  clamp := core.cmp.impls.OrdU32.clamp}
-
-@[reducible] def core.cmp.OrdU64 : core.cmp.Ord U64 := {
-  eqInst := core.cmp.EqU64
-  partialOrdInst := core.cmp.PartialOrdU64
-  cmp := liftFun2 core.cmp.impls.OrdU64.cmp
-  max := liftFun2 core.cmp.impls.OrdU64.max
-  min := liftFun2 core.cmp.impls.OrdU64.min
-  clamp := core.cmp.impls.OrdU64.clamp }
-
-@[reducible] def core.cmp.OrdU128 : core.cmp.Ord U128 := {
-  eqInst := core.cmp.EqU128
-  partialOrdInst := core.cmp.PartialOrdU128
-  cmp := liftFun2 core.cmp.impls.OrdU128.cmp
-  max := liftFun2 core.cmp.impls.OrdU128.max
-  min := liftFun2 core.cmp.impls.OrdU128.min
-  clamp := core.cmp.impls.OrdU128.clamp }
-
-@[reducible] def core.cmp.OrdUsize : core.cmp.Ord Usize := {
-  eqInst := core.cmp.EqUsize
-  partialOrdInst := core.cmp.PartialOrdUsize
-  cmp := liftFun2 core.cmp.impls.OrdUsize.cmp
-  max := liftFun2 core.cmp.impls.OrdUsize.max
-  min := liftFun2 core.cmp.impls.OrdUsize.min
-  clamp := core.cmp.impls.OrdUsize.clamp }
-
-@[reducible] def core.cmp.OrdI8 : core.cmp.Ord I8 := {
-  eqInst := core.cmp.EqI8
-  partialOrdInst := core.cmp.PartialOrdI8
-  cmp := liftFun2 core.cmp.impls.OrdI8.cmp
-  max := liftFun2 core.cmp.impls.OrdI8.max
-  min := liftFun2 core.cmp.impls.OrdI8.min
-  clamp := core.cmp.impls.OrdI8.clamp }
-
-@[reducible] def core.cmp.OrdI16 : core.cmp.Ord I16 := {
-  eqInst := core.cmp.EqI16
-  partialOrdInst := core.cmp.PartialOrdI16
-  cmp := liftFun2 core.cmp.impls.OrdI16.cmp
-  max := liftFun2 core.cmp.impls.OrdI16.max
-  min := liftFun2 core.cmp.impls.OrdI16.min
-  clamp := core.cmp.impls.OrdI16.clamp }
-
-@[reducible] def core.cmp.OrdI32 : core.cmp.Ord I32 := {
-  eqInst := core.cmp.EqI32
-  partialOrdInst := core.cmp.PartialOrdI32
-  cmp := liftFun2 core.cmp.impls.OrdI32.cmp
-  max := liftFun2 core.cmp.impls.OrdI32.max
-  min := liftFun2 core.cmp.impls.OrdI32.min
-  clamp := core.cmp.impls.OrdI32.clamp }
-
-@[reducible] def core.cmp.OrdI64 : core.cmp.Ord I64 := {
-  eqInst := core.cmp.EqI64
-  partialOrdInst := core.cmp.PartialOrdI64
-  cmp := liftFun2 core.cmp.impls.OrdI64.cmp
-  max := liftFun2 core.cmp.impls.OrdI64.max
-  min := liftFun2 core.cmp.impls.OrdI64.min
-  clamp := core.cmp.impls.OrdI64.clamp }
-
-@[reducible] def core.cmp.OrdI128 : core.cmp.Ord I128 := {
-  eqInst := core.cmp.EqI128
-  partialOrdInst := core.cmp.PartialOrdI128
-  cmp := liftFun2 core.cmp.impls.OrdI128.cmp
-  max := liftFun2 core.cmp.impls.OrdI128.max
-  min := liftFun2 core.cmp.impls.OrdI128.min
-  clamp := core.cmp.impls.OrdI128.clamp }
-
-@[reducible] def core.cmp.OrdIsize : core.cmp.Ord Isize := {
-  eqInst := core.cmp.EqIsize
-  partialOrdInst := core.cmp.PartialOrdIsize
-  cmp := liftFun2 core.cmp.impls.OrdIsize.cmp
-  max := liftFun2 core.cmp.impls.OrdIsize.max
-  min := liftFun2 core.cmp.impls.OrdIsize.min
-  clamp := core.cmp.impls.OrdIsize.clamp }
+scalar @[reducible] def core.cmp.Ord'S : core.cmp.Ord «%S» := {
+  eqInst := core.cmp.Eq'S
+  partialOrdInst := core.cmp.PartialOrd'S
+  cmp := liftFun2 core.cmp.impls.Ord'S.cmp
+  max := liftFun2 core.cmp.impls.Ord'S.max
+  min := liftFun2 core.cmp.impls.Ord'S.min
+  clamp := core.cmp.impls.Ord'S.clamp }
 
 end Aeneas.Std

--- a/backends/lean/Aeneas/Std/Scalar/LeadingZeros.lean
+++ b/backends/lean/Aeneas/Std/Scalar/LeadingZeros.lean
@@ -1,6 +1,9 @@
 import Aeneas.Std.Scalar.Core
+import Aeneas.Std.Scalar.Elab
 
 namespace Aeneas.Std
+
+open ScalarElab
 
 /-!
 # Leading zeros
@@ -21,18 +24,6 @@ def BitVec.leadingZeros {w : Nat} (x : BitVec w) : Nat :=
 #assert BitVec.leadingZeros 1#32 = 31
 #assert BitVec.leadingZeros 255#32 = 24
 
-@[progress_pure_def] def core.num.Usize.leading_zeros (x : Usize) : U32 := ⟨ BitVec.leadingZeros x.bv ⟩
-@[progress_pure_def] def core.num.U8.leading_zeros (x : U8) : U32 := ⟨ BitVec.leadingZeros x.bv ⟩
-@[progress_pure_def] def core.num.U16.leading_zeros (x : U16) : U32 := ⟨ BitVec.leadingZeros x.bv ⟩
-@[progress_pure_def] def core.num.U32.leading_zeros (x : U32) : U32 := ⟨ BitVec.leadingZeros x.bv ⟩
-@[progress_pure_def] def core.num.U64.leading_zeros (x : U64) : U32 := ⟨ BitVec.leadingZeros x.bv ⟩
-@[progress_pure_def] def core.num.U128.leading_zeros (x : U128) : U32 := ⟨ BitVec.leadingZeros x.bv ⟩
-
-@[progress_pure_def] def core.num.Isize.leading_zeros (x : Isize) : U32 := ⟨ BitVec.leadingZeros x.bv ⟩
-@[progress_pure_def] def core.num.I8.leading_zeros (x : I8) : U32 := ⟨ BitVec.leadingZeros x.bv ⟩
-@[progress_pure_def] def core.num.I16.leading_zeros (x : I16) : U32 := ⟨ BitVec.leadingZeros x.bv ⟩
-@[progress_pure_def] def core.num.I32.leading_zeros (x : I32) : U32 := ⟨ BitVec.leadingZeros x.bv ⟩
-@[progress_pure_def] def core.num.I64.leading_zeros (x : I64) : U32 := ⟨ BitVec.leadingZeros x.bv ⟩
-@[progress_pure_def] def core.num.I128.leading_zeros (x : I128) : U32 := ⟨ BitVec.leadingZeros x.bv ⟩
+scalar @[progress_pure_def] def core.num.«%S».leading_zeros (x : «%S») : U32 := ⟨ BitVec.leadingZeros x.bv ⟩
 
 end Aeneas.Std

--- a/backends/lean/Aeneas/Std/Scalar/Ops/Add.lean
+++ b/backends/lean/Aeneas/Std/Scalar/Ops/Add.lean
@@ -1,12 +1,13 @@
 import Aeneas.Std.Scalar.Core
 import Aeneas.Std.Scalar.Misc
+import Aeneas.Std.Scalar.Elab
 import Aeneas.ScalarTac
 import Aeneas.Std.Core
 import Mathlib.Data.BitVec
 
 namespace Aeneas.Std
 
-open Result Error Arith
+open Result Error Arith ScalarElab
 
 /-!
 # Addition: Definitions
@@ -94,57 +95,12 @@ theorem IScalar.add_bv_spec {ty} {x y : IScalar ty}
   split at h <;> simp_all [min, max]
   omega
 
-theorem Usize.add_bv_spec {x y : Usize} (hmax : x.val + y.val ≤ Usize.max) :
+uscalar theorem «%S».add_bv_spec {x y : «%S»} (hmax : x.val + y.val ≤ «%S».max) :
   ∃ z, x + y = ok z ∧ (↑z : Nat) = ↑x + ↑y ∧ z.bv = x.bv + y.bv :=
   UScalar.add_bv_spec (by scalar_tac)
 
-theorem U8.add_bv_spec {x y : U8} (hmax : x.val + y.val ≤ U8.max) :
-  ∃ z, x + y = ok z ∧ (↑z : Nat) = ↑x + ↑y ∧ z.bv = x.bv + y.bv :=
-  UScalar.add_bv_spec (by scalar_tac)
-
-theorem U16.add_bv_spec {x y : U16} (hmax : x.val + y.val ≤ U16.max) :
-  ∃ z, x + y = ok z ∧ (↑z : Nat) = ↑x + ↑y ∧ z.bv = x.bv + y.bv :=
-  UScalar.add_bv_spec (by scalar_tac)
-
-theorem U32.add_bv_spec {x y : U32} (hmax : x.val + y.val ≤ U32.max) :
-  ∃ z, x + y = ok z ∧ (↑z : Nat) = ↑x + ↑y ∧ z.bv = x.bv + y.bv :=
-  UScalar.add_bv_spec (by scalar_tac)
-
-theorem U64.add_bv_spec {x y : U64} (hmax : x.val + y.val ≤ U64.max) :
-  ∃ z, x + y = ok z ∧ (↑z : Nat) = ↑x + ↑y ∧ z.bv = x.bv + y.bv :=
-  UScalar.add_bv_spec (by scalar_tac)
-
-theorem U128.add_bv_spec {x y : U128} (hmax : x.val + y.val ≤ U128.max) :
-  ∃ z, x + y = ok z ∧ (↑z : Nat) = ↑x + ↑y ∧ z.bv = x.bv + y.bv :=
-  UScalar.add_bv_spec (by scalar_tac)
-
-theorem Isize.add_bv_spec {x y : Isize}
-  (hmin : Isize.min ≤ ↑x + ↑y) (hmax : ↑x + ↑y ≤ Isize.max) :
-  ∃ z, x + y = ok z ∧ (↑z : Int) = ↑x + ↑y ∧ z.bv = x.bv + y.bv :=
-  IScalar.add_bv_spec (by scalar_tac) (by scalar_tac)
-
-theorem I8.add_bv_spec {x y : I8}
-  (hmin : I8.min ≤ ↑x + ↑y) (hmax : ↑x + ↑y ≤ I8.max) :
-  ∃ z, x + y = ok z ∧ (↑z : Int) = ↑x + ↑y ∧ z.bv = x.bv + y.bv :=
-  IScalar.add_bv_spec (by scalar_tac) (by scalar_tac)
-
-theorem I16.add_bv_spec {x y : I16}
-  (hmin : I16.min ≤ ↑x + ↑y) (hmax : ↑x + ↑y ≤ I16.max) :
-  ∃ z, x + y = ok z ∧ (↑z : Int) = ↑x + ↑y ∧ z.bv = x.bv + y.bv :=
-  IScalar.add_bv_spec (by scalar_tac) (by scalar_tac)
-
-theorem I32.add_bv_spec {x y : I32}
-  (hmin : I32.min ≤ ↑x + ↑y) (hmax : ↑x + ↑y ≤ I32.max) :
-  ∃ z, x + y = ok z ∧ (↑z : Int) = ↑x + ↑y ∧ z.bv = x.bv + y.bv :=
-  IScalar.add_bv_spec (by scalar_tac) (by scalar_tac)
-
-theorem I64.add_bv_spec {x y : I64}
-  (hmin : I64.min ≤ ↑x + ↑y) (hmax : ↑x + ↑y ≤ I64.max) :
-  ∃ z, x + y = ok z ∧ (↑z : Int) = ↑x + ↑y ∧ z.bv = x.bv + y.bv :=
-  IScalar.add_bv_spec (by scalar_tac) (by scalar_tac)
-
-theorem I128.add_bv_spec {x y : I128}
-  (hmin : I128.min ≤ ↑x + ↑y) (hmax : ↑x + ↑y ≤ I128.max) :
+iscalar theorem «%S».add_bv_spec {x y : «%S»}
+  (hmin : «%S».min ≤ ↑x + ↑y) (hmax : ↑x + ↑y ≤ «%S».max) :
   ∃ z, x + y = ok z ∧ (↑z : Int) = ↑x + ↑y ∧ z.bv = x.bv + y.bv :=
   IScalar.add_bv_spec (by scalar_tac) (by scalar_tac)
 
@@ -174,57 +130,12 @@ theorem IScalar.add_spec {ty} {x y : IScalar ty}
   split at h <;> simp_all [min, max]
   omega
 
-@[progress] theorem Usize.add_spec {x y : Usize} (hmax : x.val + y.val ≤ Usize.max) :
+uscalar @[progress] theorem «%S».add_spec {x y : «%S»} (hmax : x.val + y.val ≤ «%S».max) :
   ∃ z, x + y = ok z ∧ (↑z : Nat) = ↑x + ↑y :=
   UScalar.add_spec (by scalar_tac)
 
-@[progress] theorem U8.add_spec {x y : U8} (hmax : x.val + y.val ≤ U8.max) :
-  ∃ z, x + y = ok z ∧ (↑z : Nat) = ↑x + ↑y :=
-  UScalar.add_spec (by scalar_tac)
-
-@[progress] theorem U16.add_spec {x y : U16} (hmax : x.val + y.val ≤ U16.max) :
-  ∃ z, x + y = ok z ∧ (↑z : Nat) = ↑x + ↑y :=
-  UScalar.add_spec (by scalar_tac)
-
-@[progress] theorem U32.add_spec {x y : U32} (hmax : x.val + y.val ≤ U32.max) :
-  ∃ z, x + y = ok z ∧ (↑z : Nat) = ↑x + ↑y :=
-  UScalar.add_spec (by scalar_tac)
-
-@[progress] theorem U64.add_spec {x y : U64} (hmax : x.val + y.val ≤ U64.max) :
-  ∃ z, x + y = ok z ∧ (↑z : Nat) = ↑x + ↑y :=
-  UScalar.add_spec (by scalar_tac)
-
-@[progress] theorem U128.add_spec {x y : U128} (hmax : x.val + y.val ≤ U128.max) :
-  ∃ z, x + y = ok z ∧ (↑z : Nat) = ↑x + ↑y :=
-  UScalar.add_spec (by scalar_tac)
-
-@[progress] theorem Isize.add_spec {x y : Isize}
-  (hmin : Isize.min ≤ ↑x + ↑y) (hmax : ↑x + ↑y ≤ Isize.max) :
-  ∃ z, x + y = ok z ∧ (↑z : Int) = ↑x + ↑y :=
-  IScalar.add_spec (by scalar_tac) (by scalar_tac)
-
-@[progress] theorem I8.add_spec {x y : I8}
-  (hmin : I8.min ≤ ↑x + ↑y) (hmax : ↑x + ↑y ≤ I8.max) :
-  ∃ z, x + y = ok z ∧ (↑z : Int) = ↑x + ↑y :=
-  IScalar.add_spec (by scalar_tac) (by scalar_tac)
-
-@[progress] theorem I16.add_spec {x y : I16}
-  (hmin : I16.min ≤ ↑x + ↑y) (hmax : ↑x + ↑y ≤ I16.max) :
-  ∃ z, x + y = ok z ∧ (↑z : Int) = ↑x + ↑y :=
-  IScalar.add_spec (by scalar_tac) (by scalar_tac)
-
-@[progress] theorem I32.add_spec {x y : I32}
-  (hmin : I32.min ≤ ↑x + ↑y) (hmax : ↑x + ↑y ≤ I32.max) :
-  ∃ z, x + y = ok z ∧ (↑z : Int) = ↑x + ↑y :=
-  IScalar.add_spec (by scalar_tac) (by scalar_tac)
-
-@[progress] theorem I64.add_spec {x y : I64}
-  (hmin : I64.min ≤ ↑x + ↑y) (hmax : ↑x + ↑y ≤ I64.max) :
-  ∃ z, x + y = ok z ∧ (↑z : Int) = ↑x + ↑y :=
-  IScalar.add_spec (by scalar_tac) (by scalar_tac)
-
-@[progress] theorem I128.add_spec {x y : I128}
-  (hmin : I128.min ≤ ↑x + ↑y) (hmax : ↑x + ↑y ≤ I128.max) :
+iscalar @[progress] theorem «%S».add_spec {x y : «%S»}
+  (hmin : «%S».min ≤ ↑x + ↑y) (hmax : ↑x + ↑y ≤ «%S».max) :
   ∃ z, x + y = ok z ∧ (↑z : Int) = ↑x + ↑y :=
   IScalar.add_spec (by scalar_tac) (by scalar_tac)
 

--- a/backends/lean/Aeneas/Std/Scalar/Ops/Div.lean
+++ b/backends/lean/Aeneas/Std/Scalar/Ops/Div.lean
@@ -1,12 +1,13 @@
 import Aeneas.Std.Scalar.Core
 import Aeneas.Std.Scalar.Misc
+import Aeneas.Std.Scalar.Elab
 import Aeneas.ScalarTac
 import Aeneas.Std.Core
 import Mathlib.Data.BitVec
 
 namespace Aeneas.Std
 
-open Result Error Arith
+open Result Error Arith ScalarElab
 
 /-!
 # Division: Definitions
@@ -387,57 +388,12 @@ theorem IScalar.div_bv_spec {ty} {x y : IScalar ty}
     rw [this]
     simp only [Int.tdiv_neg, Int.neg_tdiv, neg_neg]
 
-theorem U8.div_bv_spec (x : U8) {y : U8} (hnz : ↑y ≠ (0 : Nat)) :
+uscalar theorem «%S».div_bv_spec (x : «%S») {y : «%S»} (hnz : ↑y ≠ (0 : Nat)) :
   ∃ z, x / y = ok z ∧ (↑z : Nat) = ↑x / ↑y ∧ z.bv = x.bv / y.bv :=
   UScalar.div_bv_spec x hnz
 
-theorem U16.div_bv_spec (x : U16) {y : U16} (hnz : ↑y ≠ (0 : Nat)) :
-  ∃ z, x / y = ok z ∧ (↑z : Nat) = ↑x / ↑y ∧ z.bv = x.bv / y.bv :=
-  UScalar.div_bv_spec x hnz
-
-theorem U32.div_bv_spec (x : U32) {y : U32} (hnz : ↑y ≠ (0 : Nat)) :
-  ∃ z, x / y = ok z ∧ (↑z : Nat) = ↑x / ↑y ∧ z.bv = x.bv / y.bv :=
-  UScalar.div_bv_spec x hnz
-
-theorem U64.div_bv_spec (x : U64) {y : U64} (hnz : ↑y ≠ (0 : Nat)) :
-  ∃ z, x / y = ok z ∧ (↑z : Nat) = ↑x / ↑y ∧ z.bv = x.bv / y.bv :=
-  UScalar.div_bv_spec x hnz
-
-theorem U128.div_bv_spec (x : U128) {y : U128} (hnz : ↑y ≠ (0 : Nat)) :
-  ∃ z, x / y = ok z ∧ (↑z : Nat) = ↑x / ↑y ∧ z.bv = x.bv / y.bv :=
-  UScalar.div_bv_spec x hnz
-
-theorem Usize.div_bv_spec (x : Usize) {y : Usize} (hnz : ↑y ≠ (0 : Nat)) :
-  ∃ z, x / y = ok z ∧ (↑z : Nat) = ↑x / ↑y ∧ z.bv = x.bv / y.bv :=
-  UScalar.div_bv_spec x hnz
-
-theorem I8.div_bv_spec {x y : I8} (hnz : ↑y ≠ (0 : Int))
-  (hNoOverflow : ¬ (x.val = I8.min ∧ y.val = -1)) :
-  ∃ z, x / y = ok z ∧ (↑z : Int) = Int.tdiv ↑x ↑y ∧ z.bv = BitVec.sdiv x.bv y.bv :=
-  IScalar.div_bv_spec hnz (by scalar_tac)
-
-theorem I16.div_bv_spec {x y : I16} (hnz : ↑y ≠ (0 : Int))
-  (hNoOverflow : ¬ (x.val = I16.min ∧ y.val = -1)) :
-  ∃ z, x / y = ok z ∧ (↑z : Int) = Int.tdiv ↑x ↑y ∧ z.bv = BitVec.sdiv x.bv y.bv :=
-  IScalar.div_bv_spec hnz (by scalar_tac)
-
-theorem I32.div_bv_spec {x y : I32} (hnz : ↑y ≠ (0 : Int))
-  (hNoOverflow : ¬ (x.val = I32.min ∧ y.val = -1)) :
-  ∃ z, x / y = ok z ∧ (↑z : Int) = Int.tdiv ↑x ↑y ∧ z.bv = BitVec.sdiv x.bv y.bv :=
-  IScalar.div_bv_spec hnz (by scalar_tac)
-
-theorem I64.div_bv_spec {x y : I64} (hnz : ↑y ≠ (0 : Int))
-  (hNoOverflow : ¬ (x.val = I64.min ∧ y.val = -1)) :
-  ∃ z, x / y = ok z ∧ (↑z : Int) = Int.tdiv ↑x ↑y ∧ z.bv = BitVec.sdiv x.bv y.bv :=
-  IScalar.div_bv_spec hnz (by scalar_tac)
-
-theorem I128.div_bv_spec {x y : I128} (hnz : ↑y ≠ (0 : Int))
-  (hNoOverflow : ¬ (x.val = I128.min ∧ y.val = -1)) :
-  ∃ z, x / y = ok z ∧ (↑z : Int) = Int.tdiv ↑x ↑y ∧ z.bv = BitVec.sdiv x.bv y.bv :=
-  IScalar.div_bv_spec hnz (by scalar_tac)
-
-theorem Isize.div_bv_spec {x y : Isize} (hnz : ↑y ≠ (0 : Int))
-  (hNoOverflow : ¬ (x.val = Isize.min ∧ y.val = -1)) :
+iscalar theorem «%S».div_bv_spec {x y : «%S»} (hnz : ↑y ≠ (0 : Int))
+  (hNoOverflow : ¬ (x.val = «%S».min ∧ y.val = -1)) :
   ∃ z, x / y = ok z ∧ (↑z : Int) = Int.tdiv ↑x ↑y ∧ z.bv = BitVec.sdiv x.bv y.bv :=
   IScalar.div_bv_spec hnz (by scalar_tac)
 
@@ -460,59 +416,13 @@ theorem IScalar.div_spec {ty} {x y : IScalar ty}
   have ⟨ z, hz ⟩ := IScalar.div_bv_spec hzero hNoOverflow
   simp [hz]
 
-@[progress] theorem U8.div_spec (x : U8) {y : U8} (hnz : ↑y ≠ (0 : Nat)) :
+uscalar @[progress] theorem «%S».div_spec (x : «%S») {y : «%S»} (hnz : ↑y ≠ (0 : Nat)) :
   ∃ z, x / y = ok z ∧ (↑z : Nat) = ↑x / ↑y :=
   UScalar.div_spec x hnz
 
-@[progress] theorem U16.div_spec (x : U16) {y : U16} (hnz : ↑y ≠ (0 : Nat)) :
-  ∃ z, x / y = ok z ∧ (↑z : Nat) = ↑x / ↑y :=
-  UScalar.div_spec x hnz
-
-@[progress] theorem U32.div_spec (x : U32) {y : U32} (hnz : ↑y ≠ (0 : Nat)) :
-  ∃ z, x / y = ok z ∧ (↑z : Nat) = ↑x / ↑y :=
-  UScalar.div_spec x hnz
-
-@[progress] theorem U64.div_spec (x : U64) {y : U64} (hnz : ↑y ≠ (0 : Nat)) :
-  ∃ z, x / y = ok z ∧ (↑z : Nat) = ↑x / ↑y :=
-  UScalar.div_spec x hnz
-
-@[progress] theorem U128.div_spec (x : U128) {y : U128} (hnz : ↑y ≠ (0 : Nat)) :
-  ∃ z, x / y = ok z ∧ (↑z : Nat) = ↑x / ↑y :=
-  UScalar.div_spec x hnz
-
-@[progress] theorem Usize.div_spec (x : Usize) {y : Usize} (hnz : ↑y ≠ (0 : Nat)) :
-  ∃ z, x / y = ok z ∧ (↑z : Nat) = ↑x / ↑y :=
-  UScalar.div_spec x hnz
-
-@[progress] theorem I8.div_spec {x y : I8} (hnz : ↑y ≠ (0 : Int))
-  (hNoOverflow : ¬ (x.val = I8.min ∧ y.val = -1)) :
+iscalar @[progress] theorem «%S».div_spec {x y : «%S»} (hnz : ↑y ≠ (0 : Int))
+  (hNoOverflow : ¬ (x.val = «%S».min ∧ y.val = -1)) :
   ∃ z, x / y = ok z ∧ (↑z : Int) = Int.tdiv ↑x ↑y :=
   IScalar.div_spec hnz (by scalar_tac)
-
-@[progress] theorem I16.div_spec {x y : I16} (hnz : ↑y ≠ (0 : Int))
-  (hNoOverflow : ¬ (x.val = I16.min ∧ y.val = -1)) :
-  ∃ z, x / y = ok z ∧ (↑z : Int) = Int.tdiv ↑x ↑y :=
-  IScalar.div_spec hnz (by scalar_tac)
-
-@[progress] theorem I32.div_spec {x y : I32} (hnz : ↑y ≠ (0 : Int))
-  (hNoOverflow : ¬ (x.val = I32.min ∧ y.val = -1)) :
-  ∃ z, x / y = ok z ∧ (↑z : Int) = Int.tdiv ↑x ↑y :=
-  IScalar.div_spec hnz (by scalar_tac)
-
-@[progress] theorem I64.div_spec {x y : I64} (hnz : ↑y ≠ (0 : Int))
-  (hNoOverflow : ¬ (x.val = I64.min ∧ y.val = -1)) :
-  ∃ z, x / y = ok z ∧ (↑z : Int) = Int.tdiv ↑x ↑y :=
-  IScalar.div_spec hnz (by scalar_tac)
-
-@[progress] theorem I128.div_spec {x y : I128} (hnz : ↑y ≠ (0 : Int))
-  (hNoOverflow : ¬ (x.val = I128.min ∧ y.val = -1)) :
-  ∃ z, x / y = ok z ∧ (↑z : Int) = Int.tdiv ↑x ↑y :=
-  IScalar.div_spec hnz (by scalar_tac)
-
-@[progress] theorem Isize.div_spec {x y : Isize} (hnz : ↑y ≠ (0 : Int))
-  (hNoOverflow : ¬ (x.val = Isize.min ∧ y.val = -1)) :
-  ∃ z, x / y = ok z ∧ (↑z : Int) = Int.tdiv ↑x ↑y :=
-  IScalar.div_spec hnz (by scalar_tac)
-
 
 end Aeneas.Std

--- a/backends/lean/Aeneas/Std/Scalar/Ops/Mul.lean
+++ b/backends/lean/Aeneas/Std/Scalar/Ops/Mul.lean
@@ -1,5 +1,6 @@
 import Aeneas.Std.Scalar.Core
 import Aeneas.Std.Scalar.Misc
+import Aeneas.Std.Scalar.Elab
 import Aeneas.ScalarTac
 import Aeneas.Std.Core
 import Mathlib.Data.BitVec
@@ -7,7 +8,7 @@ import Mathlib.Data.Int.Init
 
 namespace Aeneas.Std
 
-open Result Error Arith
+open Result Error Arith ScalarElab
 
 /-!
 # Multiplication: Definitions
@@ -115,60 +116,14 @@ theorem IScalar.mul_bv_spec {ty} {x y : IScalar ty}
   have := mul_equiv x y
   split at this <;> simp_all
 
-theorem Usize.mul_bv_spec {x y : Usize} (hmax : x.val * y.val ≤ Usize.max) :
+uscalar theorem «%S».mul_bv_spec {x y : «%S»} (hmax : x.val * y.val ≤ «%S».max) :
   ∃ z, x * y = ok z ∧ (↑z : Nat) = ↑x * ↑y ∧ z.bv = x.bv * y.bv :=
   UScalar.mul_bv_spec (by scalar_tac)
 
-theorem U8.mul_bv_spec {x y : U8} (hmax : x.val * y.val ≤ U8.max) :
-  ∃ z, x * y = ok z ∧ (↑z : Nat) = ↑x * ↑y ∧ z.bv = x.bv * y.bv :=
-  UScalar.mul_bv_spec (by scalar_tac)
-
-theorem U16.mul_bv_spec {x y : U16} (hmax : x.val * y.val ≤ U16.max) :
-  ∃ z, x * y = ok z ∧ (↑z : Nat) = ↑x * ↑y ∧ z.bv = x.bv * y.bv :=
-  UScalar.mul_bv_spec (by scalar_tac)
-
-theorem U32.mul_bv_spec {x y : U32} (hmax : x.val * y.val ≤ U32.max) :
-  ∃ z, x * y = ok z ∧ (↑z : Nat) = ↑x * ↑y ∧ z.bv = x.bv * y.bv :=
-  UScalar.mul_bv_spec (by scalar_tac)
-
-theorem U64.mul_bv_spec {x y : U64} (hmax : x.val * y.val ≤ U64.max) :
-  ∃ z, x * y = ok z ∧ (↑z : Nat) = ↑x * ↑y ∧ z.bv = x.bv * y.bv :=
-  UScalar.mul_bv_spec (by scalar_tac)
-
-theorem U128.mul_bv_spec {x y : U128} (hmax : x.val * y.val ≤ U128.max) :
-  ∃ z, x * y = ok z ∧ (↑z : Nat) = ↑x * ↑y ∧ z.bv = x.bv * y.bv :=
-  UScalar.mul_bv_spec (by scalar_tac)
-
-theorem Isize.mul_bv_spec {x y : Isize}
-  (hmin : Isize.min ≤ ↑x * ↑y) (hmax : ↑x * ↑y ≤ Isize.max) :
+iscalar theorem «%S».mul_bv_spec {x y : «%S»}
+  (hmin : «%S».min ≤ ↑x * ↑y) (hmax : ↑x * ↑y ≤ «%S».max) :
   ∃ z, x * y = ok z ∧ (↑z : Int) = ↑x * ↑y ∧ z.bv = x.bv * y.bv :=
   IScalar.mul_bv_spec (by scalar_tac) (by scalar_tac)
-
-theorem I8.mul_bv_spec {x y : I8}
-  (hmin : I8.min ≤ ↑x * ↑y) (hmax : ↑x * ↑y ≤ I8.max) :
-  ∃ z, x * y = ok z ∧ (↑z : Int) = ↑x * ↑y ∧ z.bv = x.bv * y.bv :=
-  IScalar.mul_bv_spec (by scalar_tac) (by scalar_tac)
-
-theorem I16.mul_bv_spec {x y : I16}
-  (hmin : I16.min ≤ ↑x * ↑y) (hmax : ↑x * ↑y ≤ I16.max) :
-  ∃ z, x * y = ok z ∧ (↑z : Int) = ↑x * ↑y ∧ z.bv = x.bv * y.bv :=
-  IScalar.mul_bv_spec (by scalar_tac) (by scalar_tac)
-
-theorem I32.mul_bv_spec {x y : I32}
-  (hmin : I32.min ≤ ↑x * ↑y) (hmax : ↑x * ↑y ≤ I32.max) :
-  ∃ z, x * y = ok z ∧ (↑z : Int) = ↑x * ↑y ∧ z.bv = x.bv * y.bv :=
-  IScalar.mul_bv_spec (by scalar_tac) (by scalar_tac)
-
-theorem I64.mul_bv_spec {x y : I64} (hmin : I64.min ≤ ↑x * ↑y)
-  (hmax : ↑x * ↑y ≤ I64.max) :
-  ∃ z, x * y = ok z ∧ (↑z : Int) = ↑x * ↑y ∧ z.bv = x.bv * y.bv :=
-  IScalar.mul_bv_spec (by scalar_tac) (by scalar_tac)
-
-theorem I128.mul_bv_spec {x y : I128} (hmin : I128.min ≤ ↑x * ↑y)
-  (hmax : ↑x * ↑y ≤ I128.max) :
-  ∃ z, x * y = ok z ∧ (↑z : Int) = ↑x * ↑y ∧ z.bv = x.bv * y.bv :=
-  IScalar.mul_bv_spec (by scalar_tac) (by scalar_tac)
-
 
 /-!
 Theorems with a specification which only use integers
@@ -189,57 +144,12 @@ theorem IScalar.mul_spec {ty} {x y : IScalar ty}
   have ⟨ z, h⟩ := @mul_bv_spec ty x y (by scalar_tac) (by scalar_tac)
   simp only [ok.injEq, _root_.exists_eq_left', h]
 
-@[progress] theorem Usize.mul_spec {x y : Usize} (hmax : x.val * y.val ≤ Usize.max) :
+uscalar @[progress] theorem «%S».mul_spec {x y : «%S»} (hmax : x.val * y.val ≤ «%S».max) :
   ∃ z, x * y = ok z ∧ (↑z : Nat) = ↑x * ↑y :=
   UScalar.mul_spec (by scalar_tac)
 
-@[progress] theorem U8.mul_spec {x y : U8} (hmax : x.val * y.val ≤ U8.max) :
-  ∃ z, x * y = ok z ∧ (↑z : Nat) = ↑x * ↑y :=
-  UScalar.mul_spec (by scalar_tac)
-
-@[progress] theorem U16.mul_spec {x y : U16} (hmax : x.val * y.val ≤ U16.max) :
-  ∃ z, x * y = ok z ∧ (↑z : Nat) = ↑x * ↑y :=
-  UScalar.mul_spec (by scalar_tac)
-
-@[progress] theorem U32.mul_spec {x y : U32} (hmax : x.val * y.val ≤ U32.max) :
-  ∃ z, x * y = ok z ∧ (↑z : Nat) = ↑x * ↑y :=
-  UScalar.mul_spec (by scalar_tac)
-
-@[progress] theorem U64.mul_spec {x y : U64} (hmax : x.val * y.val ≤ U64.max) :
-  ∃ z, x * y = ok z ∧ (↑z : Nat) = ↑x * ↑y :=
-  UScalar.mul_spec (by scalar_tac)
-
-@[progress] theorem U128.mul_spec {x y : U128} (hmax : x.val * y.val ≤ U128.max) :
-  ∃ z, x * y = ok z ∧ (↑z : Nat) = ↑x * ↑y :=
-  UScalar.mul_spec (by scalar_tac)
-
-@[progress] theorem Isize.mul_spec {x y : Isize}
-  (hmin : Isize.min ≤ ↑x * ↑y) (hmax : ↑x * ↑y ≤ Isize.max) :
-  ∃ z, x * y = ok z ∧ (↑z : Int) = ↑x * ↑y :=
-  IScalar.mul_spec (by scalar_tac) (by scalar_tac)
-
-@[progress] theorem I8.mul_spec {x y : I8}
-  (hmin : I8.min ≤ ↑x * ↑y) (hmax : ↑x * ↑y ≤ I8.max) :
-  ∃ z, x * y = ok z ∧ (↑z : Int) = ↑x * ↑y :=
-  IScalar.mul_spec (by scalar_tac) (by scalar_tac)
-
-@[progress] theorem I16.mul_spec {x y : I16}
-  (hmin : I16.min ≤ ↑x * ↑y) (hmax : ↑x * ↑y ≤ I16.max) :
-  ∃ z, x * y = ok z ∧ (↑z : Int) = ↑x * ↑y :=
-  IScalar.mul_spec (by scalar_tac) (by scalar_tac)
-
-@[progress] theorem I32.mul_spec {x y : I32}
-  (hmin : I32.min ≤ ↑x * ↑y) (hmax : ↑x * ↑y ≤ I32.max) :
-  ∃ z, x * y = ok z ∧ (↑z : Int) = ↑x * ↑y :=
-  IScalar.mul_spec (by scalar_tac) (by scalar_tac)
-
-@[progress] theorem I64.mul_spec {x y : I64} (hmin : I64.min ≤ ↑x * ↑y)
-  (hmax : ↑x * ↑y ≤ I64.max) :
-  ∃ z, x * y = ok z ∧ (↑z : Int) = ↑x * ↑y :=
-  IScalar.mul_spec (by scalar_tac) (by scalar_tac)
-
-@[progress] theorem I128.mul_spec {x y : I128} (hmin : I128.min ≤ ↑x * ↑y)
-  (hmax : ↑x * ↑y ≤ I128.max) :
+iscalar @[progress] theorem «%S».mul_spec {x y : «%S»}
+  (hmin : «%S».min ≤ ↑x * ↑y) (hmax : ↑x * ↑y ≤ «%S».max) :
   ∃ z, x * y = ok z ∧ (↑z : Int) = ↑x * ↑y :=
   IScalar.mul_spec (by scalar_tac) (by scalar_tac)
 

--- a/backends/lean/Aeneas/Std/Scalar/Ops/Neg.lean
+++ b/backends/lean/Aeneas/Std/Scalar/Ops/Neg.lean
@@ -1,5 +1,6 @@
 import Aeneas.Std.Scalar.Core
 import Aeneas.Std.Scalar.Misc
+import Aeneas.Std.Scalar.Elab
 import Aeneas.ScalarTac
 import Aeneas.Std.Core
 import Mathlib.Data.BitVec

--- a/backends/lean/Aeneas/Std/Scalar/Ops/Rem.lean
+++ b/backends/lean/Aeneas/Std/Scalar/Ops/Rem.lean
@@ -1,12 +1,13 @@
 import Aeneas.Std.Scalar.Core
 import Aeneas.Std.Scalar.Misc
+import Aeneas.Std.Scalar.Elab
 import Aeneas.ScalarTac
 import Aeneas.Std.Core
 import Mathlib.Data.BitVec
 
 namespace Aeneas.Std
 
-open Result Error Arith
+open Result Error Arith ScalarElab
 
 /-!
 # Remainder: Definitions
@@ -89,51 +90,11 @@ theorem IScalar.rem_bv_spec {ty} (x : IScalar ty) {y : IScalar ty} (hzero : y.va
   simp only [val]
   simp only [BitVec.toInt_srem, bv_toInt_eq]
 
-theorem U8.rem_bv_spec (x : U8) {y : U8} (hnz : y.val ≠ 0) :
+uscalar theorem «%S».rem_bv_spec (x : «%S») {y : «%S»} (hnz : y.val ≠ 0) :
   ∃ z, x % y = ok z ∧ (↑z : Nat) = ↑x % ↑y ∧ z.bv = x.bv % y.bv :=
   UScalar.rem_bv_spec x hnz
 
-theorem U16.rem_bv_spec (x : U16) {y : U16} (hnz : y.val ≠ 0) :
-  ∃ z, x % y = ok z ∧ (↑z : Nat) = ↑x % ↑y ∧ z.bv = x.bv % y.bv :=
-  UScalar.rem_bv_spec x hnz
-
-theorem U32.rem_bv_spec (x : U32) {y : U32} (hnz : y.val ≠ 0) :
-  ∃ z, x % y = ok z ∧ (↑z : Nat) = ↑x % ↑y ∧ z.bv = x.bv % y.bv :=
-  UScalar.rem_bv_spec x hnz
-
-theorem U64.rem_bv_spec (x : U64) {y : U64} (hnz : y.val ≠ 0) :
-  ∃ z, x % y = ok z ∧ (↑z : Nat) = ↑x % ↑y ∧ z.bv = x.bv % y.bv :=
-  UScalar.rem_bv_spec x hnz
-
-theorem U128.rem_bv_spec (x : U128) {y : U128} (hnz : y.val ≠ 0) :
-  ∃ z, x % y = ok z ∧ (↑z : Nat) = ↑x % ↑y ∧ z.bv = x.bv % y.bv :=
-  UScalar.rem_bv_spec x hnz
-
-theorem Usize.rem_bv_spec (x : Usize) {y : Usize} (hnz : y.val ≠ 0) :
-  ∃ z, x % y = ok z ∧ (↑z : Nat) = ↑x % ↑y ∧ z.bv = x.bv % y.bv :=
-  UScalar.rem_bv_spec x hnz
-
-theorem I8.rem_bv_spec (x : I8) {y : I8} (hnz : y.val ≠ 0) :
-  ∃ z, x % y = ok z ∧ (↑z : Int) = Int.tmod ↑x ↑y ∧ z.bv = BitVec.srem x.bv y.bv :=
-  IScalar.rem_bv_spec x hnz
-
-theorem I16.rem_bv_spec (x : I16) {y : I16} (hnz : y.val ≠ 0) :
-  ∃ z, x % y = ok z ∧ (↑z : Int) = Int.tmod ↑x ↑y ∧ z.bv = BitVec.srem x.bv y.bv :=
-  IScalar.rem_bv_spec x hnz
-
-theorem I32.rem_bv_spec (x : I32) {y : I32} (hnz : y.val ≠ 0) :
-  ∃ z, x % y = ok z ∧ (↑z : Int) = Int.tmod ↑x ↑y ∧ z.bv = BitVec.srem x.bv y.bv :=
-  IScalar.rem_bv_spec x hnz
-
-theorem I64.rem_bv_spec (x : I64) {y : I64} (hnz : y.val ≠ 0) :
-  ∃ z, x % y = ok z ∧ (↑z : Int) = Int.tmod ↑x ↑y ∧ z.bv = BitVec.srem x.bv y.bv :=
-  IScalar.rem_bv_spec x hnz
-
-theorem I128.rem_bv_spec (x : I128) {y : I128} (hnz : y.val ≠ 0) :
-  ∃ z, x % y = ok z ∧ (↑z : Int) = Int.tmod ↑x ↑y ∧ z.bv = BitVec.srem x.bv y.bv :=
-  IScalar.rem_bv_spec x hnz
-
-theorem Isize.rem_bv_spec (x : I128) {y : I128} (hnz : y.val ≠ 0) :
+iscalar theorem «%S».rem_bv_spec (x : «%S») {y : «%S»} (hnz : y.val ≠ 0) :
   ∃ z, x % y = ok z ∧ (↑z : Int) = Int.tmod ↑x ↑y ∧ z.bv = BitVec.srem x.bv y.bv :=
   IScalar.rem_bv_spec x hnz
 
@@ -153,51 +114,11 @@ theorem IScalar.rem_spec {ty} (x : IScalar ty) {y : IScalar ty} (hzero : y.val �
   have ⟨ z, hz ⟩ := rem_bv_spec x hzero
   simp [hz]
 
-@[progress] theorem U8.rem_spec (x : U8) {y : U8} (hnz : y.val ≠ 0) :
+uscalar @[progress] theorem «%S».rem_spec (x : «%S») {y : «%S»} (hnz : y.val ≠ 0) :
   ∃ z, x % y = ok z ∧ (↑z : Nat) = ↑x % ↑y :=
   UScalar.rem_spec x hnz
 
-@[progress] theorem U16.rem_spec (x : U16) {y : U16} (hnz : y.val ≠ 0) :
-  ∃ z, x % y = ok z ∧ (↑z : Nat) = ↑x % ↑y :=
-  UScalar.rem_spec x hnz
-
-@[progress] theorem U32.rem_spec (x : U32) {y : U32} (hnz : y.val ≠ 0) :
-  ∃ z, x % y = ok z ∧ (↑z : Nat) = ↑x % ↑y :=
-  UScalar.rem_spec x hnz
-
-@[progress] theorem U64.rem_spec (x : U64) {y : U64} (hnz : y.val ≠ 0) :
-  ∃ z, x % y = ok z ∧ (↑z : Nat) = ↑x % ↑y :=
-  UScalar.rem_spec x hnz
-
-@[progress] theorem U128.rem_spec (x : U128) {y : U128} (hnz : y.val ≠ 0) :
-  ∃ z, x % y = ok z ∧ (↑z : Nat) = ↑x % ↑y :=
-  UScalar.rem_spec x hnz
-
-@[progress] theorem Usize.rem_spec (x : Usize) {y : Usize} (hnz : y.val ≠ 0) :
-  ∃ z, x % y = ok z ∧ (↑z : Nat) = ↑x % ↑y :=
-  UScalar.rem_spec x hnz
-
-@[progress] theorem I8.rem_spec (x : I8) {y : I8} (hnz : y.val ≠ 0) :
-  ∃ z, x % y = ok z ∧ (↑z : Int) = Int.tmod ↑x ↑y :=
-  IScalar.rem_spec x hnz
-
-@[progress] theorem I16.rem_spec (x : I16) {y : I16} (hnz : y.val ≠ 0) :
-  ∃ z, x % y = ok z ∧ (↑z : Int) = Int.tmod ↑x ↑y :=
-  IScalar.rem_spec x hnz
-
-@[progress] theorem I32.rem_spec (x : I32) {y : I32} (hnz : y.val ≠ 0) :
-  ∃ z, x % y = ok z ∧ (↑z : Int) = Int.tmod ↑x ↑y :=
-  IScalar.rem_spec x hnz
-
-@[progress] theorem I64.rem_spec (x : I64) {y : I64} (hnz : y.val ≠ 0) :
-  ∃ z, x % y = ok z ∧ (↑z : Int) = Int.tmod ↑x ↑y :=
-  IScalar.rem_spec x hnz
-
-@[progress] theorem I128.rem_spec (x : I128) {y : I128} (hnz : y.val ≠ 0) :
-  ∃ z, x % y = ok z ∧ (↑z : Int) = Int.tmod ↑x ↑y :=
-  IScalar.rem_spec x hnz
-
-@[progress] theorem Isize.rem_spec (x : I128) {y : I128} (hnz : y.val ≠ 0) :
+iscalar @[progress] theorem «%S».rem_spec (x : «%S») {y : «%S»} (hnz : y.val ≠ 0) :
   ∃ z, x % y = ok z ∧ (↑z : Int) = Int.tmod ↑x ↑y :=
   IScalar.rem_spec x hnz
 

--- a/backends/lean/Aeneas/Std/Scalar/Ops/Sub.lean
+++ b/backends/lean/Aeneas/Std/Scalar/Ops/Sub.lean
@@ -1,12 +1,13 @@
 import Aeneas.Std.Scalar.Core
 import Aeneas.Std.Scalar.Misc
+import Aeneas.Std.Scalar.Elab
 import Aeneas.ScalarTac
 import Aeneas.Std.Core
 import Mathlib.Data.BitVec
 
 namespace Aeneas.Std
 
-open Result Error Arith
+open Result Error Arith ScalarElab
 
 /-!
 # Subtraction: Definitions
@@ -119,57 +120,12 @@ theorem IScalar.sub_bv_spec {ty} {x y : IScalar ty}
   split at h <;> simp_all [min, max]
   omega
 
-theorem Usize.sub_bv_spec {x y : Usize} (h : y.val ≤ x.val) :
+uscalar theorem «%S».sub_bv_spec {x y : «%S»} (h : y.val ≤ x.val) :
   ∃ z, x - y = ok z ∧ z.val = x.val - y.val ∧ y.val ≤ x.val ∧ z.bv = x.bv - y.bv :=
   UScalar.sub_bv_spec h
 
-theorem U8.sub_bv_spec {x y : U8} (h : y.val ≤ x.val) :
-  ∃ z, x - y = ok z ∧ z.val = x.val - y.val ∧ y.val ≤ x.val ∧ z.bv = x.bv - y.bv :=
-  UScalar.sub_bv_spec h
-
-theorem U16.sub_bv_spec {x y : U16} (h : y.val ≤ x.val) :
-  ∃ z, x - y = ok z ∧ z.val = x.val - y.val ∧ y.val ≤ x.val ∧ z.bv = x.bv - y.bv :=
-  UScalar.sub_bv_spec h
-
-theorem U32.sub_bv_spec {x y : U32} (h : y.val ≤ x.val) :
-  ∃ z, x - y = ok z ∧ z.val = x.val - y.val ∧ y.val ≤ x.val ∧ z.bv = x.bv - y.bv :=
-  UScalar.sub_bv_spec h
-
-theorem U64.sub_bv_spec {x y : U64} (h : y.val ≤ x.val) :
-  ∃ z, x - y = ok z ∧ z.val = x.val - y.val ∧ y.val ≤ x.val ∧ z.bv = x.bv - y.bv :=
-  UScalar.sub_bv_spec h
-
-theorem U128.sub_bv_spec {x y : U128} (h : y.val ≤ x.val) :
-  ∃ z, x - y = ok z ∧ z.val = x.val - y.val ∧ y.val ≤ x.val ∧ z.bv = x.bv - y.bv :=
-  UScalar.sub_bv_spec h
-
-theorem Isize.sub_bv_spec {x y : Isize}
-  (hmin : Isize.min ≤ ↑x - ↑y) (hmax : ↑x - ↑y ≤ Isize.max) :
-  ∃ z, x - y = ok z ∧ (↑z : Int) = ↑x - ↑y ∧ z.bv = x.bv - y.bv :=
-  IScalar.sub_bv_spec (by scalar_tac) (by scalar_tac)
-
-theorem I8.sub_bv_spec {x y : I8}
-  (hmin : I8.min ≤ ↑x - ↑y) (hmax : ↑x - ↑y ≤ I8.max) :
-  ∃ z, x - y = ok z ∧ (↑z : Int) = ↑x - ↑y ∧ z.bv = x.bv - y.bv :=
-  IScalar.sub_bv_spec (by scalar_tac) (by scalar_tac)
-
-theorem I16.sub_bv_spec {x y : I16}
-  (hmin : I16.min ≤ ↑x - ↑y) (hmax : ↑x - ↑y ≤ I16.max) :
-  ∃ z, x - y = ok z ∧ (↑z : Int) = ↑x - ↑y ∧ z.bv = x.bv - y.bv :=
-  IScalar.sub_bv_spec (by scalar_tac) (by scalar_tac)
-
-theorem I32.sub_bv_spec {x y : I32}
-  (hmin : I32.min ≤ ↑x - ↑y) (hmax : ↑x - ↑y ≤ I32.max) :
-  ∃ z, x - y = ok z ∧ (↑z : Int) = ↑x - ↑y ∧ z.bv = x.bv - y.bv :=
-  IScalar.sub_bv_spec (by scalar_tac) (by scalar_tac)
-
-theorem I64.sub_bv_spec {x y : I64}
-  (hmin : I64.min ≤ ↑x - ↑y) (hmax : ↑x - ↑y ≤ I64.max) :
-  ∃ z, x - y = ok z ∧ (↑z : Int) = ↑x - ↑y ∧ z.bv = x.bv - y.bv :=
-  IScalar.sub_bv_spec (by scalar_tac) (by scalar_tac)
-
-theorem I128.sub_bv_spec {x y : I128}
-  (hmin : I128.min ≤ ↑x - ↑y) (hmax : ↑x - ↑y ≤ I128.max) :
+iscalar theorem «%S».sub_bv_spec {x y : «%S»}
+  (hmin : «%S».min ≤ ↑x - ↑y) (hmax : ↑x - ↑y ≤ «%S».max) :
   ∃ z, x - y = ok z ∧ (↑z : Int) = ↑x - ↑y ∧ z.bv = x.bv - y.bv :=
   IScalar.sub_bv_spec (by scalar_tac) (by scalar_tac)
 
@@ -196,57 +152,12 @@ theorem IScalar.sub_spec {ty} {x y : IScalar ty}
   split at h <;> simp_all [min, max]
   omega
 
-@[progress] theorem Usize.sub_spec {x y : Usize} (h : y.val ≤ x.val) :
+uscalar @[progress] theorem «%S».sub_spec {x y : «%S»} (h : y.val ≤ x.val) :
   ∃ z, x - y = ok z ∧ z.val = x.val - y.val ∧ y.val ≤ x.val :=
   UScalar.sub_spec h
 
-@[progress] theorem U8.sub_spec {x y : U8} (h : y.val ≤ x.val) :
-  ∃ z, x - y = ok z ∧ z.val = x.val - y.val ∧ y.val ≤ x.val :=
-  UScalar.sub_spec h
-
-@[progress] theorem U16.sub_spec {x y : U16} (h : y.val ≤ x.val) :
-  ∃ z, x - y = ok z ∧ z.val = x.val - y.val ∧ y.val ≤ x.val :=
-  UScalar.sub_spec h
-
-@[progress] theorem U32.sub_spec {x y : U32} (h : y.val ≤ x.val) :
-  ∃ z, x - y = ok z ∧ z.val = x.val - y.val ∧ y.val ≤ x.val :=
-  UScalar.sub_spec h
-
-@[progress] theorem U64.sub_spec {x y : U64} (h : y.val ≤ x.val) :
-  ∃ z, x - y = ok z ∧ z.val = x.val - y.val ∧ y.val ≤ x.val :=
-  UScalar.sub_spec h
-
-@[progress] theorem U128.sub_spec {x y : U128} (h : y.val ≤ x.val) :
-  ∃ z, x - y = ok z ∧ z.val = x.val - y.val ∧ y.val ≤ x.val :=
-  UScalar.sub_spec h
-
-@[progress] theorem Isize.sub_spec {x y : Isize}
-  (hmin : Isize.min ≤ ↑x - ↑y) (hmax : ↑x - ↑y ≤ Isize.max) :
-  ∃ z, x - y = ok z ∧ (↑z : Int) = ↑x - ↑y :=
-  IScalar.sub_spec (by scalar_tac) (by scalar_tac)
-
-@[progress] theorem I8.sub_spec {x y : I8}
-  (hmin : I8.min ≤ ↑x - ↑y) (hmax : ↑x - ↑y ≤ I8.max) :
-  ∃ z, x - y = ok z ∧ (↑z : Int) = ↑x - ↑y :=
-  IScalar.sub_spec (by scalar_tac) (by scalar_tac)
-
-@[progress] theorem I16.sub_spec {x y : I16}
-  (hmin : I16.min ≤ ↑x - ↑y) (hmax : ↑x - ↑y ≤ I16.max) :
-  ∃ z, x - y = ok z ∧ (↑z : Int) = ↑x - ↑y :=
-  IScalar.sub_spec (by scalar_tac) (by scalar_tac)
-
-@[progress] theorem I32.sub_spec {x y : I32}
-  (hmin : I32.min ≤ ↑x - ↑y) (hmax : ↑x - ↑y ≤ I32.max) :
-  ∃ z, x - y = ok z ∧ (↑z : Int) = ↑x - ↑y :=
-  IScalar.sub_spec (by scalar_tac) (by scalar_tac)
-
-@[progress] theorem I64.sub_spec {x y : I64}
-  (hmin : I64.min ≤ ↑x - ↑y) (hmax : ↑x - ↑y ≤ I64.max) :
-  ∃ z, x - y = ok z ∧ (↑z : Int) = ↑x - ↑y :=
-  IScalar.sub_spec (by scalar_tac) (by scalar_tac)
-
-@[progress] theorem I128.sub_spec {x y : I128}
-  (hmin : I128.min ≤ ↑x - ↑y) (hmax : ↑x - ↑y ≤ I128.max) :
+iscalar @[progress] theorem «%S».sub_spec {x y : «%S»}
+  (hmin : «%S».min ≤ ↑x - ↑y) (hmax : ↑x - ↑y ≤ «%S».max) :
   ∃ z, x - y = ok z ∧ (↑z : Int) = ↑x - ↑y :=
   IScalar.sub_spec (by scalar_tac) (by scalar_tac)
 

--- a/backends/lean/Aeneas/Std/Scalar/OverflowingOps.lean
+++ b/backends/lean/Aeneas/Std/Scalar/OverflowingOps.lean
@@ -1,6 +1,9 @@
 import Aeneas.Std.Scalar.Core
+import Aeneas.Std.Scalar.Elab
 
 namespace Aeneas.Std
+
+open ScalarElab
 
 /-!
 # Overflowing Operations
@@ -16,40 +19,10 @@ def IScalar.overflowing_add (ty : IScalarTy) (x y : IScalar ty) : IScalar ty × 
      ¬ (-2^(ty.numBits -1) ≤ x.val + y.val ∧ x.val + y.val < 2^ty.numBits))
 
 /- [core::num::{u8}::overflowing_add] -/
-def core.num.U8.overflowing_add := @UScalar.overflowing_add .U8
-
-/- [core::num::{u16}::overflowing_add] -/
-def core.num.U16.overflowing_add := @UScalar.overflowing_add .U16
-
-/- [core::num::{u32}::overflowing_add] -/
-def core.num.U32.overflowing_add := @UScalar.overflowing_add .U32
-
-/- [core::num::{u64}::overflowing_add] -/
-def core.num.U64.overflowing_add := @UScalar.overflowing_add .U64
-
-/- [core::num::{u128}::overflowing_add] -/
-def core.num.U128.overflowing_add := @UScalar.overflowing_add .U128
-
-/- [core::num::{usize}::overflowing_add] -/
-def core.num.Usize.overflowing_add := @UScalar.overflowing_add .Usize
+uscalar def core.num.«%S».overflowing_add := @UScalar.overflowing_add .«%S»
 
 /- [core::num::{i8}::overflowing_add] -/
-def core.num.I8.overflowing_add := @IScalar.overflowing_add .I8
-
-/- [core::num::{i16}::overflowing_add] -/
-def core.num.I16.overflowing_add := @IScalar.overflowing_add .I16
-
-/- [core::num::{i32}::overflowing_add] -/
-def core.num.I32.overflowing_add := @IScalar.overflowing_add .I32
-
-/- [core::num::{i64}::overflowing_add] -/
-def core.num.I64.overflowing_add := @IScalar.overflowing_add .I64
-
-/- [core::num::{i128}::overflowing_add] -/
-def core.num.I128.overflowing_add := @IScalar.overflowing_add .I128
-
-/- [core::num::{isize}::overflowing_add] -/
-def core.num.Isize.overflowing_add := @IScalar.overflowing_add .Isize
+iscalar def core.num.«%S».overflowing_add := @IScalar.overflowing_add .«%S»
 
 attribute [-simp] Bool.exists_bool
 
@@ -82,45 +55,10 @@ theorem UScalar.overflowing_add_eq {ty} (x y : UScalar ty) :
       omega
     . omega
 
-@[progress_pure overflowing_add x y]
-theorem core.num.U8.overflowing_add_eq (x y : U8) :
+uscalar @[progress_pure overflowing_add x y]
+theorem core.num.«%S».overflowing_add_eq (x y : «%S») :
   let z := overflowing_add x y
-  if x.val + y.val > UScalar.max .U8 then z.fst.val + UScalar.size .U8 = x.val + y.val ∧ z.snd = true
-  else z.fst.val = x.val + y.val ∧ z.snd = false
-  := UScalar.overflowing_add_eq x y
-
-@[progress_pure overflowing_add x y]
-theorem core.num.U16.overflowing_add_eq (x y : U16) :
-  let z := overflowing_add x y
-  if x.val + y.val > UScalar.max .U16 then z.fst.val + UScalar.size .U16 = x.val + y.val ∧ z.snd = true
-  else z.fst.val = x.val + y.val ∧ z.snd = false
-  := UScalar.overflowing_add_eq x y
-
-@[progress_pure overflowing_add x y]
-theorem core.num.U32.overflowing_add_eq (x y : U32) :
-  let z := overflowing_add x y
-  if x.val + y.val > UScalar.max .U32 then z.fst.val + UScalar.size .U32 = x.val + y.val ∧ z.snd = true
-  else z.fst.val = x.val + y.val ∧ z.snd = false
-  := UScalar.overflowing_add_eq x y
-
-@[progress_pure overflowing_add x y]
-theorem core.num.U64.overflowing_add_eq (x y : U64) :
-  let z := overflowing_add x y
-  if x.val + y.val > UScalar.max .U64 then z.fst.val + UScalar.size .U64 = x.val + y.val ∧ z.snd = true
-  else z.fst.val = x.val + y.val ∧ z.snd = false
-  := UScalar.overflowing_add_eq x y
-
-@[progress_pure overflowing_add x y]
-theorem core.num.U128.overflowing_add_eq (x y : U128) :
-  let z := overflowing_add x y
-  if x.val + y.val > UScalar.max .U128 then z.fst.val + UScalar.size .U128 = x.val + y.val ∧ z.snd = true
-  else z.fst.val = x.val + y.val ∧ z.snd = false
-  := UScalar.overflowing_add_eq x y
-
-@[progress_pure overflowing_add x y]
-theorem core.num.Usize.overflowing_add_eq (x y : Usize) :
-  let z := overflowing_add x y
-  if x.val + y.val > UScalar.max .Usize then z.fst.val + UScalar.size .Usize = x.val + y.val ∧ z.snd = true
+  if x.val + y.val > UScalar.max .«%S» then z.fst.val + UScalar.size .«%S» = x.val + y.val ∧ z.snd = true
   else z.fst.val = x.val + y.val ∧ z.snd = false
   := UScalar.overflowing_add_eq x y
 

--- a/backends/lean/Aeneas/Std/Scalar/Rotate.lean
+++ b/backends/lean/Aeneas/Std/Scalar/Rotate.lean
@@ -1,6 +1,9 @@
 import Aeneas.Std.Scalar.Core
+import Aeneas.Std.Scalar.Elab
 
 namespace Aeneas.Std
+
+open ScalarElab
 
 /-!
 # Rotate
@@ -13,55 +16,15 @@ def UScalar.rotate_left {ty} (x : UScalar ty) (shift : U32) : UScalar ty :=
   ⟨ x.bv.rotateLeft shift.val ⟩
 
 /- [core::num::{u8}::rotate_left] -/
-@[progress_pure_def]
-def core.num.U8.rotate_left : U8 → U32 → U8 := @UScalar.rotate_left .U8
-
-/- [core::num::{u16}::rotate_left] -/
-@[progress_pure_def]
-def core.num.U16.rotate_left : U16 → U32 → U16 := @UScalar.rotate_left .U16
-
-/- [core::num::{u32}::rotate_left] -/
-@[progress_pure_def]
-def core.num.U32.rotate_left : U32 → U32 → U32 := @UScalar.rotate_left .U32
-
-/- [core::num::{u64}::rotate_left] -/
-@[progress_pure_def]
-def core.num.U64.rotate_left : U64 → U32 → U64 := @UScalar.rotate_left .U64
-
-/- [core::num::{u128}::rotate_left] -/
-@[progress_pure_def]
-def core.num.U128.rotate_left : U128 → U32 → U128 := @UScalar.rotate_left .U128
-
-/- [core::num::{usize}::rotate_left] -/
-@[progress_pure_def]
-def core.num.Usize.rotate_left : Usize → U32 → Usize := @UScalar.rotate_left .Usize
+uscalar @[progress_pure_def]
+def core.num.«%S».rotate_left : «%S» → U32 → «%S» := @UScalar.rotate_left .«%S»
 
 def IScalar.rotate_left {ty} (x : IScalar ty) (shift : U32) : IScalar ty :=
   ⟨ x.bv.rotateLeft shift.val ⟩
 
 /- [core::num::{u8}::rotate_left] -/
-@[progress_pure_def]
-def core.num.I8.rotate_left : I8 → U32 → I8 := @IScalar.rotate_left .I8
-
-/- [core::num::{u16}::rotate_left] -/
-@[progress_pure_def]
-def core.num.I16.rotate_left : I16 → U32 → I16 := @IScalar.rotate_left .I16
-
-/- [core::num::{u32}::rotate_left] -/
-@[progress_pure_def]
-def core.num.I32.rotate_left : I32 → U32 → I32 := @IScalar.rotate_left .I32
-
-/- [core::num::{u64}::rotate_left] -/
-@[progress_pure_def]
-def core.num.I64.rotate_left : I64 → U32 → I64 := @IScalar.rotate_left .I64
-
-/- [core::num::{u128}::rotate_left] -/
-@[progress_pure_def]
-def core.num.I128.rotate_left : I128 → U32 → I128 := @IScalar.rotate_left .I128
-
-/- [core::num::{usize}::rotate_left] -/
-@[progress_pure_def]
-def core.num.Isize.rotate_left : Isize → U32 → Isize := @IScalar.rotate_left .Isize
+iscalar @[progress_pure_def]
+def core.num.«%S».rotate_left : «%S» → U32 → «%S» := @IScalar.rotate_left .«%S»
 
 /-!
 ## Rotate Left
@@ -70,54 +33,14 @@ def UScalar.rotate_right {ty} (x : UScalar ty) (shift : U32) : UScalar ty :=
   ⟨ x.bv.rotateLeft shift.val ⟩
 
 /- [core::num::{u8}::rotate_right] -/
-@[progress_pure_def]
-def core.num.U8.rotate_right : U8 → U32 → U8 := @UScalar.rotate_right .U8
-
-/- [core::num::{u16}::rotate_right] -/
-@[progress_pure_def]
-def core.num.U16.rotate_right : U16 → U32 → U16 := @UScalar.rotate_right .U16
-
-/- [core::num::{u32}::rotate_right] -/
-@[progress_pure_def]
-def core.num.U32.rotate_right : U32 → U32 → U32 := @UScalar.rotate_right .U32
-
-/- [core::num::{u64}::rotate_right] -/
-@[progress_pure_def]
-def core.num.U64.rotate_right : U64 → U32 → U64 := @UScalar.rotate_right .U64
-
-/- [core::num::{u128}::rotate_right] -/
-@[progress_pure_def]
-def core.num.U128.rotate_right : U128 → U32 → U128 := @UScalar.rotate_right .U128
-
-/- [core::num::{usize}::rotate_right] -/
-@[progress_pure_def]
-def core.num.Usize.rotate_right : Usize → U32 → Usize := @UScalar.rotate_right .Usize
+uscalar @[progress_pure_def]
+def core.num.«%S».rotate_right : «%S» → U32 → «%S» := @UScalar.rotate_right .«%S»
 
 def IScalar.rotate_right {ty} (x : IScalar ty) (shift : U32) : IScalar ty :=
   ⟨ x.bv.rotateLeft shift.val ⟩
 
 /- [core::num::{u8}::rotate_right] -/
-@[progress_pure_def]
-def core.num.I8.rotate_right : I8 → U32 → I8 := @IScalar.rotate_right .I8
-
-/- [core::num::{u16}::rotate_right] -/
-@[progress_pure_def]
-def core.num.I16.rotate_right : I16 → U32 → I16 := @IScalar.rotate_right .I16
-
-/- [core::num::{u32}::rotate_right] -/
-@[progress_pure_def]
-def core.num.I32.rotate_right : I32 → U32 → I32 := @IScalar.rotate_right .I32
-
-/- [core::num::{u64}::rotate_right] -/
-@[progress_pure_def]
-def core.num.I64.rotate_right : I64 → U32 → I64 := @IScalar.rotate_right .I64
-
-/- [core::num::{u128}::rotate_right] -/
-@[progress_pure_def]
-def core.num.I128.rotate_right : I128 → U32 → I128 := @IScalar.rotate_right .I128
-
-/- [core::num::{usize}::rotate_right] -/
-@[progress_pure_def]
-def core.num.Isize.rotate_right : Isize → U32 → Isize := @IScalar.rotate_right .Isize
+iscalar @[progress_pure_def]
+def core.num.«%S».rotate_right : «%S» → U32 → «%S» := @IScalar.rotate_right .«%S»
 
 end Aeneas.Std

--- a/backends/lean/Aeneas/Std/Scalar/SaturatingOps.lean
+++ b/backends/lean/Aeneas/Std/Scalar/SaturatingOps.lean
@@ -1,8 +1,9 @@
 import Aeneas.Std.Scalar.Core
+import Aeneas.Std.Scalar.Elab
 
 namespace Aeneas.Std
 
-open Result Error
+open Result Error ScalarElab
 
 /-!
 # Saturating Operations
@@ -15,22 +16,7 @@ def UScalar.saturating_add {ty : UScalarTy} (x y : UScalar ty) : UScalar ty :=
   ⟨ BitVec.ofNat _ (Min.min (UScalar.max ty) (x.val + y.val)) ⟩
 
 /- [core::num::{u8}::saturating_add] -/
-def core.num.U8.saturating_add := @UScalar.saturating_add UScalarTy.U8
-
-/- [core::num::{u16}::saturating_add] -/
-def core.num.U16.saturating_add := @UScalar.saturating_add UScalarTy.U16
-
-/- [core::num::{u32}::saturating_add] -/
-def core.num.U32.saturating_add := @UScalar.saturating_add UScalarTy.U32
-
-/- [core::num::{u64}::saturating_add] -/
-def core.num.U64.saturating_add := @UScalar.saturating_add UScalarTy.U64
-
-/- [core::num::{u128}::saturating_add] -/
-def core.num.U128.saturating_add := @UScalar.saturating_add UScalarTy.U128
-
-/- [core::num::{usize}::saturating_add] -/
-def core.num.Usize.saturating_add := @UScalar.saturating_add UScalarTy.Usize
+uscalar def core.num.«%S».saturating_add := @UScalar.saturating_add UScalarTy.«%S»
 
 /-!
 Saturating add: signed
@@ -39,22 +25,7 @@ def IScalar.saturating_add {ty : IScalarTy} (x y : IScalar ty) : IScalar ty :=
   ⟨ BitVec.ofInt _ (Max.max (IScalar.min ty) (Min.min (IScalar.max ty) (x.val + y.val))) ⟩
 
 /- [core::num::{i8}::saturating_add] -/
-def core.num.I8.saturating_add := @IScalar.saturating_add IScalarTy.I8
-
-/- [core::num::{i16}::saturating_add] -/
-def core.num.I16.saturating_add := @IScalar.saturating_add IScalarTy.I16
-
-/- [core::num::{i32}::saturating_add] -/
-def core.num.I32.saturating_add := @IScalar.saturating_add IScalarTy.I32
-
-/- [core::num::{i64}::saturating_add] -/
-def core.num.I64.saturating_add := @IScalar.saturating_add IScalarTy.I64
-
-/- [core::num::{i128}::saturating_add] -/
-def core.num.I128.saturating_add := @IScalar.saturating_add IScalarTy.I128
-
-/- [core::num::{isize}::saturating_add] -/
-def core.num.Isize.saturating_add := @IScalar.saturating_add IScalarTy.Isize
+iscalar def core.num.«%S».saturating_add := @IScalar.saturating_add IScalarTy.«%S»
 
 /-!
 Saturating sub: unsigned
@@ -63,22 +34,7 @@ def UScalar.saturating_sub {ty : UScalarTy} (x y : UScalar ty) : UScalar ty :=
   ⟨ BitVec.ofNat _ (Max.max 0 (x.val - y.val)) ⟩
 
 /- [core::num::{u8}::saturating_sub] -/
-def core.num.U8.saturating_sub := @UScalar.saturating_sub UScalarTy.U8
-
-/- [core::num::{u16}::saturating_sub] -/
-def core.num.U16.saturating_sub := @UScalar.saturating_sub UScalarTy.U16
-
-/- [core::num::{u32}::saturating_sub] -/
-def core.num.U32.saturating_sub := @UScalar.saturating_sub UScalarTy.U32
-
-/- [core::num::{u64}::saturating_sub] -/
-def core.num.U64.saturating_sub := @UScalar.saturating_sub UScalarTy.U64
-
-/- [core::num::{u128}::saturating_sub] -/
-def core.num.U128.saturating_sub := @UScalar.saturating_sub UScalarTy.U128
-
-/- [core::num::{usize}::saturating_sub] -/
-def core.num.Usize.saturating_sub := @UScalar.saturating_sub UScalarTy.Usize
+uscalar def core.num.«%S».saturating_sub := @UScalar.saturating_sub UScalarTy.«%S»
 
 /-!
 Saturating sub: signed
@@ -87,21 +43,6 @@ def IScalar.saturating_sub {ty : IScalarTy} (x y : IScalar ty) : IScalar ty :=
   ⟨ BitVec.ofInt _ (Max.max (IScalar.min ty) (Min.min (IScalar.max ty) (x.val - y.val))) ⟩
 
 /- [core::num::{i8}::saturating_sub] -/
-def core.num.I8.saturating_sub := @IScalar.saturating_sub IScalarTy.I8
-
-/- [core::num::{i16}::saturating_sub] -/
-def core.num.I16.saturating_sub := @IScalar.saturating_sub IScalarTy.I16
-
-/- [core::num::{i32}::saturating_sub] -/
-def core.num.I32.saturating_sub := @IScalar.saturating_sub IScalarTy.I32
-
-/- [core::num::{i64}::saturating_sub] -/
-def core.num.I64.saturating_sub := @IScalar.saturating_sub IScalarTy.I64
-
-/- [core::num::{i128}::saturating_sub] -/
-def core.num.I128.saturating_sub := @IScalar.saturating_sub IScalarTy.I128
-
-/- [core::num::{isize}::saturating_sub] -/
-def core.num.Isize.saturating_sub := @IScalar.saturating_sub IScalarTy.Isize
+iscalar def core.num.«%S».saturating_sub := @IScalar.saturating_sub IScalarTy.«%S»
 
 end Aeneas.Std

--- a/backends/lean/Aeneas/Std/Scalar/WrappingOps/Add.lean
+++ b/backends/lean/Aeneas/Std/Scalar/WrappingOps/Add.lean
@@ -1,8 +1,10 @@
 import Aeneas.Std.Scalar.Core
+import Aeneas.Std.Scalar.Elab
 
 namespace Aeneas.Std
 
-open Result Error
+open Result Error ScalarElab
+
 /-!
 # Wrapping Add
 -/
@@ -10,110 +12,30 @@ open Result Error
 def UScalar.wrapping_add {ty} (x y : UScalar ty) : UScalar ty := ⟨ x.bv + y.bv ⟩
 
 /- [core::num::{u8}::wrapping_add] -/
-@[progress_pure_def]
-def core.num.U8.wrapping_add : U8 → U8 → U8 := @UScalar.wrapping_add UScalarTy.U8
-
-/- [core::num::{u16}::wrapping_add] -/
-@[progress_pure_def]
-def core.num.U16.wrapping_add : U16 → U16 → U16  := @UScalar.wrapping_add UScalarTy.U16
-
-/- [core::num::{u32}::wrapping_add] -/
-@[progress_pure_def]
-def core.num.U32.wrapping_add : U32 → U32 → U32  := @UScalar.wrapping_add UScalarTy.U32
-
-/- [core::num::{u64}::wrapping_add] -/
-@[progress_pure_def]
-def core.num.U64.wrapping_add : U64 → U64 → U64  := @UScalar.wrapping_add UScalarTy.U64
-
-/- [core::num::{u128}::wrapping_add] -/
-@[progress_pure_def]
-def core.num.U128.wrapping_add : U128 → U128 → U128 := @UScalar.wrapping_add UScalarTy.U128
-
-/- [core::num::{usize}::wrapping_add] -/
-@[progress_pure_def]
-def core.num.Usize.wrapping_add : Usize → Usize → Usize  := @UScalar.wrapping_add UScalarTy.Usize
+uscalar @[progress_pure_def]
+def core.num.«%S».wrapping_add : «%S» → «%S» → «%S» := @UScalar.wrapping_add UScalarTy.«%S»
 
 def IScalar.wrapping_add {ty} (x y : IScalar ty) : IScalar ty := ⟨ x.bv + y.bv ⟩
 
 /- [core::num::{i8}::wrapping_add] -/
-@[progress_pure_def]
-def core.num.I8.wrapping_add : I8 → I8 → I8  := @IScalar.wrapping_add IScalarTy.I8
-
-/- [core::num::{i16}::wrapping_add] -/
-@[progress_pure_def]
-def core.num.I16.wrapping_add : I16 → I16 → I16  := @IScalar.wrapping_add IScalarTy.I16
-
-/- [core::num::{i32}::wrapping_add] -/
-@[progress_pure_def]
-def core.num.I32.wrapping_add : I32 → I32 → I32  := @IScalar.wrapping_add IScalarTy.I32
-
-/- [core::num::{i64}::wrapping_add] -/
-@[progress_pure_def]
-def core.num.I64.wrapping_add : I64 → I64 → I64 := @IScalar.wrapping_add IScalarTy.I64
-
-/- [core::num::{i128}::wrapping_add] -/
-@[progress_pure_def]
-def core.num.I128.wrapping_add : I128 → I128 → I128  := @IScalar.wrapping_add IScalarTy.I128
-
-/- [core::num::{isize}::wrapping_add] -/
-@[progress_pure_def]
-def core.num.Isize.wrapping_add : Isize → Isize → Isize  := @IScalar.wrapping_add IScalarTy.Isize
+iscalar @[progress_pure_def]
+def core.num.«%S».wrapping_add : «%S» → «%S» → «%S»  := @IScalar.wrapping_add IScalarTy.«%S»
 
 @[simp, bvify_simps] theorem UScalar.wrapping_add_bv_eq {ty} (x y : UScalar ty) :
   (wrapping_add x y).bv = x.bv + y.bv := by
   simp [wrapping_add]
 
-@[simp, bvify_simps] theorem U8.wrapping_add_bv_eq (x y : U8) :
-  (core.num.U8.wrapping_add x y).bv = x.bv + y.bv := by
-  simp [core.num.U8.wrapping_add, bv]
-
-@[simp, bvify_simps] theorem U16.wrapping_add_bv_eq (x y : U16) :
-  (core.num.U16.wrapping_add x y).bv = x.bv + y.bv := by
-  simp [core.num.U16.wrapping_add, bv]
-
-@[simp, bvify_simps] theorem U32.wrapping_add_bv_eq (x y : U32) :
-  (core.num.U32.wrapping_add x y).bv = x.bv + y.bv := by
-  simp [core.num.U32.wrapping_add, bv]
-
-@[simp, bvify_simps] theorem U64.wrapping_add_bv_eq (x y : U64) :
-  (core.num.U64.wrapping_add x y).bv = x.bv + y.bv := by
-  simp [core.num.U64.wrapping_add, bv]
-
-@[simp, bvify_simps] theorem U128.wrapping_add_bv_eq (x y : U128) :
-  (core.num.U128.wrapping_add x y).bv = x.bv + y.bv := by
-  simp [core.num.U128.wrapping_add, bv]
-
-@[simp, bvify_simps] theorem Usize.wrapping_add_bv_eq (x y : Usize) :
-  (core.num.Usize.wrapping_add x y).bv = x.bv + y.bv := by
-  simp [core.num.Usize.wrapping_add, bv]
+uscalar @[simp, bvify_simps] theorem «%S».wrapping_add_bv_eq (x y : «%S») :
+  (core.num.«%S».wrapping_add x y).bv = x.bv + y.bv := by
+  simp [core.num.«%S».wrapping_add, bv]
 
 @[simp, bvify_simps] theorem IScalar.wrapping_add_bv_eq {ty} (x y : IScalar ty) :
   (wrapping_add x y).bv = x.bv + y.bv := by
   simp [wrapping_add]
 
-@[simp, bvify_simps] theorem I8.wrapping_add_bv_eq (x y : I8) :
-  (core.num.I8.wrapping_add x y).bv = x.bv + y.bv := by
-  simp [core.num.I8.wrapping_add, bv]
-
-@[simp, bvify_simps] theorem I16.wrapping_add_bv_eq (x y : I16) :
-  (core.num.I16.wrapping_add x y).bv = x.bv + y.bv := by
-  simp [core.num.I16.wrapping_add, bv]
-
-@[simp, bvify_simps] theorem I32.wrapping_add_bv_eq (x y : I32) :
-  (core.num.I32.wrapping_add x y).bv = x.bv + y.bv := by
-  simp [core.num.I32.wrapping_add, bv]
-
-@[simp, bvify_simps] theorem I64.wrapping_add_bv_eq (x y : I64) :
-  (core.num.I64.wrapping_add x y).bv = x.bv + y.bv := by
-  simp [core.num.I64.wrapping_add, bv]
-
-@[simp, bvify_simps] theorem I128.wrapping_add_bv_eq (x y : I128) :
-  (core.num.I128.wrapping_add x y).bv = x.bv + y.bv := by
-  simp [core.num.I128.wrapping_add, bv]
-
-@[simp, bvify_simps] theorem Isize.wrapping_add_bv_eq (x y : Isize) :
-  (core.num.Isize.wrapping_add x y).bv = x.bv + y.bv := by
-  simp [core.num.Isize.wrapping_add, bv]
+iscalar @[simp, bvify_simps] theorem «%S».wrapping_add_bv_eq (x y : «%S») :
+  (core.num.«%S».wrapping_add x y).bv = x.bv + y.bv := by
+  simp [core.num.«%S».wrapping_add, bv]
 
 @[simp] theorem UScalar.wrapping_add_val_eq {ty} (x y : UScalar ty) :
   (wrapping_add x y).val = (x.val + y.val) % (UScalar.size ty) := by
@@ -122,28 +44,8 @@ def core.num.Isize.wrapping_add : Isize → Isize → Isize  := @IScalar.wrappin
   have : 2 ^ ty.numBits - 1 + 1 = 2^ty.numBits := by omega
   simp [this]
 
-@[simp] theorem U8.wrapping_add_val_eq (x y : U8) :
-  (core.num.U8.wrapping_add x y).val = (x.val + y.val) % (UScalar.size .U8) :=
-  UScalar.wrapping_add_val_eq x y
-
-@[simp] theorem U16.wrapping_add_val_eq (x y : U16) :
-  (core.num.U16.wrapping_add x y).val = (x.val + y.val) % (UScalar.size .U16) :=
-  UScalar.wrapping_add_val_eq x y
-
-@[simp] theorem U32.wrapping_add_val_eq (x y : U32) :
-  (core.num.U32.wrapping_add x y).val = (x.val + y.val) % (UScalar.size .U32) :=
-  UScalar.wrapping_add_val_eq x y
-
-@[simp] theorem U64.wrapping_add_val_eq (x y : U64) :
-  (core.num.U64.wrapping_add x y).val = (x.val + y.val) % (UScalar.size .U64) :=
-  UScalar.wrapping_add_val_eq x y
-
-@[simp] theorem U128.wrapping_add_val_eq (x y : U128) :
-  (core.num.U128.wrapping_add x y).val = (x.val + y.val) % (UScalar.size .U128) :=
-  UScalar.wrapping_add_val_eq x y
-
-@[simp] theorem Usize.wrapping_add_val_eq (x y : Usize) :
-  (core.num.Usize.wrapping_add x y).val = (x.val + y.val) % (UScalar.size .Usize) :=
+uscalar @[simp] theorem «%S».wrapping_add_val_eq (x y : «%S») :
+  (core.num.«%S».wrapping_add x y).val = (x.val + y.val) % (UScalar.size .«%S») :=
   UScalar.wrapping_add_val_eq x y
 
 @[simp] theorem IScalar.wrapping_add_val_eq {ty} (x y : IScalar ty) :
@@ -151,28 +53,8 @@ def core.num.Isize.wrapping_add : Isize → Isize → Isize  := @IScalar.wrappin
   simp only [wrapping_add, val]
   simp
 
-@[simp] theorem I8.wrapping_add_val_eq (x y : I8) :
-  (core.num.I8.wrapping_add x y).val = Int.bmod (x.val + y.val) (2^8) :=
-  IScalar.wrapping_add_val_eq x y
-
-@[simp] theorem I16.wrapping_add_val_eq (x y : I16) :
-  (core.num.I16.wrapping_add x y).val = Int.bmod (x.val + y.val) (2^16) :=
-  IScalar.wrapping_add_val_eq x y
-
-@[simp] theorem I32.wrapping_add_val_eq (x y : I32) :
-  (core.num.I32.wrapping_add x y).val = Int.bmod (x.val + y.val) (2^32) :=
-  IScalar.wrapping_add_val_eq x y
-
-@[simp] theorem I64.wrapping_add_val_eq (x y : I64) :
-  (core.num.I64.wrapping_add x y).val = Int.bmod (x.val + y.val) (2^64) :=
-  IScalar.wrapping_add_val_eq x y
-
-@[simp] theorem I128.wrapping_add_val_eq (x y : I128) :
-  (core.num.I128.wrapping_add x y).val = Int.bmod (x.val + y.val) (2^128) :=
-  IScalar.wrapping_add_val_eq x y
-
-@[simp] theorem Isize.wrapping_add_val_eq (x y : Isize) :
-  (core.num.Isize.wrapping_add x y).val = Int.bmod (x.val + y.val) (2^System.Platform.numBits) :=
+iscalar @[simp] theorem «%S».wrapping_add_val_eq (x y : «%S») :
+  (core.num.«%S».wrapping_add x y).val = Int.bmod (x.val + y.val) (2^ %BitWidth) :=
   IScalar.wrapping_add_val_eq x y
 
 end Aeneas.Std

--- a/backends/lean/Aeneas/Std/Scalar/WrappingOps/Mul.lean
+++ b/backends/lean/Aeneas/Std/Scalar/WrappingOps/Mul.lean
@@ -1,8 +1,10 @@
 import Aeneas.Std.Scalar.Core
+import Aeneas.Std.Scalar.Elab
 
 namespace Aeneas.Std
 
-open Result Error
+open Result Error ScalarElab
+
 /-!
 # Wrapping Mul
 -/
@@ -10,110 +12,30 @@ open Result Error
 def UScalar.wrapping_mul {ty} (x y : UScalar ty) : UScalar ty := ⟨ x.bv * y.bv ⟩
 
 /- [core::num::{u8}::wrapping_mul] -/
-@[progress_pure_def]
-def core.num.U8.wrapping_mul : U8 → U8 → U8 := @UScalar.wrapping_mul UScalarTy.U8
-
-/- [core::num::{u16}::wrapping_mul] -/
-@[progress_pure_def]
-def core.num.U16.wrapping_mul : U16 → U16 → U16  := @UScalar.wrapping_mul UScalarTy.U16
-
-/- [core::num::{u32}::wrapping_mul] -/
-@[progress_pure_def]
-def core.num.U32.wrapping_mul : U32 → U32 → U32  := @UScalar.wrapping_mul UScalarTy.U32
-
-/- [core::num::{u64}::wrapping_mul] -/
-@[progress_pure_def]
-def core.num.U64.wrapping_mul : U64 → U64 → U64  := @UScalar.wrapping_mul UScalarTy.U64
-
-/- [core::num::{u128}::wrapping_mul] -/
-@[progress_pure_def]
-def core.num.U128.wrapping_mul : U128 → U128 → U128 := @UScalar.wrapping_mul UScalarTy.U128
-
-/- [core::num::{usize}::wrapping_mul] -/
-@[progress_pure_def]
-def core.num.Usize.wrapping_mul : Usize → Usize → Usize  := @UScalar.wrapping_mul UScalarTy.Usize
+uscalar @[progress_pure_def]
+def core.num.«%S».wrapping_mul : «%S» → «%S» → «%S» := @UScalar.wrapping_mul UScalarTy.«%S»
 
 def IScalar.wrapping_mul {ty} (x y : IScalar ty) : IScalar ty := ⟨ x.bv * y.bv ⟩
 
 /- [core::num::{i8}::wrapping_mul] -/
-@[progress_pure_def]
-def core.num.I8.wrapping_mul : I8 → I8 → I8  := @IScalar.wrapping_mul IScalarTy.I8
-
-/- [core::num::{i16}::wrapping_mul] -/
-@[progress_pure_def]
-def core.num.I16.wrapping_mul : I16 → I16 → I16  := @IScalar.wrapping_mul IScalarTy.I16
-
-/- [core::num::{i32}::wrapping_mul] -/
-@[progress_pure_def]
-def core.num.I32.wrapping_mul : I32 → I32 → I32  := @IScalar.wrapping_mul IScalarTy.I32
-
-/- [core::num::{i64}::wrapping_mul] -/
-@[progress_pure_def]
-def core.num.I64.wrapping_mul : I64 → I64 → I64 := @IScalar.wrapping_mul IScalarTy.I64
-
-/- [core::num::{i128}::wrapping_mul] -/
-@[progress_pure_def]
-def core.num.I128.wrapping_mul : I128 → I128 → I128  := @IScalar.wrapping_mul IScalarTy.I128
-
-/- [core::num::{isize}::wrapping_mul] -/
-@[progress_pure_def]
-def core.num.Isize.wrapping_mul : Isize → Isize → Isize  := @IScalar.wrapping_mul IScalarTy.Isize
+iscalar @[progress_pure_def]
+def core.num.«%S».wrapping_mul : «%S» → «%S» → «%S»  := @IScalar.wrapping_mul IScalarTy.«%S»
 
 @[simp, bvify_simps] theorem UScalar.wrapping_mul_bv_eq {ty} (x y : UScalar ty) :
   (wrapping_mul x y).bv = x.bv * y.bv := by
   simp [wrapping_mul]
 
-@[simp, bvify_simps] theorem U8.wrapping_mul_bv_eq (x y : U8) :
-  (core.num.U8.wrapping_mul x y).bv = x.bv * y.bv := by
-  simp [core.num.U8.wrapping_mul, bv]
-
-@[simp, bvify_simps] theorem U16.wrapping_mul_bv_eq (x y : U16) :
-  (core.num.U16.wrapping_mul x y).bv = x.bv * y.bv := by
-  simp [core.num.U16.wrapping_mul, bv]
-
-@[simp, bvify_simps] theorem U32.wrapping_mul_bv_eq (x y : U32) :
-  (core.num.U32.wrapping_mul x y).bv = x.bv * y.bv := by
-  simp [core.num.U32.wrapping_mul, bv]
-
-@[simp, bvify_simps] theorem U64.wrapping_mul_bv_eq (x y : U64) :
-  (core.num.U64.wrapping_mul x y).bv = x.bv * y.bv := by
-  simp [core.num.U64.wrapping_mul, bv]
-
-@[simp, bvify_simps] theorem U128.wrapping_mul_bv_eq (x y : U128) :
-  (core.num.U128.wrapping_mul x y).bv = x.bv * y.bv := by
-  simp [core.num.U128.wrapping_mul, bv]
-
-@[simp, bvify_simps] theorem Usize.wrapping_mul_bv_eq (x y : Usize) :
-  (core.num.Usize.wrapping_mul x y).bv = x.bv * y.bv := by
-  simp [core.num.Usize.wrapping_mul, bv]
+uscalar @[simp, bvify_simps] theorem «%S».wrapping_mul_bv_eq (x y : «%S») :
+  (core.num.«%S».wrapping_mul x y).bv = x.bv * y.bv := by
+  simp [core.num.«%S».wrapping_mul, bv]
 
 @[simp, bvify_simps] theorem IScalar.wrapping_mul_bv_eq {ty} (x y : IScalar ty) :
   (wrapping_mul x y).bv = x.bv * y.bv := by
   simp [wrapping_mul]
 
-@[simp, bvify_simps] theorem I8.wrapping_mul_bv_eq (x y : I8) :
-  (core.num.I8.wrapping_mul x y).bv = x.bv * y.bv := by
-  simp [core.num.I8.wrapping_mul, bv]
-
-@[simp, bvify_simps] theorem I16.wrapping_mul_bv_eq (x y : I16) :
-  (core.num.I16.wrapping_mul x y).bv = x.bv * y.bv := by
-  simp [core.num.I16.wrapping_mul, bv]
-
-@[simp, bvify_simps] theorem I32.wrapping_mul_bv_eq (x y : I32) :
-  (core.num.I32.wrapping_mul x y).bv = x.bv * y.bv := by
-  simp [core.num.I32.wrapping_mul, bv]
-
-@[simp, bvify_simps] theorem I64.wrapping_mul_bv_eq (x y : I64) :
-  (core.num.I64.wrapping_mul x y).bv = x.bv * y.bv := by
-  simp [core.num.I64.wrapping_mul, bv]
-
-@[simp, bvify_simps] theorem I128.wrapping_mul_bv_eq (x y : I128) :
-  (core.num.I128.wrapping_mul x y).bv = x.bv * y.bv := by
-  simp [core.num.I128.wrapping_mul, bv]
-
-@[simp, bvify_simps] theorem Isize.wrapping_mul_bv_eq (x y : Isize) :
-  (core.num.Isize.wrapping_mul x y).bv = x.bv * y.bv := by
-  simp [core.num.Isize.wrapping_mul, bv]
+iscalar @[simp, bvify_simps] theorem «%S».wrapping_mul_bv_eq (x y : «%S») :
+  (core.num.«%S».wrapping_mul x y).bv = x.bv * y.bv := by
+  simp [core.num.«%S».wrapping_mul, bv]
 
 @[simp] theorem UScalar.wrapping_mul_val_eq {ty} (x y : UScalar ty) :
   (wrapping_mul x y).val = (x.val * y.val) % (UScalar.size ty) := by
@@ -122,28 +44,8 @@ def core.num.Isize.wrapping_mul : Isize → Isize → Isize  := @IScalar.wrappin
   have : 2 ^ ty.numBits - 1 + 1 = 2^ty.numBits := by omega
   simp [this]
 
-@[simp] theorem U8.wrapping_mul_val_eq (x y : U8) :
-  (core.num.U8.wrapping_mul x y).val = (x.val * y.val) % (UScalar.size .U8) :=
-  UScalar.wrapping_mul_val_eq x y
-
-@[simp] theorem U16.wrapping_mul_val_eq (x y : U16) :
-  (core.num.U16.wrapping_mul x y).val = (x.val * y.val) % (UScalar.size .U16) :=
-  UScalar.wrapping_mul_val_eq x y
-
-@[simp] theorem U32.wrapping_mul_val_eq (x y : U32) :
-  (core.num.U32.wrapping_mul x y).val = (x.val * y.val) % (UScalar.size .U32) :=
-  UScalar.wrapping_mul_val_eq x y
-
-@[simp] theorem U64.wrapping_mul_val_eq (x y : U64) :
-  (core.num.U64.wrapping_mul x y).val = (x.val * y.val) % (UScalar.size .U64) :=
-  UScalar.wrapping_mul_val_eq x y
-
-@[simp] theorem U128.wrapping_mul_val_eq (x y : U128) :
-  (core.num.U128.wrapping_mul x y).val = (x.val * y.val) % (UScalar.size .U128) :=
-  UScalar.wrapping_mul_val_eq x y
-
-@[simp] theorem Usize.wrapping_mul_val_eq (x y : Usize) :
-  (core.num.Usize.wrapping_mul x y).val = (x.val * y.val) % (UScalar.size .Usize) :=
+uscalar @[simp] theorem «%S».wrapping_mul_val_eq (x y : «%S») :
+  (core.num.«%S».wrapping_mul x y).val = (x.val * y.val) % (UScalar.size .«%S») :=
   UScalar.wrapping_mul_val_eq x y
 
 @[simp] theorem IScalar.wrapping_mul_val_eq {ty} (x y : IScalar ty) :
@@ -151,28 +53,8 @@ def core.num.Isize.wrapping_mul : Isize → Isize → Isize  := @IScalar.wrappin
   simp only [wrapping_mul, val]
   simp
 
-@[simp] theorem I8.wrapping_mul_val_eq (x y : I8) :
-  (core.num.I8.wrapping_mul x y).val = Int.bmod (x.val * y.val) (2^8) :=
-  IScalar.wrapping_mul_val_eq x y
-
-@[simp] theorem I16.wrapping_mul_val_eq (x y : I16) :
-  (core.num.I16.wrapping_mul x y).val = Int.bmod (x.val * y.val) (2^16) :=
-  IScalar.wrapping_mul_val_eq x y
-
-@[simp] theorem I32.wrapping_mul_val_eq (x y : I32) :
-  (core.num.I32.wrapping_mul x y).val = Int.bmod (x.val * y.val) (2^32) :=
-  IScalar.wrapping_mul_val_eq x y
-
-@[simp] theorem I64.wrapping_mul_val_eq (x y : I64) :
-  (core.num.I64.wrapping_mul x y).val = Int.bmod (x.val * y.val) (2^64) :=
-  IScalar.wrapping_mul_val_eq x y
-
-@[simp] theorem I128.wrapping_mul_val_eq (x y : I128) :
-  (core.num.I128.wrapping_mul x y).val = Int.bmod (x.val * y.val) (2^128) :=
-  IScalar.wrapping_mul_val_eq x y
-
-@[simp] theorem Isize.wrapping_mul_val_eq (x y : Isize) :
-  (core.num.Isize.wrapping_mul x y).val = Int.bmod (x.val * y.val) (2^System.Platform.numBits) :=
+iscalar @[simp] theorem «%S».wrapping_mul_val_eq (x y : «%S») :
+  (core.num.«%S».wrapping_mul x y).val = Int.bmod (x.val * y.val) (2^ %BitWidth) :=
   IScalar.wrapping_mul_val_eq x y
 
 end Aeneas.Std

--- a/backends/lean/Aeneas/Std/Scalar/WrappingOps/Sub.lean
+++ b/backends/lean/Aeneas/Std/Scalar/WrappingOps/Sub.lean
@@ -1,8 +1,9 @@
 import Aeneas.Std.Scalar.Core
+import Aeneas.Std.Scalar.Elab
 
 namespace Aeneas.Std
 
-open Result Error
+open Result Error ScalarElab
 
 /-!
 # Wrapping Sub
@@ -11,110 +12,30 @@ open Result Error
 def UScalar.wrapping_sub {ty} (x y : UScalar ty) : UScalar ty := ⟨ x.bv - y.bv ⟩
 
 /- [core::num::{u8}::wrapping_sub] -/
-@[progress_pure_def]
-def core.num.U8.wrapping_sub : U8 → U8 → U8 := @UScalar.wrapping_sub UScalarTy.U8
-
-/- [core::num::{u16}::wrapping_sub] -/
-@[progress_pure_def]
-def core.num.U16.wrapping_sub : U16 → U16 → U16  := @UScalar.wrapping_sub UScalarTy.U16
-
-/- [core::num::{u32}::wrapping_sub] -/
-@[progress_pure_def]
-def core.num.U32.wrapping_sub : U32 → U32 → U32  := @UScalar.wrapping_sub UScalarTy.U32
-
-/- [core::num::{u64}::wrapping_sub] -/
-@[progress_pure_def]
-def core.num.U64.wrapping_sub : U64 → U64 → U64  := @UScalar.wrapping_sub UScalarTy.U64
-
-/- [core::num::{u128}::wrapping_sub] -/
-@[progress_pure_def]
-def core.num.U128.wrapping_sub : U128 → U128 → U128 := @UScalar.wrapping_sub UScalarTy.U128
-
-/- [core::num::{usize}::wrapping_sub] -/
-@[progress_pure_def]
-def core.num.Usize.wrapping_sub : Usize → Usize → Usize  := @UScalar.wrapping_sub UScalarTy.Usize
+uscalar @[progress_pure_def]
+def core.num.«%S».wrapping_sub : «%S» → «%S» → «%S» := @UScalar.wrapping_sub UScalarTy.«%S»
 
 def IScalar.wrapping_sub {ty} (x y : IScalar ty) : IScalar ty := ⟨ x.bv - y.bv ⟩
 
 /- [core::num::{i8}::wrapping_sub] -/
-@[progress_pure_def]
-def core.num.I8.wrapping_sub : I8 → I8 → I8  := @IScalar.wrapping_sub IScalarTy.I8
-
-/- [core::num::{i16}::wrapping_sub] -/
-@[progress_pure_def]
-def core.num.I16.wrapping_sub : I16 → I16 → I16  := @IScalar.wrapping_sub IScalarTy.I16
-
-/- [core::num::{i32}::wrapping_sub] -/
-@[progress_pure_def]
-def core.num.I32.wrapping_sub : I32 → I32 → I32  := @IScalar.wrapping_sub IScalarTy.I32
-
-/- [core::num::{i64}::wrapping_sub] -/
-@[progress_pure_def]
-def core.num.I64.wrapping_sub : I64 → I64 → I64 := @IScalar.wrapping_sub IScalarTy.I64
-
-/- [core::num::{i128}::wrapping_sub] -/
-@[progress_pure_def]
-def core.num.I128.wrapping_sub : I128 → I128 → I128  := @IScalar.wrapping_sub IScalarTy.I128
-
-/- [core::num::{isize}::wrapping_sub] -/
-@[progress_pure_def]
-def core.num.Isize.wrapping_sub : Isize → Isize → Isize  := @IScalar.wrapping_sub IScalarTy.Isize
+iscalar @[progress_pure_def]
+def core.num.«%S».wrapping_sub : «%S» → «%S» → «%S»  := @IScalar.wrapping_sub IScalarTy.«%S»
 
 @[simp, bvify_simps] theorem UScalar.wrapping_sub_bv_eq {ty} (x y : UScalar ty) :
   (wrapping_sub x y).bv = x.bv - y.bv := by
   simp [wrapping_sub]
 
-@[simp, bvify_simps] theorem U8.wrapping_sub_bv_eq (x y : U8) :
-  (core.num.U8.wrapping_sub x y).bv = x.bv - y.bv := by
-  simp [core.num.U8.wrapping_sub, bv]
-
-@[simp, bvify_simps] theorem U16.wrapping_sub_bv_eq (x y : U16) :
-  (core.num.U16.wrapping_sub x y).bv = x.bv - y.bv := by
-  simp [core.num.U16.wrapping_sub, bv]
-
-@[simp, bvify_simps] theorem U32.wrapping_sub_bv_eq (x y : U32) :
-  (core.num.U32.wrapping_sub x y).bv = x.bv - y.bv := by
-  simp [core.num.U32.wrapping_sub, bv]
-
-@[simp, bvify_simps] theorem U64.wrapping_sub_bv_eq (x y : U64) :
-  (core.num.U64.wrapping_sub x y).bv = x.bv - y.bv := by
-  simp [core.num.U64.wrapping_sub, bv]
-
-@[simp, bvify_simps] theorem U128.wrapping_sub_bv_eq (x y : U128) :
-  (core.num.U128.wrapping_sub x y).bv = x.bv - y.bv := by
-  simp [core.num.U128.wrapping_sub, bv]
-
-@[simp, bvify_simps] theorem Usize.wrapping_sub_bv_eq (x y : Usize) :
-  (core.num.Usize.wrapping_sub x y).bv = x.bv - y.bv := by
-  simp [core.num.Usize.wrapping_sub, bv]
+uscalar @[simp, bvify_simps] theorem «%S».wrapping_sub_bv_eq (x y : «%S») :
+  (core.num.«%S».wrapping_sub x y).bv = x.bv - y.bv := by
+  simp [core.num.«%S».wrapping_sub, bv]
 
 @[simp, bvify_simps] theorem IScalar.wrapping_sub_bv_eq {ty} (x y : IScalar ty) :
   (wrapping_sub x y).bv = x.bv - y.bv := by
   simp [wrapping_sub]
 
-@[simp, bvify_simps] theorem I8.wrapping_sub_bv_eq (x y : I8) :
-  (core.num.I8.wrapping_sub x y).bv = x.bv - y.bv := by
-  simp [core.num.I8.wrapping_sub, bv]
-
-@[simp, bvify_simps] theorem I16.wrapping_sub_bv_eq (x y : I16) :
-  (core.num.I16.wrapping_sub x y).bv = x.bv - y.bv := by
-  simp [core.num.I16.wrapping_sub, bv]
-
-@[simp, bvify_simps] theorem I32.wrapping_sub_bv_eq (x y : I32) :
-  (core.num.I32.wrapping_sub x y).bv = x.bv - y.bv := by
-  simp [core.num.I32.wrapping_sub, bv]
-
-@[simp, bvify_simps] theorem I64.wrapping_sub_bv_eq (x y : I64) :
-  (core.num.I64.wrapping_sub x y).bv = x.bv - y.bv := by
-  simp [core.num.I64.wrapping_sub, bv]
-
-@[simp, bvify_simps] theorem I128.wrapping_sub_bv_eq (x y : I128) :
-  (core.num.I128.wrapping_sub x y).bv = x.bv - y.bv := by
-  simp [core.num.I128.wrapping_sub, bv]
-
-@[simp, bvify_simps] theorem Isize.wrapping_sub_bv_eq (x y : Isize) :
-  (core.num.Isize.wrapping_sub x y).bv = x.bv - y.bv := by
-  simp [core.num.Isize.wrapping_sub, bv]
+iscalar @[simp, bvify_simps] theorem «%S».wrapping_sub_bv_eq (x y : «%S») :
+  (core.num.«%S».wrapping_sub x y).bv = x.bv - y.bv := by
+  simp [core.num.«%S».wrapping_sub, bv]
 
 @[simp] theorem UScalar.wrapping_sub_val_eq {ty} (x y : UScalar ty) :
   (wrapping_sub x y).val = (x.val + (UScalar.size ty - y.val)) % UScalar.size ty := by
@@ -124,28 +45,8 @@ def core.num.Isize.wrapping_sub : Isize → Isize → Isize  := @IScalar.wrappin
   simp [this]
   ring_nf
 
-@[simp] theorem U8.wrapping_sub_val_eq (x y : U8) :
-  (core.num.U8.wrapping_sub x y).val = (x.val + (UScalar.size .U8 - y.val)) % UScalar.size .U8 :=
-  UScalar.wrapping_sub_val_eq x y
-
-@[simp] theorem U16.wrapping_sub_val_eq (x y : U16) :
-  (core.num.U16.wrapping_sub x y).val = (x.val + (UScalar.size .U16 - y.val)) % UScalar.size .U16 :=
-  UScalar.wrapping_sub_val_eq x y
-
-@[simp] theorem U32.wrapping_sub_val_eq (x y : U32) :
-  (core.num.U32.wrapping_sub x y).val = (x.val + (UScalar.size .U32 - y.val)) % UScalar.size .U32 :=
-  UScalar.wrapping_sub_val_eq x y
-
-@[simp] theorem U64.wrapping_sub_val_eq (x y : U64) :
-  (core.num.U64.wrapping_sub x y).val = (x.val + (UScalar.size .U64 - y.val)) % UScalar.size .U64 :=
-  UScalar.wrapping_sub_val_eq x y
-
-@[simp] theorem U128.wrapping_sub_val_eq (x y : U128) :
-  (core.num.U128.wrapping_sub x y).val = (x.val + (UScalar.size .U128 - y.val)) % UScalar.size .U128 :=
-  UScalar.wrapping_sub_val_eq x y
-
-@[simp] theorem Usize.wrapping_sub_val_eq (x y : Usize) :
-  (core.num.Usize.wrapping_sub x y).val = (x.val + (UScalar.size .Usize - y.val)) % UScalar.size .Usize :=
+uscalar @[simp] theorem «%S».wrapping_sub_val_eq (x y : «%S») :
+  (core.num.«%S».wrapping_sub x y).val = (x.val + (UScalar.size .«%S» - y.val)) % UScalar.size .«%S» :=
   UScalar.wrapping_sub_val_eq x y
 
 @[simp] theorem IScalar.wrapping_sub_val_eq {ty} (x y : IScalar ty) :
@@ -153,28 +54,8 @@ def core.num.Isize.wrapping_sub : Isize → Isize → Isize  := @IScalar.wrappin
   simp only [wrapping_sub, val]
   simp
 
-@[simp] theorem I8.wrapping_sub_val_eq (x y : I8) :
-  (core.num.I8.wrapping_sub x y).val = Int.bmod (x.val - y.val) (2^8) :=
-  IScalar.wrapping_sub_val_eq x y
-
-@[simp] theorem I16.wrapping_sub_val_eq (x y : I16) :
-  (core.num.I16.wrapping_sub x y).val = Int.bmod (x.val - y.val) (2^16) :=
-  IScalar.wrapping_sub_val_eq x y
-
-@[simp] theorem I32.wrapping_sub_val_eq (x y : I32) :
-  (core.num.I32.wrapping_sub x y).val = Int.bmod (x.val - y.val) (2^32) :=
-  IScalar.wrapping_sub_val_eq x y
-
-@[simp] theorem I64.wrapping_sub_val_eq (x y : I64) :
-  (core.num.I64.wrapping_sub x y).val = Int.bmod (x.val - y.val) (2^64) :=
-  IScalar.wrapping_sub_val_eq x y
-
-@[simp] theorem I128.wrapping_sub_val_eq (x y : I128) :
-  (core.num.I128.wrapping_sub x y).val = Int.bmod (x.val - y.val) (2^128) :=
-  IScalar.wrapping_sub_val_eq x y
-
-@[simp] theorem Isize.wrapping_sub_val_eq (x y : Isize) :
-  (core.num.Isize.wrapping_sub x y).val = Int.bmod (x.val - y.val) (2^System.Platform.numBits) :=
+iscalar @[simp] theorem «%S».wrapping_sub_val_eq (x y : «%S») :
+  (core.num.«%S».wrapping_sub x y).val = Int.bmod (x.val - y.val) (2^ %BitWidth) :=
   IScalar.wrapping_sub_val_eq x y
 
 end Aeneas.Std


### PR DESCRIPTION
This PR introduces several macros to factor out the scalar definitions and theorems.
For instance, the following command:
```lean
uscalar @[progress] theorem «%S».ShiftRight_spec {ty1} (x : «%S») (y : UScalar ty1) (hy : y.val < %BitWidth) :
  ∃ (z : «%S»), x >>> y = ok z ∧ z.val = x.val >>> y.val ∧ z.bv = x.bv >>> y.val
  := by apply UScalar.ShiftRight_spec; simp [*]
```

gets elaborated to:
```lean
@[progress] theorem U8.ShiftRight_spec {ty1} (x : U8) (y : UScalar ty1) (hy : y.val < 8) :
  ∃ (z : U8), x >>> y = ok z ∧ z.val = x.val >>> y.val ∧ z.bv = x.bv >>> y.val
  := by apply UScalar.ShiftRight_spec; simp [*]

... -- theorems for U16, etc.

@[progress] theorem Usize.ShiftRight_spec {ty1} (x : Usize) (y : UScalar ty1) (hy : y.val < System.Platform.numBits) :
  ∃ (z : Usize), x >>> y = ok z ∧ z.val = x.val >>> y.val ∧ z.bv = x.bv >>> y.val
  := by apply UScalar.ShiftRight_spec; simp [*]
```