### PR TITLE
Improve the saturate tactic to allow using theorems with preconditions

### DIFF
--- a/backends/lean/Aeneas/Arith/Lemmas.lean
+++ b/backends/lean/Aeneas/Arith/Lemmas.lean
@@ -32,14 +32,14 @@ theorem Nat.not_eq_imp_not_eq {i j} : Nat.not_eq i j → i ≠ j := by
   simp_all
 
 
-@[nonlin_scalar_tac n % m]
+@[scalar_tac_nonlin n % m]
 theorem Nat.mod_zero_or_lt (n m : Nat) : m = 0 ∨ (n % m < m) := by
   dcases h: m = 0
   . simp [h]
   . right
     apply Nat.mod_lt; omega
 
-@[nonlin_scalar_tac n / m]
+@[scalar_tac_nonlin n / m]
 theorem Nat.div_zero_or_le (n m : Nat) : m = 0 ∨ (n / m ≤ n) := by
   dcases h: m = 0 <;> simp [*]
   apply Nat.div_le_self
@@ -60,7 +60,7 @@ theorem Int.self_le_ediv {x y : ℤ} (hx : x ≤ 0) (hy : 0 ≤ y) :
       omega
   . simp_all
 
-@[nonlin_scalar_tac n % m]
+@[scalar_tac_nonlin n % m]
 theorem Int.emod_neg_or_pos_lt (n m : Int) : m ≤ 0 ∨ (0 ≤ n % m ∧ n % m < m) := by
   if h: 0 < m then
     right; constructor
@@ -68,7 +68,7 @@ theorem Int.emod_neg_or_pos_lt (n m : Int) : m ≤ 0 ∨ (0 ≤ n % m ∧ n % m 
     . apply Int.emod_lt_of_pos; omega
   else left; omega
 
-@[nonlin_scalar_tac n / m]
+@[scalar_tac_nonlin n / m]
 theorem Int.div_neg_or_pos_le (n m : Int) : n < 0 ∨ m < 0 ∨ (0 ≤ n / m ∧ n / m ≤ n) := by
   dcases hn: 0 ≤ n <;> dcases hm: 0 ≤ m <;> try simp_all
   right; right; constructor
@@ -80,7 +80,7 @@ theorem Int.pos_mul_pos_is_pos (n m : Int) (hm : 0 ≤ m) (hn : 0 ≤ n): 0 ≤ 
   rw [h]
   apply mul_le_mul <;> norm_cast
 
-@[nonlin_scalar_tac m * n]
+@[scalar_tac_nonlin m * n]
 theorem Int.pos_mul_pos_is_pos_disj (n m : Int) : m < 0 ∨ n < 0 ∨ 0 ≤ m * n := by
   cases h: (m < 0 : Bool) <;> simp_all
   cases h: (n < 0 : Bool) <;> simp_all

--- a/backends/lean/Aeneas/Progress/Progress.lean
+++ b/backends/lean/Aeneas/Progress/Progress.lean
@@ -549,7 +549,7 @@ def evalProgress (keep keepPretty : Option Name) (withArg: Option Expr) (ids: Ar
     if ← ScalarTac.goalIsLinearInt then
       /- Also: we don't try to split the goal if it is a conjunction
          (it shouldn't be), but we split the disjunctions. -/
-      ScalarTac.scalarTac { split := false, fastSaturate := true }
+      ScalarTac.scalarTac { split := false }
     else
       throwError "Not a linear arithmetic goal"
   let simpLemmas ← Aeneas.ScalarTac.scalarTacSimpExt.getTheorems

--- a/backends/lean/Aeneas/Progress/Progress.lean
+++ b/backends/lean/Aeneas/Progress/Progress.lean
@@ -577,7 +577,7 @@ def evalProgress (keep keepPretty : Option Name) (withArg: Option Expr) (ids: Ar
     withMainContext do
     trace[Progress] "trying to solve precondition: {← getMainGoal}"
     try
-      firstTac ([simpTac, scalarTac] ++ byTac)
+      firstTacSolve ([simpTac, scalarTac] ++ byTac)
       trace[Progress] "Precondition solved!"
     catch _ =>
       trace[Progress] "Precondition not solved")

--- a/backends/lean/Aeneas/Range/Notations.lean
+++ b/backends/lean/Aeneas/Range/Notations.lean
@@ -1,9 +1,11 @@
+import Aeneas.ScalarTac.ScalarTac
+
 namespace Aeneas.Notations.Range
 
 scoped syntax "aeneas_range_tactic" : tactic
 
 -- The default tactic to discharge proof obligations related to ranges
 macro_rules
-| `(tactic| aeneas_range_tactic) => `(tactic| decide)
+| `(tactic| aeneas_range_tactic) => `(tactic| first | decide | scalar_tac)
 
 end Aeneas.Notations.Range

--- a/backends/lean/Aeneas/Saturate/Tactic.lean
+++ b/backends/lean/Aeneas/Saturate/Tactic.lean
@@ -598,7 +598,9 @@ partial def evalSaturate {α}
             let path := AsmPath.asm x.fvarId!
             let assumptions := assumptions.insert thTy path
             addAux (i + 1) assumptions allFVars newFVars
-      else f allFVars newFVars assumptions
+      else
+        trace[Saturate] "Goal after introducing the assumptions: {← getMainGoal}"
+        f allFVars newFVars assumptions
     addAux 0 state.assumptions allFVars #[]
 
   -- We do this in several passes: we add the assumptions, then explore the context again to saturate, etc.
@@ -618,7 +620,7 @@ partial def evalSaturate {α}
         -- We're done
         next allFVars
       else
-        trace[Saturate] "state.pmatches: {state.pmatches.toArray.map Prod.snd}"
+        trace[Saturate] "state.pmatches (num of partial matches: {state.pmatches.size}):\n{state.pmatches.toArray.map Prod.snd}"
         trace[Saturate] "state.assumptions: {state.assumptions.toArray}"
         let oldAssumptions := state.assumptions
         let mut state := { state with assumptions, matched := Std.HashSet.emptyWithCapacity }

--- a/backends/lean/Aeneas/Saturate/Tactic.lean
+++ b/backends/lean/Aeneas/Saturate/Tactic.lean
@@ -243,11 +243,8 @@ def matchExprWithRules
     for rule in exprs do
       trace[Saturate.explore] "Checking potential match: {rule}"
       -- Check if the theorem is still active
-      let some activeRule := rules.nameToRule.find? rule.thName
-        | trace[Saturate.explore] "The rule is not active"; continue
-      -- Check that the patterns are the same - we uniquely identify them with their source information
-      unless activeRule.src == rule.src do
-         continue
+      if rules.deactivatedRules.contains rule.thName then
+        trace[Saturate.explore] "The rule is not active"; continue
       -- Retrieve the first pattern
       let (pat, patterns) ← do
         match rule.patterns.toList with

--- a/backends/lean/Aeneas/ScalarDecrTac.lean
+++ b/backends/lean/Aeneas/ScalarDecrTac.lean
@@ -62,7 +62,7 @@ macro_rules
       -- Simplify the context - otherwise simp_all below will blow up
       remove_invImage_assumptions <;>
       -- Finish
-      scalar_tac +fastSaturate)
+      scalar_tac)
 
 -- This simplification lemma it is useful for the proofs of termination
 attribute [scalar_tac_simps, simp] Prod.lex_iff

--- a/backends/lean/Aeneas/ScalarTac/CondSimpTac.lean
+++ b/backends/lean/Aeneas/ScalarTac/CondSimpTac.lean
@@ -111,7 +111,7 @@ def condSimpTac
   /- Introduce the scalar_tac assumptions - by doing this beforehand we don't have to
      redo it every time we call `scalar_tac`. TODO: also do the `simp_all`. -/
   withMainContext do
-  ScalarTac.scalarTacSaturateForward { fastSaturate := true, nonLin := satNonLin } fun scalarTacAsms => do
+  ScalarTac.scalarTacSaturateForward { nonLin := satNonLin } fun scalarTacAsms => do
   trace[CondSimpTac] "Goal after saturating the context: {← getMainGoal}"
   let additionalSimpThms ← addSimpThms
   trace[CondSimpTac] "Goal after adding the additional simp assumptions: {← getMainGoal}"

--- a/backends/lean/Aeneas/ScalarTac/CondSimpTac.lean
+++ b/backends/lean/Aeneas/ScalarTac/CondSimpTac.lean
@@ -5,6 +5,12 @@ namespace Aeneas.ScalarTac
 open Lean Lean.Meta Lean.Parser.Tactic Lean.Elab.Tactic
 open Utils
 
+structure CondSimpTacConfig where
+  nonLin : Bool := false
+  saturationPasses := 3
+
+declare_config_elab elabCondSimpTacConfig CondSimpTacConfig
+
 structure CondSimpPartialArgs where
   declsToUnfold : Array Name := #[]
   addSimpThms : Array Name := #[]
@@ -89,8 +95,9 @@ def condSimpTacSimp (config : Simp.Config) (args : CondSimpArgs) (loc : Utils.Lo
 
 /-- A helper to define tactics which perform conditional simplifications with `scalar_tac` as a discharger. -/
 def condSimpTac
-  (tacName : String) (satNonLin : Bool)
-  (simpConfig : Simp.Config) (args : CondSimpArgs) (addSimpThms : TacticM (Array FVarId)) (doFirstSimp : Bool)
+  (tacName : String) (config : CondSimpTacConfig)
+  (simpConfig : Simp.Config) (args : CondSimpArgs)
+  (addSimpThms : TacticM (Array FVarId)) (doFirstSimp : Bool)
   (loc : Utils.Location) : TacticM Unit := do
   Elab.Tactic.focus do
   withMainContext do
@@ -111,7 +118,8 @@ def condSimpTac
   /- Introduce the scalar_tac assumptions - by doing this beforehand we don't have to
      redo it every time we call `scalar_tac`. TODO: also do the `simp_all`. -/
   withMainContext do
-  ScalarTac.scalarTacSaturateForward { nonLin := satNonLin } fun scalarTacAsms => do
+  ScalarTac.scalarTacSaturateForward { nonLin := config.nonLin, saturationPasses := config.saturationPasses }
+    fun scalarTacAsms => do
   trace[CondSimpTac] "Goal after saturating the context: {← getMainGoal}"
   let additionalSimpThms ← addSimpThms
   trace[CondSimpTac] "Goal after adding the additional simp assumptions: {← getMainGoal}"

--- a/backends/lean/Aeneas/ScalarTac/Lemmas.lean
+++ b/backends/lean/Aeneas/ScalarTac/Lemmas.lean
@@ -289,7 +289,7 @@ private def c : Nat := 100
 @[local scalar_tac x * c]
 private theorem mul_c (x : Nat) : x * c ≤ 100 * x := by simp [c]; omega
 
-example (x : Nat) : x * c ≤ 100 * x := by scalar_tac
+example (x : Nat) : x * c ≤ 100 * x := by scalar_tac_preprocess
 
 end
 
@@ -365,6 +365,74 @@ theorem lt_mul_le_le (x y a b : ℕ) (h0 : x < a) (h1 : y ≤ b) :
 @[scalar_tac x * y]
 theorem le_mul_le_le (x y a b : ℕ) (h0 : x ≤ a) (h1 : y ≤ b) :
   x * y ≤ a * b := by apply Nat.le_mul_le; omega
+
+/-!
+Not activating those lemmas for now, because there are a lot of them
+and it leads to performance issues.
+TODO: experiment with lemmas for non linear goals.
+-/
+
+--@[scalar_tac_nonlin a * b]
+theorem lt_mul_lt_le' (x y a b : ℕ) (h0 : x < a) (h1 : y < b) :
+  (x + 1) * (y + 1) ≤ a * b := by apply Nat.le_mul_le; omega
+
+--@[scalar_tac_nonlin a * b]
+theorem le_mul_lt_le' (x y a b : ℕ) (h0 : x ≤ a) (h1 : y < b) :
+  x * (y + 1) ≤ a * b := by apply Nat.le_mul_le; omega
+
+--@[scalar_tac_nonlin a * b]
+theorem lt_mul_le_le' (x y a b : ℕ) (h0 : x < a) (h1 : y ≤ b) :
+  (x + 1) * y ≤ a * b := by apply Nat.le_mul_le; omega
+
+--@[scalar_tac_nonlin a * b]
+theorem le_mul_le_le' (x y a b : ℕ) (h0 : x ≤ a) (h1 : y ≤ b) :
+  x * y ≤ a * b := by apply Nat.le_mul_le; omega
+
+--@[scalar_tac_nonlin x * y]
+theorem lt_mul_le_left (x y a : ℕ) (h0 : x < a) :
+  x * y ≤ (a - 1) * y := by apply Nat.le_mul_le; omega
+
+--@[scalar_tac_nonlin x * b]
+theorem lt_mul_lt_left (x a b : ℕ) (h0 : x < a) :
+  x * b + b ≤ a * b := by
+  calc
+    x * b + b = (x + 1) * b := by ring_nf
+    _ ≤ a * b := by apply Nat.le_mul_le; omega
+
+--@[scalar_tac_nonlin x * y]
+theorem lt_mul_le_right (x y a : ℕ) (h0 : y < a) :
+  x * y ≤ x * (a - 1) := by apply Nat.le_mul_le; omega
+
+--@[scalar_tac_nonlin a * y]
+theorem lt_mul_lt_right (y a b : ℕ) (h0 : y < b) :
+  a * y + a ≤ a * b := by
+  calc
+    a * y + a = a * (y + 1) := by ring_nf
+    _ ≤ a * b := by apply Nat.le_mul_le; omega
+
+--@[scalar_tac_nonlin x * y]
+theorem le_mul_le_left (x y a : ℕ) (h0 : x ≤ a) :
+  x * y ≤ a * y := by apply Nat.le_mul_le; omega
+
+--@[scalar_tac_nonlin x * y]
+theorem le_mul_le_right (x y a : ℕ) (h0 : y ≤ a) :
+  x * y ≤ x * a := by apply Nat.le_mul_le; omega
+
+/-
+example (i j n1 n2 : ℕ)
+  (hi : i < n1)
+  (hj : j < n2) :
+  i * n2 + j < n1 * n2
+  := by
+  scalar_tac +nonLin
+
+example (i j n1 n2 : ℕ)
+  (hi : i < n1)
+  (hj : j < n2) :
+  n1 * j + i < n1 * n2
+  := by
+  scalar_tac +nonLin
+-/
 
 /-!
 # Modulo

--- a/backends/lean/Aeneas/ScalarTac/Lemmas.lean
+++ b/backends/lean/Aeneas/ScalarTac/Lemmas.lean
@@ -317,6 +317,10 @@ attribute [scalar_tac_simps] Set.Mem
 /-!
 # Subtypes
 -/
+@[scalar_tac x.val]
+theorem subtype_property {α : Sort u} (p : α → Prop) (x : Subtype p) : p x.val := by
+  cases x; trivial
+
 @[scalar_tac_simps]
 theorem nat_subset_le_iff (p : ℕ → Prop) (x y : {n : ℕ // p n}) : x ≤ y ↔ x.val ≤ y.val := by rfl
 

--- a/backends/lean/Aeneas/ScalarTac/Lemmas.lean
+++ b/backends/lean/Aeneas/ScalarTac/Lemmas.lean
@@ -259,13 +259,6 @@ example (x y : Int) (h : |x| ≤ |y|) : x ≤ |y| := by scalar_tac
 example (x y : Int) (h : |x| ≤ |y|) : x ≤ |y| := by scalar_tac
 
 /-!
-# Fast Saturate
--/
-example :
-  128 ≤ Usize.max ∧ 128 ≥ 5 := by
-  scalar_tac +fastSaturate
-
-/-!
 # Forward Saturation
 -/
 
@@ -352,6 +345,12 @@ theorem lt_mul_le_le (x y a b : ℕ) (h0 : x < a) (h1 : y ≤ b) :
 @[scalar_tac x * y]
 theorem le_mul_le_le (x y a b : ℕ) (h0 : x ≤ a) (h1 : y ≤ b) :
   x * y ≤ a * b := by apply Nat.le_mul_le; omega
+
+/-!
+# Modulo
+-/
+@[scalar_tac x % y]
+theorem mod_lt (x y : ℕ) (h : 0 < y) : x % y < y := by exact Nat.mod_lt x h
 
 end ScalarTac
 

--- a/backends/lean/Aeneas/ScalarTac/Lemmas.lean
+++ b/backends/lean/Aeneas/ScalarTac/Lemmas.lean
@@ -334,6 +334,25 @@ theorem nat_subset_lt_iff (p : ℕ → Prop) (x y : {n : ℕ // p n}) : x < y �
 theorem nat_subset_eq_iff (p : ℕ → Prop) (x y : {n : ℕ // p n}) : x = y ↔ x.val = y.val := by
   cases x; cases y; simp
 
+/-!
+# Multiplication
+-/
+@[scalar_tac x * y]
+theorem lt_mul_lt_le (x y a b : ℕ) (h0 : x < a) (h1 : y < b) :
+  x * y ≤ (a - 1) * (b - 1) := by apply Nat.le_mul_le; omega
+
+@[scalar_tac x * y]
+theorem le_mul_lt_le (x y a b : ℕ) (h0 : x ≤ a) (h1 : y < b) :
+  x * y ≤ a * (b - 1) := by apply Nat.le_mul_le; omega
+
+@[scalar_tac x * y]
+theorem lt_mul_le_le (x y a b : ℕ) (h0 : x < a) (h1 : y ≤ b) :
+  x * y ≤ (a - 1) * b := by apply Nat.le_mul_le; omega
+
+@[scalar_tac x * y]
+theorem le_mul_le_le (x y a b : ℕ) (h0 : x ≤ a) (h1 : y ≤ b) :
+  x * y ≤ a * b := by apply Nat.le_mul_le; omega
+
 end ScalarTac
 
 end Aeneas

--- a/backends/lean/Aeneas/ScalarTac/Lemmas.lean
+++ b/backends/lean/Aeneas/ScalarTac/Lemmas.lean
@@ -215,6 +215,12 @@ namespace ScalarTac
 
 open Std
 
+attribute [scalar_tac_simps] Prod.mk.injEq
+
+attribute [scalar_tac_simps]
+  -- Int.subNatNat is very annoying - TODO: there is probably something more general thing to do
+  Int.subNatNat_eq_coe
+
 @[scalar_tac x.val]
 theorem UScalar.bounds {ty : UScalarTy} (x : UScalar ty) :
   x.val ≤ UScalar.max ty := by
@@ -228,6 +234,8 @@ theorem IScalar.bounds {ty : IScalarTy} (x : IScalar ty) :
   simp [IScalar.max, IScalar.min]
   have := x.hBounds
   omega
+
+attribute [scalar_tac a.toNat] Int.toNat_eq_max
 
 /-!
 # Neq

--- a/backends/lean/Aeneas/ScalarTac/Lemmas.lean
+++ b/backends/lean/Aeneas/ScalarTac/Lemmas.lean
@@ -215,7 +215,7 @@ namespace ScalarTac
 
 open Std
 
-attribute [scalar_tac_simps] Prod.mk.injEq
+attribute [scalar_tac_simps] Prod.mk.injEq gt_iff_lt
 
 attribute [scalar_tac_simps]
   -- Int.subNatNat is very annoying - TODO: there is probably something more general thing to do

--- a/backends/lean/Aeneas/ScalarTac/Lemmas.lean
+++ b/backends/lean/Aeneas/ScalarTac/Lemmas.lean
@@ -230,6 +230,14 @@ theorem IScalar.bounds {ty : IScalarTy} (x : IScalar ty) :
   omega
 
 /-!
+# Neq
+-/
+
+/- We use this because several scalar_tac patterns are triggered by a precondition of the shape `a < b`. -/
+@[scalar_tac_simps]
+theorem Nat_neq_zero_iff (x : ℕ) : x ≠ 0 ↔ 0 < x := by omega
+
+/-!
 # Min, Max
 -/
 

--- a/backends/lean/Aeneas/ScalarTac/ScalarTac.lean
+++ b/backends/lean/Aeneas/ScalarTac/ScalarTac.lean
@@ -124,6 +124,8 @@ structure SaturateConfig where
   saturateTarget : Bool := true
   /- Should we dive into binders? -/
   saturateVisitBoundExpressions := false
+  /- -/
+  saturationPasses := 3
 
 structure Config extends SaturateConfig where
   /- If `true`, split all the matches/if then else in the context (note that `omega`
@@ -153,7 +155,9 @@ def scalarTacSaturateForward {Î±} (config : SaturateConfig) (f : Array FVarId â†
     if config.nonLin then #[scalarTacAttribute, scalarTacNonLinAttribute]
     else #[scalarTacAttribute]
   Saturate.evalSaturate
-    { visitProofTerms := false, visitBoundExpressions := config.saturateVisitBoundExpressions }
+    { visitProofTerms := false,
+      visitBoundExpressions := config.saturateVisitBoundExpressions,
+      saturationPasses := config.saturationPasses }
     rules none none
     (declsToExplore := none)
     (exploreAssumptions := config.saturateAssumptions)

--- a/backends/lean/Aeneas/ScalarTac/ScalarTac.lean
+++ b/backends/lean/Aeneas/ScalarTac/ScalarTac.lean
@@ -152,11 +152,12 @@ def unexpForall' : Lean.PrettyPrinter.Unexpander | `($_ $_) => `(∀ _, __) | _ 
 structure SaturateConfig where
   /- Should we use non-linear arithmetic reasoning? -/
   nonLin : Bool := false
-  fastSaturate : Bool := false
   /- Should we explore the assumptions when saturating?. -/
   saturateAssumptions : Bool := true
   /- Should we explore the target when saturating?. -/
   saturateTarget : Bool := true
+  /- Should we dive into binders? -/
+  saturateVisitBoundExpressions := false
 
 structure Config extends SaturateConfig where
   /- If `true`, split all the matches/if then else in the context (note that `omega`
@@ -188,7 +189,7 @@ def scalarTacSaturateForward {α} (config : SaturateConfig) (f : Array FVarId �
     else ruleSets
   -- TODO
   -- evalAesopSaturate options ruleSets.toArray
-  Saturate.evalSaturate { visitProofTerms := false } ruleSets (if config.fastSaturate then Saturate.exploreArithSubterms else none) none
+  Saturate.evalSaturate { visitProofTerms := false, visitBoundExpressions := config.saturateVisitBoundExpressions } ruleSets none none
     (declsToExplore := none)
     (exploreAssumptions := config.saturateAssumptions)
     (exploreTarget := config.saturateTarget) f

--- a/backends/lean/Aeneas/ScalarTac/ScalarTac.lean
+++ b/backends/lean/Aeneas/ScalarTac/ScalarTac.lean
@@ -77,9 +77,15 @@ macro "nonlin_scalar_tac" pat:term : attr =>
 macro "scalar_tac" pat:term : attr =>
   `(attr|aeneas_saturate (set := $(Lean.mkIdent `Aeneas.ScalarTac)) (pattern := $pat))
 
+macro "scalar_tac" : attr =>
+  `(attr|aeneas_saturate (set := $(Lean.mkIdent `Aeneas.ScalarTac)))
+
 /-- The `nonlin_scalar_tac` attribute used to tag forward theorems for the `scalar_tac` tactics. -/
 macro "nonlin_scalar_tac" pat:term : attr =>
   `(attr|aeneas_saturate (set := $(Lean.mkIdent `Aeneas.ScalarTacNonLin)) (pattern := $pat))
+
+macro "nonlin_scalar_tac" : attr =>
+  `(attr|aeneas_saturate (set := $(Lean.mkIdent `Aeneas.ScalarTacNonLin)))
 
 -- This is useful especially in the termination proofs
 attribute [scalar_tac a.toNat] Int.toNat_eq_max
@@ -360,7 +366,7 @@ def scalarTac (config : Config) : TacticM Unit := do
             ``Nat.mod_eq_of_lt, ``Int.emod_eq_of_lt', ``Nat.pow_le_pow_right, ``Nat.pow_le_pow_left,
             ``Nat.pow_lt_pow_right, ``Nat.le_pow, ``Nat.lt_pow,
             ``Nat.div_le_div_right, ``Nat.mul_div_le, ``Nat.div_mul_le_self]
-        firstTac tacs
+        firstTacSolve tacs
       catch _ => error
     else
       error

--- a/backends/lean/Aeneas/ScalarTac/Tests.lean
+++ b/backends/lean/Aeneas/ScalarTac/Tests.lean
@@ -141,11 +141,7 @@ example (d i : ℕ) (h : i ≤ 256) : d * i / 8 ≤ d * 256 / 8 := by
   apply Nat.div_le_div_right
   scalar_tac +nonLin
 
-@[local scalar_tac a.val * b.val]
-private theorem U16_Zq_mul_in_bounds (a b : U16) (h0 : a.val < 3329) (h1 : b.val < 3329) :
-  a.val * b.val ≤ 3328 * 3328 := by
-  scalar_tac +nonLin
-
+/- A bug used to make this fail -/
 example
   (i1 i2 : U16)
   (i1_post_2 : (↑i1 : ℕ) < 3329)
@@ -153,5 +149,15 @@ example
   i1.val * i2.val ≤ U32.max
   := by
   scalar_tac +fastSaturate
+
+/- This example exhibited an "unknown free variable" bug because expressions
+   containing free variables were not properly ignored. -/
+example
+  (layer : ℕ)
+  (_ : layer < 7)
+  (_ : ∀ (a b : Nat), b = a * (a + 1) → True) :
+  True
+  := by
+  scalar_tac
 
 end Aeneas.Std

--- a/backends/lean/Aeneas/ScalarTac/Tests.lean
+++ b/backends/lean/Aeneas/ScalarTac/Tests.lean
@@ -141,4 +141,17 @@ example (d i : ℕ) (h : i ≤ 256) : d * i / 8 ≤ d * 256 / 8 := by
   apply Nat.div_le_div_right
   scalar_tac +nonLin
 
+@[local scalar_tac a.val * b.val]
+private theorem U16_Zq_mul_in_bounds (a b : U16) (h0 : a.val < 3329) (h1 : b.val < 3329) :
+  a.val * b.val ≤ 3328 * 3328 := by
+  scalar_tac +nonLin
+
+example
+  (i1 i2 : U16)
+  (i1_post_2 : (↑i1 : ℕ) < 3329)
+  (i2_post_2 : (↑i2 : ℕ) < 3329) :
+  i1.val * i2.val ≤ U32.max
+  := by
+  scalar_tac +fastSaturate
+
 end Aeneas.Std

--- a/backends/lean/Aeneas/ScalarTac/Tests.lean
+++ b/backends/lean/Aeneas/ScalarTac/Tests.lean
@@ -141,15 +141,6 @@ example (d i : ℕ) (h : i ≤ 256) : d * i / 8 ≤ d * 256 / 8 := by
   apply Nat.div_le_div_right
   scalar_tac +nonLin
 
-/- A bug used to make this fail -/
-example
-  (i1 i2 : U16)
-  (i1_post_2 : (↑i1 : ℕ) < 3329)
-  (i2_post_2 : (↑i2 : ℕ) < 3329) :
-  i1.val * i2.val ≤ U32.max
-  := by
-  scalar_tac +fastSaturate
-
 /- This example exhibited an "unknown free variable" bug because expressions
    containing free variables were not properly ignored. -/
 example

--- a/backends/lean/Aeneas/ScalarTac/Tests.lean
+++ b/backends/lean/Aeneas/ScalarTac/Tests.lean
@@ -1,6 +1,6 @@
 import Aeneas.ScalarTac.Lemmas
 
-namespace Aeneas.Std
+namespace Aeneas.Std.ScalarTac.Tests
 
 /-!
 # Tests
@@ -151,4 +151,13 @@ example
   := by
   scalar_tac
 
-end Aeneas.Std
+
+def inv (x : Nat) : Prop := 0 < x ∧ x % 2 = 0
+@[scalar_tac inv x]
+theorem inv_imp (x : Nat) (h : inv x) : 0 < x ∧ x % 2 = 0 := by simp [inv] at h; assumption
+
+--example (x y : Nat) (h : inv x) : y % x < x := by
+--  scalar_tac
+
+
+end Aeneas.Std.ScalarTac.Tests

--- a/backends/lean/Aeneas/SimpScalar/SimpScalar.lean
+++ b/backends/lean/Aeneas/SimpScalar/SimpScalar.lean
@@ -14,6 +14,11 @@ namespace Aeneas.SimpScalar
 
 open Lean Lean.Meta Lean.Parser.Tactic Lean.Elab.Tactic
 
+structure Config where
+  nonLin : Bool := false
+
+declare_config_elab elabConfig Config
+
 /- Making sure we always reason in terms of `≤` and `<` -/
 attribute [simp_scalar_simps] ge_iff_le gt_iff_lt
 
@@ -172,7 +177,7 @@ theorem BitVec.toNat_lt_two_pow {w} (x : BitVec w) (i : ℕ) (h : w ≤ i) : x.t
 
 attribute [simp_scalar_simps] BitVec.setWidth_eq BitVec.ofNat_eq_ofNat
 
-def simpScalarTac (args : ScalarTac.CondSimpPartialArgs) (loc : Utils.Location) : TacticM Unit := do
+def simpScalarTac (config : Config) (args : ScalarTac.CondSimpPartialArgs) (loc : Utils.Location) : TacticM Unit := do
   let addSimpThms : TacticM (Array FVarId) := pure #[]
   let args : ScalarTac.CondSimpArgs := {
       simpThms := #[← simpScalarSimpExt.getTheorems, ← SimpBoolProp.simpBoolPropSimpExt.getTheorems],
@@ -181,25 +186,24 @@ def simpScalarTac (args : ScalarTac.CondSimpPartialArgs) (loc : Utils.Location) 
       addSimpThms := args.addSimpThms,
       hypsToUse := args.hypsToUse,
     }
-  ScalarTac.condSimpTac "simp_scalar" true {maxDischargeDepth := 2, failIfUnchanged := false, contextual := true} args addSimpThms false loc
+  ScalarTac.condSimpTac "simp_scalar" config.nonLin
+    {maxDischargeDepth := 2, failIfUnchanged := false, contextual := true}
+    args addSimpThms false loc
 
-syntax (name := simp_scalar) "simp_scalar" ("[" (term<|>"*"),* "]")? (location)? : tactic
+syntax (name := simp_scalar) "simp_scalar" Parser.Tactic.optConfig ("[" (term<|>"*"),* "]")? (location)? : tactic
 
-def parseSimpScalar : TSyntax ``simp_scalar -> TacticM (ScalarTac.CondSimpPartialArgs × Utils.Location)
-| `(tactic| simp_scalar $[[$args,*]]?) => do
-  let args := args.map (·.getElems) |>.getD #[]
-  let args ← ScalarTac.condSimpParseArgs "simp_scalar" args
-  pure (args, Utils.Location.targets #[] true)
-| `(tactic| simp_scalar $[[$args,*]]? $[$loc:location]?) => do
+def parseSimpScalar : TSyntax ``simp_scalar -> TacticM (Config × ScalarTac.CondSimpPartialArgs × Utils.Location)
+| `(tactic| simp_scalar $config $[[$args,*]]? $[$loc:location]?) => do
+  let config ← elabConfig config
   let args := args.map (·.getElems) |>.getD #[]
   let args ← ScalarTac.condSimpParseArgs "simp_scalar" args
   let loc ← Utils.parseOptLocation loc
-  pure (args, loc)
+  pure (config, args, loc)
 | _ => Lean.Elab.throwUnsupportedSyntax
 
 elab stx:simp_scalar : tactic =>
   withMainContext do
-  let (args, loc) ← parseSimpScalar stx
-  simpScalarTac args loc
+  let (config, args, loc) ← parseSimpScalar stx
+  simpScalarTac config args loc
 
 end Aeneas.SimpScalar

--- a/backends/lean/Aeneas/Std/Array/Array.lean
+++ b/backends/lean/Aeneas/Std/Array/Array.lean
@@ -29,12 +29,6 @@ instance [BEq α] [LawfulBEq α] : LawfulBEq (Array α n) := SubtypeLawfulBEq _
 theorem Array.length_eq {α : Type u} {n : Usize} (a : Array α n) : a.val.length = n.val := by
   cases a; simp[*]
 
--- TODO: remove
-@[scalar_tac a.val]
-theorem Array.length_eq' {α : Type u} {n : Usize} (a : Array α n) : a.val.length = n.val ∧ n.val ≤ Usize.max := by
-  cases a; simp[*]
-  scalar_tac
-
 @[simp, scalar_tac_simps, simp_scalar_simps, simp_lists_simps]
 abbrev Array.length {α : Type u} {n : Usize} (v : Array α n) : Nat := v.val.length
 
@@ -65,8 +59,11 @@ example : Result (Array Int (Usize.ofNat 2)) := do
 @[reducible] instance {α : Type u} {n : Usize} : GetElem? (Array α n) Nat α (fun a i => i < a.val.length) where
   getElem? a i := getElem? a.val i
 
-@[simp, scalar_tac_simps] theorem Array.getElem?_Nat_eq {α : Type u} {n : Usize} (v : Array α n) (i : Nat) : v[i]? = v.val[i]? := by rfl
-@[simp, scalar_tac_simps] theorem Array.getElem!_Nat_eq {α : Type u} [Inhabited α] {n : Usize} (v : Array α n) (i : Nat) : v[i]! = v.val[i]! := by
+@[simp, scalar_tac_simps, simp_lists_simps]
+theorem Array.getElem?_Nat_eq {α : Type u} {n : Usize} (v : Array α n) (i : Nat) : v[i]? = v.val[i]? := by rfl
+
+@[simp, scalar_tac_simps, simp_lists_simps]
+theorem Array.getElem!_Nat_eq {α : Type u} [Inhabited α] {n : Usize} (v : Array α n) (i : Nat) : v[i]! = v.val[i]! := by
   simp only [instGetElem?ArrayNatLtLengthValListEqVal, List.getElem!_eq_getElem?_getD]; split <;> simp_all
   rfl
 

--- a/backends/lean/Aeneas/Std/Array/Array.lean
+++ b/backends/lean/Aeneas/Std/Array/Array.lean
@@ -35,12 +35,6 @@ theorem Array.length_eq' {α : Type u} {n : Usize} (a : Array α n) : a.val.leng
   cases a; simp[*]
   scalar_tac
 
--- TODO: remove
-@[scalar_tac a.val.length]
-theorem Array.length_eq'' {α : Type u} {n : Usize} (a : Array α n) : a.val.length = n.val ∧ n.val ≤ Usize.max := by
-  cases a; simp[*]
-  scalar_tac
-
 @[simp, scalar_tac_simps, simp_scalar_simps, simp_lists_simps]
 abbrev Array.length {α : Type u} {n : Usize} (v : Array α n) : Nat := v.val.length
 

--- a/backends/lean/Aeneas/Std/Slice.lean
+++ b/backends/lean/Aeneas/Std/Slice.lean
@@ -26,7 +26,6 @@ instance [BEq α] : BEq (Slice α) := SubtypeBEq _
 
 instance [BEq α] [LawfulBEq α] : LawfulBEq (Slice α) := SubtypeLawfulBEq _
 
-@[scalar_tac s.val]
 theorem Slice.length_ineq {α : Type u} (s : Slice α) : s.val.length ≤ Usize.max := by
   cases s; simp[*]
 
@@ -55,8 +54,11 @@ theorem Slice.len_val {α : Type u} (v : Slice α) : (Slice.len v).val = v.lengt
 @[reducible] instance {α : Type u} : GetElem? (Slice α) Nat α (fun a i => i < a.val.length) where
   getElem? a i := getElem? a.val i
 
-@[simp, scalar_tac_simps] theorem Slice.getElem?_Nat_eq {α : Type u} (v : Slice α) (i : Nat) : v[i]? = v.val[i]? := by rfl
-@[simp, scalar_tac_simps] theorem Slice.getElem!_Nat_eq {α : Type u} [Inhabited α] (v : Slice α) (i : Nat) : v[i]! = v.val[i]! := by
+@[simp, scalar_tac_simps, simp_lists_simps]
+theorem Slice.getElem?_Nat_eq {α : Type u} (v : Slice α) (i : Nat) : v[i]? = v.val[i]? := by rfl
+
+@[simp, scalar_tac_simps, simp_lists_simps]
+theorem Slice.getElem!_Nat_eq {α : Type u} [Inhabited α] (v : Slice α) (i : Nat) : v[i]! = v.val[i]! := by
   simp only [instGetElem?SliceNatLtLengthValListLeMax, List.getElem!_eq_getElem?_getD]; split <;> simp_all
   rfl
 

--- a/backends/lean/Aeneas/Std/Slice.lean
+++ b/backends/lean/Aeneas/Std/Slice.lean
@@ -30,10 +30,6 @@ instance [BEq α] [LawfulBEq α] : LawfulBEq (Slice α) := SubtypeLawfulBEq _
 theorem Slice.length_ineq {α : Type u} (s : Slice α) : s.val.length ≤ Usize.max := by
   cases s; simp[*]
 
--- TODO: update `scalar_tac` so that we can remove this theorem
-@[scalar_tac s.val.length]
-theorem Slice.length_ineq' {α : Type u} (s : Slice α) : s.val.length ≤ Usize.max := Slice.length_ineq s
-
 @[simp, scalar_tac_simps, simp_scalar_simps, simp_lists_simps]
 abbrev Slice.length {α : Type u} (v : Slice α) : Nat := v.val.length
 

--- a/backends/lean/Aeneas/Std/Vec.lean
+++ b/backends/lean/Aeneas/Std/Vec.lean
@@ -27,7 +27,6 @@ instance [BEq α] : BEq (Vec α) := SubtypeBEq _
 
 instance [BEq α] [LawfulBEq α] : LawfulBEq (Vec α) := SubtypeLawfulBEq _
 
-@[scalar_tac v.val]
 theorem Vec.len_ineq {α : Type u} (v : Vec α) : v.val.length ≤ Usize.max := by
   cases v; simp[*]
 
@@ -61,8 +60,11 @@ theorem Vec.len_val {α : Type u} (v : Vec α) : (Vec.len v).val = v.length :=
   getElem? a i := getElem? a.val i
   getElem! a i := getElem! a.val i
 
-@[simp, scalar_tac_simps] theorem Vec.getElem?_Nat_eq {α : Type u} (v : Vec α) (i : Nat) : v[i]? = v.val[i]? := by rfl
-@[simp, scalar_tac_simps] theorem Vec.getElem!_Nat_eq {α : Type u} [Inhabited α] (v : Vec α) (i : Nat) : v[i]! = v.val[i]! := by rfl
+@[simp, scalar_tac_simps, simp_lists_simps]
+theorem Vec.getElem?_Nat_eq {α : Type u} (v : Vec α) (i : Nat) : v[i]? = v.val[i]? := by rfl
+
+@[simp, scalar_tac_simps, simp_lists_simps]
+theorem Vec.getElem!_Nat_eq {α : Type u} [Inhabited α] (v : Vec α) (i : Nat) : v[i]! = v.val[i]! := by rfl
 
 @[reducible] instance {α : Type u} : GetElem (Vec α) Usize α (fun a i => i < a.val.length) where
   getElem a i h := getElem a.val i.val h

--- a/backends/lean/Aeneas/Std/Vec.lean
+++ b/backends/lean/Aeneas/Std/Vec.lean
@@ -31,11 +31,6 @@ instance [BEq α] [LawfulBEq α] : LawfulBEq (Vec α) := SubtypeLawfulBEq _
 theorem Vec.len_ineq {α : Type u} (v : Vec α) : v.val.length ≤ Usize.max := by
   cases v; simp[*]
 
--- TODO: update scalar_tac so that we can remove this one
-@[scalar_tac v.val.length]
-theorem Vec.len_ineq' {α : Type u} (v : Vec α) : v.val.length ≤ Usize.max := by
-  cases v; simp[*]
-
 @[simp, scalar_tac_simps, simp_scalar_simps, simp_lists_simps]
 abbrev Vec.length {α : Type u} (v : Vec α) : Nat := v.val.length
 

--- a/backends/lean/Aeneas/Utils.lean
+++ b/backends/lean/Aeneas/Utils.lean
@@ -324,7 +324,7 @@ partial def repeatTac (tac : TacticM Unit) : TacticM Unit := do
   -- TODO: does this restore the state?
   catch _ => pure ()
 
-def firstTac (tacl : List (TacticM Unit)) : TacticM Unit := do
+def firstTacSolve (tacl : List (TacticM Unit)) : TacticM Unit := do
   match tacl with
   | [] => throwError "no tactic succeeded"
   | tac :: tacl =>
@@ -336,15 +336,7 @@ def firstTac (tacl : List (TacticM Unit)) : TacticM Unit := do
       -- Check that there are no remaining goals
       let gl ← Tactic.getUnsolvedGoals
       if ¬ gl.isEmpty then throwError "tactic failed"
-    catch _ => firstTac tacl
-/-    let res ← Lean.observing? do
-      tac
-      -- Check that there are no remaining goals
-      let gl ← Tactic.getUnsolvedGoals
-      if ¬ gl.isEmpty then throwError "tactic failed"
-    match res with
-    | some _ => pure ()
-    | none => firstTac tacl -/
+    catch _ => firstTacSolve tacl
 
 def isConj (e : Expr) : MetaM Bool :=
   e.consumeMData.withApp fun f args => pure (f.isConstOf ``And ∧ args.size = 2)

--- a/tests/lean/Hashmap/Properties.lean
+++ b/tests/lean/Hashmap/Properties.lean
@@ -169,13 +169,7 @@ theorem allocate_slots_spec {α : Type} (slots : alloc.vec.Vec (AList α)) (n : 
     have Hslots1Nil :
       ∀ (i : Nat), i < slots1.length → slots1[i]! = Nil := by
       intro i h0
-      fsimp [*]
-      if hi : i < slots.length then
-        fsimp [*]
-      else
-        fsimp_all
-        have : i - slots.val.length = 0 := by scalar_tac
-        fsimp [*]
+      by_cases hi: i < slots.length <;> simp_lists [*]
     have Hslots1Len : alloc.vec.Vec.len slots1 + n1.val ≤ Usize.max := by
       scalar_tac
     progress as ⟨ slots2 ⟩
@@ -245,11 +239,9 @@ theorem new_with_capacity_spec
   . simp_all [HashMap.v, length]
   . fsimp [lookup]
     intro k
-    have : k.val % slots.val.length < slots.val.length := by
-      scalar_tac +nonLin
-    simp at Hnil
-    have := Hnil _ this
-    fsimp [this]
+    simp at Hnil -- TODO: this is annoying
+    simp_lists [Hnil]
+    simp -- TODO: remove
 
 @[progress]
 theorem new_spec (α : Type) :
@@ -371,7 +363,7 @@ theorem insert_no_resize_spec {α : Type} (hm : HashMap α) (key : Usize) (value
   progress as ⟨ hash_mod, hhm ⟩
   fsimp at hhm
   have _ : hash_mod.val < alloc.vec.Vec.length hm.slots := by
-    scalar_tac +nonLin
+    scalar_tac
   progress as ⟨ l, h_leq ⟩
   have h_slot :
     slot_s_inv_hash hm.slots.length (hash_mod_key key hm.slots.length) l.v := by

--- a/tests/lean/Hashmap/Properties.lean
+++ b/tests/lean/Hashmap/Properties.lean
@@ -449,8 +449,7 @@ theorem insert_no_resize_spec {α : Type} (hm : HashMap α) (key : Usize) (value
     -- are the same, in which case we have to reason about what happens
     -- in one slot
     let k_hash_mod := k.val % hm.slots.length
-    have _ : k_hash_mod < alloc.vec.Vec.length hm.slots := by
-      scalar_tac +nonLin
+    have _ : k_hash_mod < alloc.vec.Vec.length hm.slots := by scalar_tac
     cases h_hm: k_hash_mod == hash_mod.val <;> simp_all (config := {zetaDelta := true})
 
   fsimp_all [nhm]
@@ -558,8 +557,7 @@ private theorem slots_forall_nil_imp_lookup_none (slots : Slots T) (hLen : slots
   intro key
   fsimp [Slots.lookup]
   -- TODO: simplify
-  have : key.val % slots.val.length < slots.val.length := by
-    scalar_tac +nonLin
+  have : key.val % slots.val.length < slots.val.length := by scalar_tac
   have := hEmpty (key.val % slots.val.length) (by fsimp [*])
   fsimp at *
   fsimp [*]
@@ -958,7 +956,7 @@ theorem get_spec {α} (hm : HashMap α) (key : Usize) (hInv : hm.inv) :
   fsimp [hash_key, alloc.vec.Vec.len]
   progress as ⟨ hash_mod ⟩ -- TODO: decompose post by default
   fsimp at *
-  have : hash_mod.val < hm.slots.length := by scalar_tac +nonLin
+  have : hash_mod.val < hm.slots.length := by scalar_tac
   progress as ⟨ slot ⟩
   progress as ⟨ v ⟩
   fsimp_all [lookup]
@@ -1026,7 +1024,7 @@ theorem get_mut_spec {α} (hm : HashMap α) (key : Usize) (hInv : hm.inv) :
   fsimp [hash_key, alloc.vec.Vec.len]
   progress as ⟨ hash_mod ⟩
   fsimp at *
-  have : hash_mod.val < hm.slots.val.length ∧ hash_mod.val < hm.slots.val.length := by scalar_tac +nonLin
+  have : hash_mod.val < hm.slots.val.length ∧ hash_mod.val < hm.slots.val.length := by scalar_tac
   progress as ⟨ slot, index_back ⟩
   have : slot_t_inv hm.slots.val.length hash_mod slot := by
     fsimp_all [inv, slots_t_inv]
@@ -1053,7 +1051,7 @@ theorem get_mut_spec {α} (hm : HashMap α) (key : Usize) (hInv : hm.inv) :
       clear hBackSome
       intro key' hNotEq
       -- TODO: simplify
-      have : key'.val % hm.slots.val.length < hm.slots.val.length := by scalar_tac +nonLin
+      have : key'.val % hm.slots.val.length < hm.slots.val.length := by scalar_tac
       -- We need to do a case disjunction
       cases h: (key.val % hm.slots.val.length == key'.val % hm.slots.val.length) <;>
       simp_all
@@ -1091,7 +1089,7 @@ private theorem lookup_not_none_imp_len_s_pos (hm : HashMap α) (key : Usize) (h
   (hNotEmpty : 0 < hm.slots.val.length) :
   0 < hm.len_s := by
   -- TODO: simplify
-  have : key.val % hm.slots.val.length < hm.slots.val.length := by scalar_tac +nonLin
+  have : key.val % hm.slots.val.length < hm.slots.val.length := by scalar_tac
   have := List.length_getElem!_le_length_flatten hm.v (key.val % hm.slots.val.length)
   have := List.lookup_not_none_imp_length_pos (hm.slots.val[key.val % hm.slots.val.length]!).v key
   simp_all [lookup, len_s, al_v, v]
@@ -1111,8 +1109,7 @@ theorem remove_spec {α} (hm : HashMap α) (key : Usize) (hInv : hm.inv) :
   progress as ⟨ hash_mod ⟩ -- TODO: decompose post by default
   fsimp at *
   -- TODO: simplify
-  have : hash_mod.val < hm.slots.val.length := by
-    scalar_tac +nonLin
+  have : hash_mod.val < hm.slots.val.length := by scalar_tac
   progress as ⟨ slot, index_back ⟩
   have : slot_t_inv hm.slots.val.length hash_mod slot := by
     fsimp_all [inv, slots_t_inv]
@@ -1124,7 +1121,7 @@ theorem remove_spec {α} (hm : HashMap α) (key : Usize) (hInv : hm.inv) :
     split_conjs
     . intro key' hNotEq
       -- We need to make a case disjunction
-      have : key' % hm.slots.val.length < hm.slots.val.length := by scalar_tac +nonLin
+      have : key' % hm.slots.val.length < hm.slots.val.length := by scalar_tac
       cases h: key.val % hm.slots.val.length == key'.val % hm.slots.val.length <;>
       fsimp_all
     . -- TODO
@@ -1140,7 +1137,7 @@ theorem remove_spec {α} (hm : HashMap α) (key : Usize) (hInv : hm.inv) :
     simp_all [lookup, al_v, HashMap.v]
     constructor
     . intro key' hNotEq
-      have : key' % hm.slots.val.length < hm.slots.val.length := by scalar_tac +nonLin
+      have : key' % hm.slots.val.length < hm.slots.val.length := by scalar_tac
       cases h: key.val % hm.slots.val.length == key'.val % hm.slots.val.length <;>
       fsimp_all
     . simp_all [List.length_flatten_set_as_int_eq]


### PR DESCRIPTION
Because the saturation tactic is used by `scalar_tac` it is now possible to register the following theorem with `scalar_tac`:
```lean
@[scalar_tac x * y]
theorem lt_mul_lt_le (x y a b : ℕ) (h0 : x < a) (h1 : y < b) :
  x * y ≤ (a - 1) * (b - 1) := by apply Nat.le_mul_le; omega
```

This PR also simplifies and improves the following:
- there is no "fast saturation" mode anymore
- saturation does not visit proof terms by default
- saturation does not use sets of rules anymore, and we instead provide the possibility of declaring new attributes which register saturation rules. The consequence is that `scalar_tac` and `scalar_tac_nonlin` are now two different attributes.
- several tactics like `bvify` or `simp_scalars` now have a configuration