### PR TITLE
Drastically improve the performance of `condSimpTac`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -178,7 +178,7 @@ test-%: build-dev
 # Replay the Lean tests and time them
 .PHONY: timed-lean
 timed-lean:
-	cd tests/lean && find . -type f -iname "*.lean" -not -path "./.lake/*" -exec printf "\n{}\n" \; -exec lake env time lean {} \; >& timing.out
+	cd tests/lean && find . -type f -iname "*.lean" -not -path "./.lake/*" -exec printf "\n{}\n" \; -exec lake env time lean {} \;
 
 # =============================================================================
 # Nix

--- a/backends/lean/Aeneas.lean
+++ b/backends/lean/Aeneas.lean
@@ -19,6 +19,7 @@ import Aeneas.Saturate
 import Aeneas.ScalarDecrTac
 import Aeneas.ScalarNF
 import Aeneas.ScalarTac
+import Aeneas.Simp
 import Aeneas.SimpIfs
 import Aeneas.SimpLemmas
 import Aeneas.SimpLists

--- a/backends/lean/Aeneas/Array.lean
+++ b/backends/lean/Aeneas/Array.lean
@@ -5,6 +5,8 @@ namespace Array
 
 attribute [-simp] List.getElem!_eq_getElem?_getD
 
+attribute [scalar_tac_simps, simp_lists_simps] Array.size
+
 def setSlice! {α} (a : Array α) (i : ℕ) (s : List α) : Array α :=
   ⟨ a.toList.setSlice! i s⟩
 

--- a/backends/lean/Aeneas/BitVec.lean
+++ b/backends/lean/Aeneas/BitVec.lean
@@ -17,6 +17,9 @@ open Lean
 
 attribute [-simp] List.getElem!_eq_getElem?_getD
 
+attribute [bvify_simps, simp_scalar_simps] BitVec.zero_eq
+attribute [bvify_simps, simp_scalar_simps] BitVec.instInhabited
+
 def BitVec.toArray {n} (bv: BitVec n) : Array Bool := Array.finRange n |>.map (bv[·])
 def BitVec.ofFn {n} (f: Fin n → Bool) : BitVec n := (BitVec.ofBoolListLE <| List.ofFn f).cast (by simp)
 def BitVec.set {n} (i: Fin n) (b: Bool) (bv: BitVec n) : BitVec n := bv ^^^ (((bv[i] ^^ b).toNat : BitVec n) <<< i.val)

--- a/backends/lean/Aeneas/BvTac/BvTac.lean
+++ b/backends/lean/Aeneas/BvTac/BvTac.lean
@@ -71,7 +71,7 @@ partial def bvTacPreprocess (config : Config) (n : Option Expr): TacticM Unit :=
     /- Call `simp_all ` to normalize the goal a bit -/
     let simpLemmas ← bvifySimpExt.getTheorems
     let simprocs ← bvifySimprocExt.getSimprocs
-    Utils.simpAll {dsimp := false, failIfUnchanged := false, maxDischargeDepth := 0} true
+    Simp.simpAll {dsimp := false, failIfUnchanged := false, maxDischargeDepth := 0} true
                   {simprocs := #[simprocs], simpThms := #[simpLemmas]}
     allGoals do
     trace[BvTac] "Goal after `simp_all`: {← getMainGoal}"

--- a/backends/lean/Aeneas/Bvify/Bvify.lean
+++ b/backends/lean/Aeneas/Bvify/Bvify.lean
@@ -285,7 +285,7 @@ def bvifyTacSimp (loc : Utils.Location) : TacticM (Option (Array FVarId)) := do
       simpThms := #[← bvifySimpExt.getTheorems, ← SimpBoolProp.simpBoolPropSimpExt.getTheorems]
       simprocs := #[← bvifySimprocExt.getSimprocs, ← SimpBoolProp.simpBoolPropSimprocExt.getSimprocs]
     }
-  ScalarTac.condSimpTacSimp bvifySimpConfig args loc #[] false
+  ScalarTac.condSimpTacSimp bvifySimpConfig args loc #[] #[] none
 
 def bvifyTac (config : Config) (n : Expr) (loc : Utils.Location) : TacticM Unit := do
   let args : ScalarTac.CondSimpArgs := {

--- a/backends/lean/Aeneas/Bvify/Bvify.lean
+++ b/backends/lean/Aeneas/Bvify/Bvify.lean
@@ -280,7 +280,7 @@ def bvifyAddSimpThms (n : Expr) : TacticM (Array FVarId) := do
 
 def bvifySimpConfig : Simp.Config := {maxDischargeDepth := 2, failIfUnchanged := false}
 
-def bvifyTacSimp (loc : Utils.Location) : TacticM Unit := do
+def bvifyTacSimp (loc : Utils.Location) : TacticM (Option (Array FVarId)) := do
   let args : ScalarTac.CondSimpArgs := {
       simpThms := #[← bvifySimpExt.getTheorems, ← SimpBoolProp.simpBoolPropSimpExt.getTheorems]
       simprocs := #[← bvifySimprocExt.getSimprocs, ← SimpBoolProp.simpBoolPropSimprocExt.getSimprocs]

--- a/backends/lean/Aeneas/Bvify/Bvify.lean
+++ b/backends/lean/Aeneas/Bvify/Bvify.lean
@@ -288,12 +288,16 @@ def bvifyTacSimp (loc : Utils.Location) : TacticM (Option (Array FVarId)) := do
   ScalarTac.condSimpTacSimp bvifySimpConfig args loc #[] #[] none
 
 def bvifyTac (config : Config) (n : Expr) (loc : Utils.Location) : TacticM Unit := do
+  let hypsArgs : ScalarTac.CondSimpArgs := {
+      simpThms := #[← bvifyHypsSimpExt.getTheorems]
+      simprocs := #[← bvifyHypsSimprocExt.getSimprocs]
+    }
   let args : ScalarTac.CondSimpArgs := {
       simpThms := #[← bvifySimpExt.getTheorems, ← SimpBoolProp.simpBoolPropSimpExt.getTheorems]
       simprocs := #[← bvifySimprocExt.getSimprocs, ← SimpBoolProp.simpBoolPropSimprocExt.getSimprocs]
     }
   let config := { nonLin := config.nonLin, saturationPasses := config.saturationPasses }
-  ScalarTac.condSimpTac "bvify" config bvifySimpConfig args (bvifyAddSimpThms n) true loc
+  ScalarTac.condSimpTac "bvify" config bvifySimpConfig hypsArgs args (bvifyAddSimpThms n) true loc
 
 syntax (name := bvify) "bvify " colGt Parser.Tactic.optConfig term (location)? : tactic
 

--- a/backends/lean/Aeneas/Bvify/Init.lean
+++ b/backends/lean/Aeneas/Bvify/Init.lean
@@ -29,4 +29,18 @@ initialize bvifySimprocExt : Simp.SimprocExtension ←
     The `bvify_simps_proc` attribute registers simp procedures to be used by `bvify`
     during its preprocessing phase." none --(some bvifySimprocsRef)
 
+/-- The `bvify_hyps_simps` simp attribute. -/
+initialize bvifyHypsSimpExt : SimpExtension ←
+  registerSimpAttr `bvify_hyps_simps "\
+    The `bvify_hyps_simps` attribute registers simp lemmas to be used by `bvify`."
+
+-- TODO: initialization fails with this, while the same works for `scalar_tac`??
+--initialize bvifySimprocsRef : IO.Ref Simprocs ← IO.mkRef {}
+
+/-- The `bvify_hyps_simps_proc` simp attribute for the simp rocs. -/
+initialize bvifyHypsSimprocExt : Simp.SimprocExtension ←
+  Simp.registerSimprocAttr `bvify_hyps_simps_proc "\
+    The `bvify_hyps_simps_proc` attribute registers simp procedures to be used by `bvify`
+    during its preprocessing phase." none --(some bvifySimprocsRef)
+
 end Aeneas.Bvify

--- a/backends/lean/Aeneas/Let/Let.lean
+++ b/backends/lean/Aeneas/Let/Let.lean
@@ -15,7 +15,7 @@ def opaque_refold (h x : Name) (e : Expr) : TacticM Unit :=
   withMainContext do
   /- Retrieve the list of propositions in the context -/
   let ctx ← getLCtx
-  let props ← (← ctx.getDecls).filterM fun x => do pure (← inferType x.type).isProp
+  let props ← (← ctx.getDecls).filterM fun x => isProp x.type
   /- Generalize -/
   let goal ← getMainGoal
   let (_, _, ngoal) ← goal.generalizeHyp #[{expr := e, xName? := x, hName? := h}] (props.map LocalDecl.fvarId).toArray
@@ -66,7 +66,7 @@ def transparent_refold (x : Name) (e : Expr) : TacticM Unit :=
   withMainContext do
   /- Retrieve the list of propositions in the context -/
   let ctx ← getLCtx
-  let props ← (← ctx.getDecls).filterM fun x => do pure (← inferType x.type).isProp
+  let props ← (← ctx.getDecls).filterM fun x => isProp x.type
   /- List the assumptions which contain the declaration that we want to refold -/
   let mut toRevert := #[]
   for decl in props.reverse do

--- a/backends/lean/Aeneas/List/List.lean
+++ b/backends/lean/Aeneas/List/List.lean
@@ -588,7 +588,7 @@ theorem setSlice!_drop {α} (l : List α) (i : ℕ) :
   by_cases h1: j < l.length <;> simp_lists
   simp_scalar
 
-@[simp_lists_simps]
+@[simp_lists_hyps_simps]
 def Inhabited_getElem_eq_getElem! {α} [Inhabited α] (l : List α) (i : ℕ) (hi : i < l.length) :
   l[i] = l[i]! := by
   simp only [List.getElem!_eq_getElem?_getD, List.getElem?_eq_getElem, Option.getD_some, hi]

--- a/backends/lean/Aeneas/Progress/Init.lean
+++ b/backends/lean/Aeneas/Progress/Init.lean
@@ -86,7 +86,7 @@ section Methods
       trace[Progress] "Existentials: {zs}"
       trace[Progress] "Proposition after stripping the quantifiers: {ty₃}"
       -- ty₃ == ty₄ ∧ post?
-      let (ty₄, post?) ← Utils.optSplitConj ty₃.consumeMData
+      let (ty₄, post?) := Utils.optSplitConj ty₃.consumeMData
       trace[Progress] "After splitting the conjunction:\n- eq: {ty₄}\n- post: {post?}"
       -- ty₄ == (program = res)
       let (program, res) ← Utils.destEq ty₄.consumeMData

--- a/backends/lean/Aeneas/Progress/Init.lean
+++ b/backends/lean/Aeneas/Progress/Init.lean
@@ -65,33 +65,33 @@ structure ProgressSpecDesc where
   postcond? : Option Expr
 
 section Methods
-  variable [MonadLiftT MetaM m] [MonadControlT MetaM m] [Monad m] [MonadOptions m]
+  variable {m} [MonadLiftT MetaM m] [MonadControlT MetaM m] [Monad m] [MonadOptions m]
   variable [MonadTrace m] [MonadLiftT IO m] [MonadRef m] [AddMessageContext m]
   variable [MonadError m]
   variable {a : Type}
 
 
-/-- Given ty := ∀ xs.., ∃ zs.., program = res ∧ post?, destruct and run continuation -/
-def programTelescope[Inhabited (m α)] [Nonempty (m α)] (ty: Expr)
-  (k: (xs:Array (MVarId × BinderInfo)) → (zs:Array FVarId) → (program:Expr) → (res:Expr) → (post:Option Expr) → m α)
-: m α := do
-  let ty := ty.consumeMData
-  unless ←isProp ty do
-    throwError "Expected a proposition, got {←inferType ty}"
-  -- ty == ∀ xs, ty₂
-  let (xs, xs_bi, ty₂) ← forallMetaTelescope ty
-  trace[Progress] "Universally quantified arguments and assumptions: {xs}"
-  -- ty₂ == ∃ zs, ty₃ ≃ Exists {α} (fun zs => ty₃)
-  existsTelescope ty₂.consumeMData fun zs ty₃ => do
-    trace[Progress] "Existentials: {zs}"
-    trace[Progress] "Proposition after stripping the quantifiers: {ty₃}"
-    -- ty₃ == ty₄ ∧ post?
-    let (ty₄, post?) ← Utils.optSplitConj ty₃.consumeMData
-    trace[Progress] "After splitting the conjunction:\n- eq: {ty₄}\n- post: {post?}"
-    -- ty₄ == (program = res)
-    let (program, res) ← Utils.destEq ty₄.consumeMData
-    trace[Progress] "After splitting the equality:\n- lhs: {program}\n- rhs: {res}"
-    k (xs.map (·.mvarId!) |>.zip xs_bi) (zs.map (·.fvarId!)) program res post?
+  /-- Given ty := ∀ xs.., ∃ zs.., program = res ∧ post?, destruct and run continuation -/
+  def monadTelescope {α} [Inhabited (m α)] [Nonempty (m α)] (ty: Expr)
+    (k: (xs:Array (MVarId × BinderInfo)) → (zs:Array FVarId) → (program:Expr) → (res:Expr) → (post:Option Expr) → m α)
+  : m α := do
+    let ty := ty.consumeMData
+    unless ←isProp ty do
+      throwError "Expected a proposition, got {←inferType ty}"
+    -- ty == ∀ xs, ty₂
+    let (xs, xs_bi, ty₂) ← forallMetaTelescope ty
+    trace[Progress] "Universally quantified arguments and assumptions: {xs}"
+    -- ty₂ == ∃ zs, ty₃ ≃ Exists {α} (fun zs => ty₃)
+    existsTelescope ty₂.consumeMData fun zs ty₃ => do
+      trace[Progress] "Existentials: {zs}"
+      trace[Progress] "Proposition after stripping the quantifiers: {ty₃}"
+      -- ty₃ == ty₄ ∧ post?
+      let (ty₄, post?) ← Utils.optSplitConj ty₃.consumeMData
+      trace[Progress] "After splitting the conjunction:\n- eq: {ty₄}\n- post: {post?}"
+      -- ty₄ == (program = res)
+      let (program, res) ← Utils.destEq ty₄.consumeMData
+      trace[Progress] "After splitting the equality:\n- lhs: {program}\n- rhs: {res}"
+      k (xs.map (·.mvarId!) |>.zip xs_bi) (zs.map (·.fvarId!)) program res post?
 
   /- Analyze a goal or a progress theorem to decompose its arguments.
 
@@ -113,7 +113,7 @@ def programTelescope[Inhabited (m α)] [Nonempty (m α)] (ty: Expr)
   def withProgressSpec [Inhabited (m a)] [Nonempty (m a)]
     (isGoal : Bool) (th : Expr) (k : ProgressSpecDesc → m a) :
     m a := do
-    programTelescope th fun xs evars mExpr ret post => do
+    monadTelescope th fun xs evars mExpr ret post => do
     -- Recursively destruct the monadic application to dive into the binds,
     -- if necessary (this is for when we use `withProgressSpec` inside of the `progress` tactic),
     -- and destruct the application to get the function name

--- a/backends/lean/Aeneas/Progress/Progress.lean
+++ b/backends/lean/Aeneas/Progress/Progress.lean
@@ -12,7 +12,7 @@ open Lean Elab Term Meta Tactic
 open Utils
 
 /-- A special definition that we use to introduce pretty-printed terms in the context -/
-def prettyMonadEq {α : Type u} (x : Std.Result α) (y : α) : Prop := x = .ok y
+@[irreducible] def prettyMonadEq {α : Type u} (_ : Std.Result α) (_ : α) : Type := Unit
 
 macro:max "[> " "let" y:term " ← " x:term " <]"   : term => `(prettyMonadEq $x $y)
 
@@ -21,7 +21,9 @@ def unexpPrettyMonadEqofNat : Lean.PrettyPrinter.Unexpander | `($_ $x $y) => `([
 
 example (x y z : Std.U32) (_ : [> let z ← (x + y) <]) : True := by simp
 
-theorem eq_imp_prettyMonadEq {α : Type u} {x : Std.Result α} {y : α} (h : x = .ok y) : prettyMonadEq x y := by simp [prettyMonadEq, h]
+def eq_imp_prettyMonadEq {α : Type u} {x : Std.Result α} {y : α} (_ : x = .ok y) : prettyMonadEq x y := by
+  unfold prettyMonadEq
+  constructor
 
 def traceGoalWithNode (msg : String) : TacticM Unit := Utils.traceGoalWithNode `Progress msg
 

--- a/backends/lean/Aeneas/Progress/Progress.lean
+++ b/backends/lean/Aeneas/Progress/Progress.lean
@@ -301,7 +301,6 @@ def progressWith (args : Args) (fExpr : Expr) (th : Expr) : TacticM (Result Prog
             else
             logWarning m!"Too many ids provided ({ids0}) not enough conjuncts to split in the postcondition"
             pure (Ok (hPost.fvarId! :: hPosts).reverse.toArray)
-        withMainContext do
         let curPostId := (← hPost.fvarId!.getDecl).userName
         let res ← splitPostWithIds curPostId [] hPost ids
         next res
@@ -312,7 +311,10 @@ def progressWith (args : Args) (fExpr : Expr) (th : Expr) : TacticM (Result Prog
     trace[Progress] ""
     return (Error msg) -- Can we get there? We're using `return`
   | Ok hPosts =>
-    trace[Progress] "type of hPosts: {← hPosts.mapM (·.getType >>= (liftM ∘ ppExpr))}"
+    /- Warning: the main goal may have been solved here, meaning it is unsafe to,
+       for instance, call `withMainContext`, or to print the `hPosts`
+       TODO: fix this.
+     -/
     -- Update the set of goals
     let curGoals ← getUnsolvedGoals
     trace[Progress] "current goals: {curGoals}"

--- a/backends/lean/Aeneas/Progress/Progress.lean
+++ b/backends/lean/Aeneas/Progress/Progress.lean
@@ -23,8 +23,7 @@ example (x y z : Std.U32) (_ : [> let z ← (x + y) <]) : True := by simp
 
 theorem eq_imp_prettyMonadEq {α : Type u} {x : Std.Result α} {y : α} (h : x = .ok y) : prettyMonadEq x y := by simp [prettyMonadEq, h]
 
-def traceGoalWithNode (msg : String) : TacticM Unit := do
-  withTraceNode `Progress (fun _ => do pure msg) do trace[Progress] "{← getMainGoal}"
+def traceGoalWithNode (msg : String) : TacticM Unit := Utils.traceGoalWithNode `Progress msg
 
 -- TODO: the scalar types annoyingly often get reduced when we use the progress
 -- tactic. We should find a way of controling reduction. For now we use rewriting

--- a/backends/lean/Aeneas/Progress/ProgressStar.lean
+++ b/backends/lean/Aeneas/Progress/ProgressStar.lean
@@ -152,7 +152,7 @@ attribute [progress_simps] Aeneas.Std.bind_assoc_eq
 partial def evalProgressStar(cfg: Config): TacticM Info :=
   withMainContext do focus do
   trace[ProgressStar] "Simplifying the goal: {←(getMainTarget >>= (liftM ∘ ppExpr))}"
-  Utils.simpAt (simpOnly := true)
+  Simp.simpAt (simpOnly := true)
     { maxDischargeDepth := 1, failIfUnchanged := false}
     {simpThms := #[← Progress.progressSimpExt.getTheorems]}
     (.targets #[] true)

--- a/backends/lean/Aeneas/Progress/ProgressStar.lean
+++ b/backends/lean/Aeneas/Progress/ProgressStar.lean
@@ -152,13 +152,12 @@ attribute [progress_simps] Aeneas.Std.bind_assoc_eq
 partial def evalProgressStar(cfg: Config): TacticM Info :=
   withMainContext do focus do
   trace[ProgressStar] "Simplifying the goal: {←(getMainTarget >>= (liftM ∘ ppExpr))}"
-  Simp.simpAt (simpOnly := true)
+  let r ← Simp.simpAt (simpOnly := true)
     { maxDischargeDepth := 1, failIfUnchanged := false}
     {simpThms := #[← Progress.progressSimpExt.getTheorems]}
     (.targets #[] true)
   /- We may have proven the goal already -/
-  let goals ← getUnsolvedGoals
-  if goals == [] then
+  if r.isNone then
     let progress_simps ← `(Parser.Tactic.simpLemma| $(mkIdent `progress_simps):term)
     return ⟨ #[← `(tactic|simp [$progress_simps])], [] ⟩
   /- Continue -/

--- a/backends/lean/Aeneas/Progress/ProgressStar.lean
+++ b/backends/lean/Aeneas/Progress/ProgressStar.lean
@@ -293,13 +293,8 @@ where
         else `(tactic|simp [*])
       -- `scalar_tac`
       let scalarTac : TacticM Syntax.Tactic := do
-        if ← ScalarTac.goalIsLinearInt then
-          /- Also: we don't try to split the goal if it is a conjunction
-            (it shouldn't be), but we split the disjunctions. -/
-          ScalarTac.scalarTac { split := false }
-          `(tactic|scalar_tac)
-        else
-          throwError "Not a linear arithmetic goal"
+        ScalarTac.scalarTac {}
+        `(tactic|scalar_tac)
       -- TODO: add the tactic given by the user
       let rec tryFinish (tacl : List (String × TacticM Syntax.Tactic)) : TacticM Syntax.Tactic := do
         match tacl with

--- a/backends/lean/Aeneas/Progress/Trace.lean
+++ b/backends/lean/Aeneas/Progress/Trace.lean
@@ -5,6 +5,5 @@ namespace Aeneas.Progress
 
 -- We can't define and use trace classes in the same file
 initialize registerTraceClass `Progress
-initialize registerTraceClass `ProgressStar
 
 end Aeneas.Progress

--- a/backends/lean/Aeneas/Saturate/Attribute.lean
+++ b/backends/lean/Aeneas/Saturate/Attribute.lean
@@ -245,7 +245,7 @@ def makeAttribute (mapName attributeName : Name) (elabAttribute : Syntax → Met
               else
                 -- Create a pattern
                 let pat ← inferType fv
-                unless (← inferType pat).isProp do
+                unless ← isProp pat do
                   throwError "Found a free variable not bound in the (optional) user provided pattern or in a precondition: {fv}"
                 let curPatFVars ← getFVarIds pat (Std.HashSet.emptyWithCapacity)
                 patFVars := patFVars.union (curPatFVars.insert fv.fvarId!)

--- a/backends/lean/Aeneas/Saturate/Tactic.lean
+++ b/backends/lean/Aeneas/Saturate/Tactic.lean
@@ -106,6 +106,8 @@ structure State where
      assumptions to instantiate some other theorems.
    -/
   assumptions : Std.HashMap Expr AsmPath
+  /- Do not introduce a theorem if its conclusion is already in the set -/
+  ignore : Std.HashSet Expr
 
 def State.insertHitRules (s : State) (rules : Array Rule) : State :=
   { s with diagnostics := s.diagnostics.insertHitRules rules }
@@ -131,8 +133,9 @@ def State.new
   (pmatches : DiscrTree PartialMatch := DiscrTree.empty)
   (diagnostics : Diagnostics := Diagnostics.empty)
   (matched : Std.HashSet Expr := Std.HashSet.emptyWithCapacity)
-  (assumptions : Std.HashMap Expr AsmPath := Std.HashMap.emptyWithCapacity) : State :=
-  { rules, pmatches, diagnostics, matched, assumptions }
+  (assumptions : Std.HashMap Expr AsmPath := Std.HashMap.emptyWithCapacity)
+  (ignore : Std.HashSet Expr := Std.HashSet.emptyWithCapacity) : State :=
+  { rules, pmatches, diagnostics, matched, assumptions, ignore }
 
 def mkExprFromPath (path : AsmPath) : MetaM Expr := do
   match path with
@@ -455,6 +458,51 @@ private partial def visit
     trace[Saturate.explore] ".proj"
     visit config none (depth + 1) exploreSubterms preprocessThm boundVars state b
 
+/-- Recompute the set of assumptions.
+
+    This is necessary if we want to saturate the goal in several steps and modify
+    the assumptions in between (with a call to simp for example).
+-/
+private partial def visitRecomputeAssumptions
+  (path : Option AsmPath)
+  (depth : Nat)
+  (exploreSubterms : Expr → Array Expr → MetaM (Array Expr))
+  (state : State) (e : Expr)
+  : MetaM State := do
+  trace[Saturate.explore] "Visiting {e}"
+  -- Register the current assumption, if it is a conjunct inside an assumption
+  let state := state.insertAssumption path e
+  let e := e.consumeMData
+  match e with
+  | .bvar _
+  | .fvar _
+  | .mvar _
+  | .sort _
+  | .lit _
+  | .const _ _ =>
+    trace[Saturate.explore] "Stop: bvar, fvar, etc."
+    pure state
+  | .app .. => do e.withApp fun f args => do
+    trace[Saturate.explore] ".app"
+    /- Check if this is a conjunction and we know the path to the current sub-expression (because it is a conjunct
+       in an assumption) -/
+    if path.isSome ∧ f.isConst ∧ f.constName! == ``And ∧ args.size == 2 then do
+      -- This is a conjunction
+      let some path := path
+        | throwError "Unreachable"
+      let state ← visitRecomputeAssumptions (some (.conj .left path)) (depth + 1) exploreSubterms state (args[0]!)
+      let state ← visitRecomputeAssumptions (some (.conj .right path)) (depth + 1) exploreSubterms state (args[1]!)
+      pure state
+    else
+      pure state
+  | .lam ..
+  | .forallE ..
+  | .letE .. => do pure state
+  | .mdata _ b => do
+    trace[Saturate.explore] ".mdata"
+    visitRecomputeAssumptions path (depth + 1) exploreSubterms state b
+  | .proj _ _ _ => do pure state
+
 def arithOpArity3 : Std.HashSet Name := Std.HashSet.ofList [
   ``Nat.cast, ``Int.cast
 ]
@@ -494,24 +542,17 @@ def exploreArithSubterms (f : Expr) (args : Array Expr) : MetaM (Array Expr) := 
     pure #[]
 
 /- The saturation tactic itself -/
-partial def evalSaturate {α}
+partial def evalSaturateCore
   (config : Config)
-  (satAttr : Array SaturateAttribute)
+  (state : State)
   (exploreSubterms : Option (Expr → Array Expr → MetaM (Array Expr)) := none)
   (preprocessThm : Option (Array Expr → Expr → MetaM Unit))
-  (declsToExplore : Option (Array FVarId) := none)
-  (exploreAssumptions : Bool := true)
+  (declsToExplore : Array FVarId)
   (exploreTarget : Bool := true)
-  (next : Array FVarId → TacticM α)
-  : TacticM α
+  : TacticM (State × Array FVarId)
   := do
   withMainContext do
   trace[Saturate] "Exploring goal: {← getMainGoal}"
-  -- Retrieve the rule sets
-  let env ← getEnv
-  let s := satAttr.map fun s => s.ext.getState env
-  -- Get the local context
-  let ctx ← Lean.MonadLCtx.getLCtx
   -- Explore
   let exploreSubterms :=
     match exploreSubterms with
@@ -527,11 +568,10 @@ partial def evalSaturate {α}
 
   -- Explore the assumptions
   trace[Saturate] "Exploring the assumptions"
-  let state := State.new s
 
   let visitLocalDecl (state : State) (decl : LocalDecl) : TacticM State := do
     trace[Saturate] "Exploring local decl: {decl.userName}"
-    /- We explore both the type, the expresion and the body (if there is) -/
+    /- We explore both the type, the expression and the body (if there is) -/
     /- Note that the path is used only when exploring the type of assumptions -/
     let path ←
       if (← inferType decl.type).isProp then pure (some (.asm decl.fvarId))
@@ -543,24 +583,9 @@ partial def evalSaturate {α}
     | some value => visit config none state value
 
   let state ← do
-    if exploreAssumptions then do
-      let decls ←
-        match declsToExplore with
-        | none => do pure (← ctx.getDecls).toArray
-        | some decls => decls.mapM fun d => d.getDecl
-      decls.foldlM (fun state (decl : LocalDecl) => do
-        trace[Saturate] "Exploring local decl: {decl.userName}"
-        /- We explore both the type, the expresion and the body (if there is) -/
-        /- Note that the path is used only when exploring the type of assumptions -/
-        let path ←
-          if (← inferType decl.type).isProp then pure (some (.asm decl.fvarId))
-          else pure none
-        let state ← visit config path state decl.type
-        let state ← visit config none state decl.toExpr
-        match decl.value? with
-        | none => pure state
-        | some value => visit config none state value) state
-    else pure state
+    trace[Saturate] "declsToExplore: {declsToExplore.map Expr.fvar}"
+    let decls ← declsToExplore.mapM fun d => d.getDecl
+    decls.foldlM visitLocalDecl state
 
   -- Explore the target
   trace[Saturate] "Exploring the target"
@@ -583,7 +608,7 @@ partial def evalSaturate {α}
       -- The application worked: introduce the assumption in the context
       let thTy ← withMainContext do inferType th
       -- Check that we don't add the same assumption twice
-      if assumptions.contains thTy then
+      if assumptions.contains thTy || state.ignore.contains thTy then
         continue
       else
         let x ← Utils.addDeclTac (.num (.str .anonymous "_h") i) th thTy (asLet := false) fun x => pure x
@@ -636,21 +661,61 @@ partial def evalSaturate {α}
   -- Display the diagnostics information
   trace[Saturate.diagnostics] "Saturate diagnostics info: {state.diagnostics.toArray}"
   -- Continue
-  next allFVars
+  pure (state, allFVars)
+
+/- Reexplore the context to recompute the set of assumptions -/
+def recomputeAssumptions
+  (state : State)
+  (exploreSubterms : Option (Expr → Array Expr → MetaM (Array Expr)) := none)
+  (declsToExplore : Array FVarId)
+  : TacticM State
+  := do
+  withMainContext do
+  trace[Saturate] "Exploring goal: {← getMainGoal}"
+  let ignore := state.assumptions.fold (fun ignore asm _ => ignore.insert asm) state.ignore
+  let state : State := { state with ignore, assumptions := Std.HashMap.emptyWithCapacity }
+  -- Explore
+  let exploreSubterms :=
+    match exploreSubterms with
+    | none => fun f args => pure (#[f] ++ args)
+    | some explore => explore
+  let visit path (state : State) expr : MetaM State :=
+    visitRecomputeAssumptions path 0 exploreSubterms state expr
+
+  -- Explore the assumptions
+  trace[Saturate] "Exploring the assumptions"
+
+  let decls ← declsToExplore.mapM fun d => d.getDecl
+  decls.foldlM (fun (state : State) (decl : LocalDecl) => do
+    trace[Saturate] "Exploring local decl: {decl.userName}"
+    if (← inferType decl.type).isProp then
+      let path := some (.asm decl.fvarId)
+      visit path state decl.type
+    else pure state) state
+
+partial def evalSaturate {α}
+  (config : Config)
+  (satAttr : Array SaturateAttribute)
+  (exploreSubterms : Option (Expr → Array Expr → MetaM (Array Expr)) := none)
+  (preprocessThm : Option (Array Expr → Expr → MetaM Unit))
+  (declsToExplore : Array FVarId)
+  (exploreTarget : Bool := true)
+  (next : Array FVarId → TacticM α)
+  : TacticM α
+  := do
+  -- Retrieve the rule sets
+  let env ← getEnv
+  let s := satAttr.map fun s => s.ext.getState env
+  let state := State.new s
+  let (_, fvarIds) ← evalSaturateCore config state exploreSubterms preprocessThm declsToExplore exploreTarget
+  withMainContext do next fvarIds
 
 elab "aeneas_saturate" : tactic => do
   let _ ← evalSaturate {} #[saturateAttr] none none
-    (declsToExplore := none)
-    (exploreAssumptions := true)
+    (declsToExplore := ((← (← getLCtx).getDecls).map fun d => d.fvarId).toArray)
     (exploreTarget := true) (fun _ => pure ())
 
 namespace Test
-  local elab "aeneas_saturate_test" : tactic => do
-    let _ ← evalSaturate {} #[saturateAttr] none none
-      (declsToExplore := none)
-      (exploreAssumptions := true)
-      (exploreTarget := true) (fun _ => pure ())
-
   set_option trace.Saturate.attribute false in
   @[aeneas_saturate l.length] -- TODO: local doesn't work here
   theorem rule1 (α : Type u) (l : List α) : l.length ≥ 0 := by simp
@@ -685,7 +750,7 @@ let _g := fun l => l.length + l5.length;
     let _k := l4.length
     let _g := fun (l : List α) => l.length + l5.length
     (l0 ++ l1 ++ l2).length = l0.length + l1.length + l2.length := by
-    aeneas_saturate_test
+    aeneas_saturate
     extract_goal1
     simp [Nat.add_assoc]
 
@@ -730,7 +795,7 @@ let _g := fun l => l.length + l5.length;
       let _k := l4.length
       let _g := fun (l : List α) => l.length + l5.length
       (l0 ++ l1 ++ l2).length = l0.length + l1.length + l2.length := by
-      aeneas_saturate_test
+      aeneas_saturate
       extract_goal1
       simp [Nat.add_assoc]
 
@@ -765,7 +830,7 @@ let _g := fun l => l.length + l5.length;
       let _k := l4.length
       let _g := fun (l : List α) => l.length + l5.length
       (l0 ++ l1 ++ l2).length = l0.length + l1.length + l2.length := by
-      aeneas_saturate_test
+      aeneas_saturate
       extract_goal1
       simp [Nat.add_assoc]
   end Test
@@ -799,7 +864,7 @@ let _g := fun l => l.length + l5.length;
     let _k := l4.length
     let _g := fun (l : List α) => l.length + l5.length
     (l0 ++ l1 ++ l2).length = l0.length + l1.length + l2.length := by
-    aeneas_saturate_test
+    aeneas_saturate
     extract_goal1
     simp [Nat.add_assoc]
 
@@ -812,11 +877,11 @@ let _g := fun l => l.length + l5.length;
   theorem rule2 (x : Nat) (h : 1 ≤ x) : 2 ≤ x + x := by omega
 
   example (x : Nat) (_h : 1 ≤ x) : 2 ≤ x + x := by
-    aeneas_saturate_test
+    aeneas_saturate
     assumption
 
   example (x : Nat) (_h : True ∧ 1 ≤ x ∧ True) : 2 ≤ x + x := by
-    aeneas_saturate_test
+    aeneas_saturate
     assumption
 
   set_option trace.Saturate.attribute true in
@@ -828,12 +893,12 @@ let _g := fun l => l.length + l5.length;
      *after one exploration pass* (in particular, the assumption `0 ≤ x * y`is useless). -/
   set_option trace.Saturate.insertPartialMatch true in
   example (x y : Nat) (_ : 0 ≤ x * y) (h : 3 ≤ y ∧ 2 ≤ x) : 6 ≤ x * y := by
-    aeneas_saturate_test
+    aeneas_saturate
     omega
 
   set_option trace.Saturate.insertPartialMatch true in
   example (x y z : Nat) (h : 2 ≤ x ∧ 3 ≤ y) (h1 : 8 ≤ z) : 32 ≤ x * y * z := by
-    aeneas_saturate_test
+    aeneas_saturate
     omega
 -/
 end Test

--- a/backends/lean/Aeneas/Saturate/Tactic.lean
+++ b/backends/lean/Aeneas/Saturate/Tactic.lean
@@ -382,6 +382,8 @@ private partial def visit
   (boundVars : Std.HashSet FVarId)
   (state : State) (e : Expr)
   : MetaM State := do
+  let e := e.consumeMData
+  --
   trace[Saturate.explore] "Visiting {e}"
   -- Register the current assumption, if it is a conjunct inside an assumption
   let state := state.insertAssumption path e
@@ -405,7 +407,6 @@ private partial def visit
         | some v => visit config none (depth + 1) exploreSubterms preprocessThm boundVars state v
       pure (boundVars, state)
       ) (boundVars, state)
-  let e := e.consumeMData
   match e with
   | .bvar _
   | .fvar _
@@ -470,9 +471,9 @@ private partial def visitRecomputeAssumptions
   (state : State) (e : Expr)
   : MetaM State := do
   trace[Saturate.explore] "Visiting {e}"
+  let e := e.consumeMData
   -- Register the current assumption, if it is a conjunct inside an assumption
   let state := state.insertAssumption path e
-  let e := e.consumeMData
   match e with
   | .bvar _
   | .fvar _

--- a/backends/lean/Aeneas/Saturate/Tactic.lean
+++ b/backends/lean/Aeneas/Saturate/Tactic.lean
@@ -367,8 +367,8 @@ def matchExpr
 def filterProofTerms (config : Config) (exprs : Array Expr) : MetaM (Array Expr) :=
   if ¬ config.visitProofTerms then
     exprs.filterM fun arg => do
-        let ty ← inferType (← inferType arg)
-        if ty.isProp then pure false
+        let ty ← inferType arg
+        if ← isProp ty then pure false
         else pure true
   else pure exprs
 
@@ -574,7 +574,7 @@ partial def evalSaturateCore
     /- We explore both the type, the expression and the body (if there is) -/
     /- Note that the path is used only when exploring the type of assumptions -/
     let path ←
-      if (← inferType decl.type).isProp then pure (some (.asm decl.fvarId))
+      if ← isProp decl.type then pure (some (.asm decl.fvarId))
       else pure none
     let state ← visit config path state decl.type
     let state ← visit config none state decl.toExpr
@@ -688,7 +688,7 @@ def recomputeAssumptions
   let decls ← declsToExplore.mapM fun d => d.getDecl
   decls.foldlM (fun (state : State) (decl : LocalDecl) => do
     trace[Saturate] "Exploring local decl: {decl.userName}"
-    if (← inferType decl.type).isProp then
+    if ← isProp decl.type then
       let path := some (.asm decl.fvarId)
       visit path state decl.type
     else pure state) state

--- a/backends/lean/Aeneas/ScalarDecrTac.lean
+++ b/backends/lean/Aeneas/ScalarDecrTac.lean
@@ -10,17 +10,6 @@ namespace Utils
 
 open Lean Lean.Elab Command Term Lean.Meta Tactic
 
-/-- Attempt to clear a list of fvar ids -/
-def tryClearFVarIds (fvarIds : Array FVarId) : TacticM Unit := do
-  let fvarIds ← withMainContext <| sortFVarIds fvarIds
-  for fvarId in fvarIds.reverse do
-    try
-      withMainContext do
-        let mvarId ← (← getMainGoal).clear fvarId
-        replaceMainGoal [mvarId]
-    catch _ =>
-      pure ()
-
 /- Utility function for proofs of termination (i.e., inside `decreasing_by`).
 
    Clean up the local context by removing all assumptions containing occurrences
@@ -54,6 +43,63 @@ def removeInvImageAssumptions : TacticM Unit := do
 elab "remove_invImage_assumptions" : tactic =>
   removeInvImageAssumptions
 
+
+def clearUnusedDeclsOnePass : TacticM Unit := do
+  withMainContext do
+  let lctx ← getLCtx
+  let decls ← lctx.getDecls
+  let decls ← decls.filterM (fun d => do pure (¬ (← isProp d.type)))
+  let allFVarIds : Std.HashSet FVarId := Std.HashSet.ofList (decls.map LocalDecl.fvarId)
+  let usedFVarIds ← decls.foldlM (fun used d => do
+    let used ← Utils.getFVarIds d.type used
+    match d.value? with
+    | none => pure used
+    | some value => getFVarIds value used) Std.HashSet.emptyWithCapacity
+  let toClear := allFVarIds.filter (fun id => ¬ usedFVarIds.contains id)
+  setGoals [← (← getMainGoal).tryClearMany toClear.toArray]
+
+elab "clear_unused_decls_one_pass" : tactic =>
+  clearUnusedDeclsOnePass
+
+/- We clear from the end to the beginning -/
+def clearRedundantHyps : TacticM Unit := do
+  withTraceNode `ScalarTac (fun _ => pure m!"clearRedundantHyps") do
+  withMainContext do
+  let lctx ← getLCtx
+  let decls ← lctx.getAssumptions
+  let decls := decls.reverse
+  let mut assums := Std.HashSet.emptyWithCapacity
+  let mut toClear := #[]
+  for decl in decls do
+    trace[ScalarTac] "Exploring: {Expr.fvar decl.fvarId}"
+    if isExists decl.type then
+      toClear := toClear.push decl.fvarId
+      trace[ScalarTac] "Clearing because existential"
+      continue
+    let conjs := splitConjs decl.type
+    trace[ScalarTac] "conjs:\n{conjs}"
+    if conjs.all fun x => assums.contains x then
+      toClear := toClear.push decl.fvarId
+      trace[ScalarTac] "Clearing because assumptions are already in the context"
+      continue
+    trace[ScalarTac] "Not clearing"
+    assums := assums.insertMany conjs
+  setGoals [← (← getMainGoal).tryClearMany toClear]
+
+elab "clear_redundant_hyps" : tactic =>
+  clearRedundantHyps
+
+/--
+info: example :
+  True
+  := by sorry
+-/
+#guard_msgs in
+example (x y : Nat) (_ : x < 3 ∧ y < 4) (_ : x < 3) (_ : y < 4) : True := by
+  clear_redundant_hyps
+  extract_goal1
+  simp only
+
 -- For termination proofs
 syntax "scalar_decr_tac" : tactic
 macro_rules
@@ -62,6 +108,10 @@ macro_rules
       simp_wf <;>
       -- Simplify the context - otherwise simp_all below will blow up
       remove_invImage_assumptions <;>
+      --
+      clear_unused_decls_one_pass <;>
+      --
+      clear_redundant_hyps <;>
       -- Finish
       scalar_tac)
 

--- a/backends/lean/Aeneas/ScalarDecrTac.lean
+++ b/backends/lean/Aeneas/ScalarDecrTac.lean
@@ -101,9 +101,9 @@ example (x y : Nat) (_ : x < 3 ∧ y < 4) (_ : x < 3) (_ : y < 4) : True := by
   simp only
 
 -- For termination proofs
-syntax "scalar_decr_tac" : tactic
+syntax "scalar_decr_tac_preprocess" : tactic
 macro_rules
-  | `(tactic| scalar_decr_tac) =>
+  | `(tactic| scalar_decr_tac_preprocess) =>
     `(tactic|
       simp_wf <;>
       -- Simplify the context - otherwise simp_all below will blow up
@@ -111,9 +111,13 @@ macro_rules
       --
       clear_unused_decls_one_pass <;>
       --
-      clear_redundant_hyps <;>
-      -- Finish
-      scalar_tac)
+      clear_redundant_hyps)
+
+-- For termination proofs
+syntax "scalar_decr_tac" : tactic
+macro_rules
+  | `(tactic| scalar_decr_tac) =>
+    `(tactic| scalar_decr_tac_preprocess <;> scalar_tac)
 
 -- This simplification lemma it is useful for the proofs of termination
 attribute [scalar_tac_simps, simp] Prod.lex_iff

--- a/backends/lean/Aeneas/ScalarDecrTac.lean
+++ b/backends/lean/Aeneas/ScalarDecrTac.lean
@@ -46,9 +46,10 @@ def removeInvImageAssumptions : TacticM Unit := do
   let filtDecls ← liftM (decls.filterM fun decl => do
     if ← isProp decl.type then containsInvertImage decl
     else pure false)
+  let filtDecls := filtDecls.toArray.map LocalDecl.fvarId
   /- Attempt to clear those assumptions - note that it may not always succeed as
      some other assumptions might depend on them -/
-  tryClearFVarIds ⟨ filtDecls.map fun d => d.fvarId ⟩
+  setGoals [← (← getMainGoal).tryClearMany filtDecls]
 
 elab "remove_invImage_assumptions" : tactic =>
   removeInvImageAssumptions

--- a/backends/lean/Aeneas/ScalarTac/CondSimpTac.lean
+++ b/backends/lean/Aeneas/ScalarTac/CondSimpTac.lean
@@ -126,8 +126,10 @@ def condSimpTac
   /- Preprocess the assumptions -/
   let scalarConfig : ScalarTac.Config := { nonLin := config.nonLin, saturationPasses := config.saturationPasses }
   let state ← State.new scalarConfig
-  /- First the hyps to use -/
-  let some (_, hypsToUse) ← scalarTacPartialPreprocess scalarConfig state #[] hypsToUse false
+  /- First the hyps to use.
+     Note that we do not inline the local let-declarations: we will do this only for the "regular" assumptions
+     and the target. -/
+  let some (_, hypsToUse) ← scalarTacPartialPreprocess scalarConfig state (zetaDelta := false) #[] hypsToUse false
     | trace[CondSimpTac] "Goal proven through preprocessing!"; return
   withMainContext do
   trace[CondSimpTac] "Goal after preprocessing the hyps to use ({hypsToUse.map Expr.fvar}): {← getMainGoal}"
@@ -140,7 +142,7 @@ def condSimpTac
   withMainContext do
   trace[CondSimpTac] "Goal after simplifying the preprocessed hyps to use ({hypsToUse.map Expr.fvar}): {← getMainGoal}"
   /- Preprocess the "regular" assumptions -/
-  let some (state, newAsms) ← scalarTacPartialPreprocess scalarConfig state #[] newAsms false
+  let some (state, newAsms) ← scalarTacPartialPreprocess scalarConfig state (zetaDelta := true) #[] newAsms false
     | trace[CondSimpTac] "Goal proven through preprocessing!"; return
   withMainContext do
   trace[CondSimpTac] "Goal after the initial preprocessing: {← getMainGoal}"

--- a/backends/lean/Aeneas/ScalarTac/CondSimpTac.lean
+++ b/backends/lean/Aeneas/ScalarTac/CondSimpTac.lean
@@ -55,7 +55,7 @@ def condSimpParseArgs (tacName : String) (args : TSyntaxArray [`term, `token.«*
         trace[CondSimpTac] "found token: *"
         let decls ← (← getLCtx).getDecls
         let decls ← decls.filterMapM (
-          fun d => do if (← inferType d.type).isProp then pure (some d.fvarId) else pure none)
+          fun d => do if ← isProp d.type then pure (some d.fvarId) else pure none)
         trace[CondSimpTac] "filtered decls: {decls.map Expr.fvar}"
         hypsToUse := hypsToUse.append decls.toArray
       else

--- a/backends/lean/Aeneas/ScalarTac/CondSimpTac.lean
+++ b/backends/lean/Aeneas/ScalarTac/CondSimpTac.lean
@@ -83,8 +83,7 @@ def condSimpTacSimp (config : Simp.Config) (args : CondSimpArgs) (loc : Utils.Lo
   if dischWithScalarTac then
     /- Note that when calling `scalar_tac` we saturate only by looking at the target: we have
        already saturated by looking at the assumptions (we do this once and for all beforehand) -/
-    let (ref, d) ← tacticToDischarge (← `(tactic|scalar_tac -saturateAssumptions))
-    let dischargeWrapper := Lean.Elab.Tactic.Simp.DischargeWrapper.custom ref d
+    let dischargeWrapper ← Simp.tacticToDischarge (scalarTac {saturateAssumptions := false})
     dischargeWrapper.with fun discharge? => do
       -- Initialize the simp context
       let (ctx, simprocs) ← Simp.mkSimpCtx true config .simp simpArgs

--- a/backends/lean/Aeneas/ScalarTac/CondSimpTac.lean
+++ b/backends/lean/Aeneas/ScalarTac/CondSimpTac.lean
@@ -115,8 +115,8 @@ def condSimpTac
   /- Introduce the scalar_tac assumptions - by doing this beforehand we don't have to
      redo it every time we call `scalar_tac`. TODO: also do the `simp_all`. -/
   withMainContext do
-  ScalarTac.scalarTacSaturateForward { nonLin := config.nonLin, saturationPasses := config.saturationPasses }
-    fun scalarTacAsms => do
+  ScalarTac.scalarTacSaturateForward { nonLin := config.nonLin, saturationPasses := config.saturationPasses } none none
+    fun _ scalarTacAsms => do
   trace[CondSimpTac] "Goal after saturating the context: {← getMainGoal}"
   let additionalSimpThms ← addSimpThms
   trace[CondSimpTac] "Goal after adding the additional simp assumptions: {← getMainGoal}"

--- a/backends/lean/Aeneas/ScalarTac/CondSimpTac.lean
+++ b/backends/lean/Aeneas/ScalarTac/CondSimpTac.lean
@@ -151,7 +151,7 @@ def condSimpTacPreprocess (config : CondSimpTacConfig) (hypsArgs args : CondSimp
   /- First the hyps to use.
      Note that we do not inline the local let-declarations: we will do this only for the "regular" assumptions
      and the target. -/
-  let some (_, hypsToUse) ← scalarTacPartialPreprocess scalarConfig hypsArgs.toSimpArgs state (zetaDelta := false) #[] hypsToUse false
+  let some (_, hypsToUse) ← partialPreprocess scalarConfig hypsArgs.toSimpArgs state (zetaDelta := false) #[] hypsToUse false
     | trace[ScalarTac] "Goal proved through preprocessing!"; return none
   withMainContext do
   withTraceNode `ScalarTac (fun _ => pure m!"Goal after preprocessing the hyps to use ({hypsToUse.map Expr.fvar})") do
@@ -166,7 +166,7 @@ def condSimpTacPreprocess (config : CondSimpTacConfig) (hypsArgs args : CondSimp
   withTraceNode `ScalarTac (fun _ => pure m!"Goal after simplifying the preprocessed hyps to use ({hypsToUse.map Expr.fvar})") do
     trace[ScalarTac] "{← getMainGoal}"
   /- Preprocess the "regular" assumptions -/
-  let some (state, newAsms) ← scalarTacPartialPreprocess scalarConfig (← ScalarTac.getSimpArgs) state (zetaDelta := true) #[] newAsms false
+  let some (state, newAsms) ← partialPreprocess scalarConfig (← ScalarTac.getSimpArgs) state (zetaDelta := true) #[] newAsms false
     | trace[ScalarTac] "Goal proved through preprocessing!"; return none
   withMainContext do
   traceGoalWithNode `ScalarTac "Goal after the initial preprocessing"

--- a/backends/lean/Aeneas/ScalarTac/CondSimpTac.lean
+++ b/backends/lean/Aeneas/ScalarTac/CondSimpTac.lean
@@ -16,7 +16,9 @@ structure CondSimpPartialArgs where
   addSimpThms : Array Name := #[]
   hypsToUse : Array FVarId := #[]
 
-def condSimpParseArgs (tacName : String) (args : TSyntaxArray [`term, `token.«*»]) : TacticM CondSimpPartialArgs := do
+def condSimpParseArgs (tacName : String) (args : TSyntaxArray [`term, `token.«*»]) :
+  TacticM CondSimpPartialArgs := do
+  withTraceNode `ScalarTac (fun _ => pure m!"condSimpParseArgs") do
   let mut declsToUnfold := #[]
   let mut addSimpThms := #[]
   let mut hypsToUse := #[]
@@ -27,14 +29,14 @@ def condSimpParseArgs (tacName : String) (args : TSyntaxArray [`term, `token.«*
     | `($stx:ident) => do
       match (← getLCtx).findFromUserName? stx.getId with
       | .some decl =>
-        trace[CondSimpTac] "arg (local decl): {stx.raw}"
+        trace[ScalarTac] "arg (local decl): {stx.raw}"
         if decl.isLet then
           declsToUnfold := declsToUnfold.push decl.userName
         else
           hypsToUse := hypsToUse.push decl.fvarId
       | .none =>
         -- Not a local declaration
-        trace[CondSimpTac] "arg (theorem): {stx.raw}"
+        trace[ScalarTac] "arg (theorem): {stx.raw}"
         let some e ← Lean.Elab.Term.resolveId? stx (withInfo := true)
           | throwError m!"Could not find theorem: {arg}"
         if let .const name _ := e then
@@ -50,17 +52,17 @@ def condSimpParseArgs (tacName : String) (args : TSyntaxArray [`term, `token.«*
             | _ => throwError m!"{name} is not a theorem, an axiom or a definition"
         else throwError m!"Unexpected: {arg}"
     | term => do
-      trace[CondSimpTac] "term kind: {term.raw.getKind}"
+      trace[ScalarTac] "term kind: {term.raw.getKind}"
       if term.raw.getKind == `token.«*» then
-        trace[CondSimpTac] "found token: *"
+        trace[ScalarTac] "found token: *"
         let decls ← (← getLCtx).getDecls
         let decls ← decls.filterMapM (
           fun d => do if ← isProp d.type then pure (some d.fvarId) else pure none)
-        trace[CondSimpTac] "filtered decls: {decls.map Expr.fvar}"
+        trace[ScalarTac] "filtered decls: {decls.map Expr.fvar}"
         hypsToUse := hypsToUse.append decls.toArray
       else
         -- TODO: we need to make that work
-        trace[CondSimpTac] "arg (term): {term}"
+        trace[ScalarTac] "arg (term): {term}"
         throwError m!"Unimplemented: arbitrary terms are not supported yet as arguments to `{tacName}` (received: {arg})"
   pure ⟨ declsToUnfold, addSimpThms, hypsToUse ⟩
 
@@ -88,12 +90,13 @@ def condSimpTacSimp (config : Simp.Config) (args : CondSimpArgs) (loc : Utils.Lo
   (toClear : Array FVarId := #[])
   (additionalHypsToUse : Array FVarId := #[]) (state : Option (ScalarTac.State × Array FVarId)) :
   TacticM (Option (Array FVarId)) := do
+  withTraceNode `ScalarTac (fun _ => pure m!"condSimpTacSimp") do
   withMainContext do
   let simpArgs := args.toSimpArgs
   let simpArgs := { simpArgs with hypsToUse := simpArgs.hypsToUse ++ additionalHypsToUse }
   match state with
   | some (state, asms) =>
-    trace[CondSimpTac] "condSimpTacSimp: scalarTac assumptions: {asms.map Expr.fvar}"
+    trace[ScalarTac] "scalarTac assumptions: {asms.map Expr.fvar}"
     /- Note that when calling `scalar_tac` we saturate only by looking at the target: we have
        already saturated by looking at the assumptions (we do this once and for all beforehand) -/
     let dischargeWrapper ← Simp.tacticToDischarge (incrScalarTac {saturateAssumptions := false} state toClear asms)
@@ -105,35 +108,43 @@ def condSimpTacSimp (config : Simp.Config) (args : CondSimpArgs) (loc : Utils.Lo
   | none =>
     Simp.simpAt true config simpArgs loc
 
-/-- A helper to define tactics which perform conditional simplifications with `scalar_tac` as a discharger. -/
-def condSimpTac
-  (tacName : String) (config : CondSimpTacConfig)
-  (simpConfig : Simp.Config) (hypsArgs args : CondSimpArgs)
-  (addSimpThms : TacticM (Array FVarId)) (doFirstSimp : Bool)
-  (loc : Utils.Location) : TacticM Unit := do
-  Elab.Tactic.focus do
+structure PreprocessResult where
+  args : CondSimpArgs
+  toClear : Array FVarId
+  hypsToUse : Array FVarId
+  state : State
+  oldAsms : Array FVarId
+  newAsms : Array FVarId
+  additionalSimpThms : Array FVarId
+
+/-- Preprocess the goal.
+    Return `none` if the preprocessing actually solves the goal.
+-/
+def condSimpTacPreprocess (config : CondSimpTacConfig) (hypsArgs args : CondSimpArgs)
+  (addSimpThms : TacticM (Array FVarId)) : TacticM (Option PreprocessResult) := do
+  withTraceNode `ScalarTac (fun _ => pure m!"condSimpTacPreprocess") do
   withMainContext do
   /- Concatenate the arguments for the conditional rewritings: we only want to restrict the simplifications
      performed on the higher-order hypotheses, but we need all the simplifications performed to those to
      be applied to the rest of the context as well. -/
   let args := args ++ hypsArgs
-  trace[CondSimpTac] "Initial goal: {← getMainGoal}"
+  traceGoalWithNode `ScalarTac  "Initial goal"
   /- First duplicate the propositions in the context: we need the preprocessing of `scalar_tac` to modify
      the assumptions, but we need to preserve a copy so that we can present a clean state to the user later
      (and pretend nothing happened). Note that we do this in two times: we want to treat the simp
      theorems provided by the user in `args` separately from the other assumptions. -/
   let allAssumptions ← pure (← (← getLCtx).getAssumptions).toArray
-  trace[CondSimpTac] "allAssumptions: {allAssumptions.map fun d => Expr.fvar d.fvarId}"
+  trace[ScalarTac] "allAssumptions: {allAssumptions.map fun d => Expr.fvar d.fvarId}"
   let (_, hypsToUse) ← Utils.duplicateAssumptions (some args.hypsToUse)
   withMainContext do
-  trace[CondSimpTac] "Goal after duplicating the hyps to use: {← getMainGoal}"
-  trace[CondSimpTac] "hypsToUse: {hypsToUse.map Expr.fvar}"
+  traceGoalWithNode `ScalarTac "Goal after duplicating the hyps to use"
+  trace[ScalarTac] "hypsToUse: {hypsToUse.map Expr.fvar}"
   /- -/
   let (oldAsms, newAsms) ← Utils.duplicateAssumptions (some (allAssumptions.map LocalDecl.fvarId))
   let toClear := oldAsms
   withMainContext do
-  trace[CondSimpTac] "Goal after duplicating the assumptions: {← getMainGoal}"
-  trace[CondSimpTac] "newAsms: {newAsms.map Expr.fvar}"
+  traceGoalWithNode `ScalarTac "Goal after duplicating the assumptions"
+  trace[ScalarTac] "newAsms: {newAsms.map Expr.fvar}"
   /- Preprocess the assumptions -/
   let scalarConfig : ScalarTac.Config := { nonLin := config.nonLin, saturationPasses := config.saturationPasses }
   let state ← State.new scalarConfig
@@ -141,27 +152,40 @@ def condSimpTac
      Note that we do not inline the local let-declarations: we will do this only for the "regular" assumptions
      and the target. -/
   let some (_, hypsToUse) ← scalarTacPartialPreprocess scalarConfig hypsArgs.toSimpArgs state (zetaDelta := false) #[] hypsToUse false
-    | trace[CondSimpTac] "Goal proven through preprocessing!"; return
+    | trace[ScalarTac] "Goal proved through preprocessing!"; return none
   withMainContext do
-  trace[CondSimpTac] "Goal after preprocessing the hyps to use ({hypsToUse.map Expr.fvar}): {← getMainGoal}"
+  withTraceNode `ScalarTac (fun _ => pure m!"Goal after preprocessing the hyps to use ({hypsToUse.map Expr.fvar})") do
+    trace[ScalarTac] "{← getMainGoal}"
   /- Remove the `forall'` and simplify the hyps to use -/
   let simpHypsToUseArgs := { hypsArgs with hypsToUse := #[], declsToUnfold := #[``forall'] }
   let some hypsToUse ← Simp.simpAt true {failIfUnchanged := false, maxDischargeDepth := 0}
         simpHypsToUseArgs (.targets hypsToUse false)
-    | trace[ScalarTac] "Goal proven by preprocessing!"; return
+    | trace[ScalarTac] "Goal proved by preprocessing!"; return none
   let args := { args with hypsToUse }
   withMainContext do
-  trace[CondSimpTac] "Goal after simplifying the preprocessed hyps to use ({hypsToUse.map Expr.fvar}): {← getMainGoal}"
+  withTraceNode `ScalarTac (fun _ => pure m!"Goal after simplifying the preprocessed hyps to use ({hypsToUse.map Expr.fvar})") do
+    trace[ScalarTac] "{← getMainGoal}"
   /- Preprocess the "regular" assumptions -/
   let some (state, newAsms) ← scalarTacPartialPreprocess scalarConfig (← ScalarTac.getSimpArgs) state (zetaDelta := true) #[] newAsms false
-    | trace[CondSimpTac] "Goal proven through preprocessing!"; return
+    | trace[ScalarTac] "Goal proved through preprocessing!"; return none
   withMainContext do
-  trace[CondSimpTac] "Goal after the initial preprocessing: {← getMainGoal}"
-  trace[CondSimpTac] "newAsms: {newAsms.map Expr.fvar}"
+  traceGoalWithNode `ScalarTac "Goal after the initial preprocessing"
+  trace[ScalarTac] "newAsms: {newAsms.map Expr.fvar}"
   /- Introduce the additional simp theorems -/
   let additionalSimpThms ← addSimpThms
-  trace[CondSimpTac] "Goal after adding the additional simp assumptions: {← getMainGoal}"
+  traceGoalWithNode `ScalarTac "Goal after adding the additional simp assumptions"
+  pure (some { args, toClear, hypsToUse, state, oldAsms, newAsms, additionalSimpThms })
+
+def condSimpTacCore
+  (tacName : String)
+  (simpConfig : Simp.Config)
+  (doFirstSimp : Bool)
+  (loc : Utils.Location)
+  (res : PreprocessResult) : TacticM (Option MVarId) := do
+  withTraceNode `ScalarTac (fun _ => pure m!"CondSimpTacCore") do
+  let { args, toClear, hypsToUse := _, state, oldAsms, newAsms, additionalSimpThms } := res
   /- Simplify the targets (note that we preserve the new assumptions for `scalar_tac`) -/
+  withMainContext do
   let loc ← do
     match loc with
     | .wildcard => pure (Utils.Location.targets oldAsms true)
@@ -170,26 +194,47 @@ def condSimpTac
   let nloc ←
     if doFirstSimp then
       match ← condSimpTacSimp simpConfig args loc (toClear := toClear) (additionalHypsToUse := additionalSimpThms) none with
-      | none => return
+      | none => trace[ScalarTac] "Goal proved through preprocessing!"; return none
       | some freshFvarIds =>
         match loc with
         | .wildcard => pure (Utils.Location.targets freshFvarIds true)
         | .wildcard_dep => throwError "{tacName} does not support using location `Utils.Location.wildcard_dep`"
         | .targets _ type => pure (Utils.Location.targets freshFvarIds type)
     else pure loc
-  trace[CondSimpTac] "Goal after simplifying: {← getMainGoal}"
+  traceGoalWithNode `ScalarTac "Goal after simplifying"
   /- Simplify the targets by using `scalar_tac` as a discharger.
      TODO: scalar_tac should only be allowed to preprocess `scalarTacAsms`.
      TODO: we should preprocess those.
    -/
   let _ ← condSimpTacSimp simpConfig args nloc (toClear := toClear) (additionalHypsToUse := additionalSimpThms) (some (state, newAsms))
-  if (← getUnsolvedGoals) == [] then return
+  if (← getUnsolvedGoals) == [] then pure none
+  else pure (some (← getMainGoal))
+
+def condSimpTacClear (res : PreprocessResult) : TacticM Unit := do
+  withTraceNode `ScalarTac (fun _ => pure m!"CondSimpTacClear") do
+  setGoals [← (← getMainGoal).tryClearMany res.hypsToUse]
+  traceGoalWithNode `ScalarTac "Goal after clearing the duplicated hypotheses to use"
+  setGoals [← (← getMainGoal).tryClearMany res.newAsms]
+  traceGoalWithNode `ScalarTac "Goal after clearing the duplicated assumptions"
+  setGoals [← (← getMainGoal).tryClearMany res.additionalSimpThms]
+  traceGoalWithNode `ScalarTac "Goal after clearing the additional theorems"
+
+/-- A helper to define tactics which perform conditional simplifications with `scalar_tac` as a discharger. -/
+def condSimpTac
+  (tacName : String) (config : CondSimpTacConfig)
+  (simpConfig : Simp.Config) (hypsArgs args : CondSimpArgs)
+  (addSimpThms : TacticM (Array FVarId)) (doFirstSimp : Bool)
+  (loc : Utils.Location) : TacticM Unit := do
+  withTraceNode `ScalarTac (fun _ => pure m!"CondSimpTac") do
+  Elab.Tactic.focus do
+  /- Preprocess -/
+  let some res ←
+    condSimpTacPreprocess config hypsArgs args addSimpThms
+    | trace[ScalarTac] "Goal proved through preprocessing!"; return -- goal proved
+  /- Simplify the targets (note that we preserve the new assumptions for `scalar_tac`) -/
+  let some _ ← condSimpTacCore tacName simpConfig doFirstSimp loc res
+    | trace[ScalarTac] "Goal proved!"; return -- goal proved
   /- Clear the additional assumptions -/
-  setGoals [← (← getMainGoal).tryClearMany hypsToUse]
-  trace[CondSimpTac] "Goal after clearing the duplicated hypotheses to use: {← getMainGoal}"
-  setGoals [← (← getMainGoal).tryClearMany newAsms]
-  trace[CondSimpTac] "Goal after clearing the duplicated assumptions: {← getMainGoal}"
-  setGoals [← (← getMainGoal).tryClearMany additionalSimpThms]
-  trace[CondSimpTac] "Goal after clearing the additional theorems: {← getMainGoal}"
+  condSimpTacClear res
 
 end Aeneas.ScalarTac

--- a/backends/lean/Aeneas/ScalarTac/CondSimpTac.lean
+++ b/backends/lean/Aeneas/ScalarTac/CondSimpTac.lean
@@ -151,7 +151,7 @@ def condSimpTacPreprocess (config : CondSimpTacConfig) (hypsArgs args : CondSimp
   /- First the hyps to use.
      Note that we do not inline the local let-declarations: we will do this only for the "regular" assumptions
      and the target. -/
-  let some (_, hypsToUse) ← partialPreprocess scalarConfig hypsArgs.toSimpArgs state (zetaDelta := false) #[] hypsToUse false
+  let some (_, hypsToUse) ← partialPreprocess scalarConfig hypsArgs.toSimpArgs state (zetaDelta := false) #[] hypsToUse false (postProcessSat := false)
     | trace[ScalarTac] "Goal proved through preprocessing!"; return none
   withMainContext do
   withTraceNode `ScalarTac (fun _ => pure m!"Goal after preprocessing the hyps to use ({hypsToUse.map Expr.fvar})") do
@@ -166,7 +166,7 @@ def condSimpTacPreprocess (config : CondSimpTacConfig) (hypsArgs args : CondSimp
   withTraceNode `ScalarTac (fun _ => pure m!"Goal after simplifying the preprocessed hyps to use ({hypsToUse.map Expr.fvar})") do
     trace[ScalarTac] "{← getMainGoal}"
   /- Preprocess the "regular" assumptions -/
-  let some (state, newAsms) ← partialPreprocess scalarConfig (← ScalarTac.getSimpArgs) state (zetaDelta := true) #[] newAsms false
+  let some (state, newAsms) ← partialPreprocess scalarConfig (← ScalarTac.getSimpArgs) state (zetaDelta := true) #[] newAsms false (postProcessSat := false)
     | trace[ScalarTac] "Goal proved through preprocessing!"; return none
   withMainContext do
   traceGoalWithNode `ScalarTac "Goal after the initial preprocessing"

--- a/backends/lean/Aeneas/ScalarTac/CondSimpTac.lean
+++ b/backends/lean/Aeneas/ScalarTac/CondSimpTac.lean
@@ -74,7 +74,7 @@ structure CondSimpArgs where
 def condSimpTacSimp (config : Simp.Config) (args : CondSimpArgs) (loc : Utils.Location)
   (additionalAsms : Array FVarId := #[]) (dischWithScalarTac : Bool) : TacticM Unit := do
   withMainContext do
-  let simpArgs : Utils.SimpArgs :=
+  let simpArgs : Simp.SimpArgs :=
     {simpThms := args.simpThms,
      simprocs := args.simprocs,
      declsToUnfold := args.declsToUnfold,
@@ -87,11 +87,11 @@ def condSimpTacSimp (config : Simp.Config) (args : CondSimpArgs) (loc : Utils.Lo
     let dischargeWrapper := Lean.Elab.Tactic.Simp.DischargeWrapper.custom ref d
     let _ ← dischargeWrapper.with fun discharge? => do
       -- Initialize the simp context
-      let (ctx, simprocs) ← Utils.mkSimpCtx true config .simp simpArgs
+      let (ctx, simprocs) ← Simp.mkSimpCtx true config .simp simpArgs
       -- Apply the simplifier
-      let _ ← Utils.customSimpLocation ctx simprocs discharge? loc
+      let _ ← Simp.customSimpLocation ctx simprocs discharge? loc
   else
-    Utils.simpAt true config simpArgs loc
+    Simp.simpAt true config simpArgs loc
 
 /-- A helper to define tactics which perform conditional simplifications with `scalar_tac` as a discharger. -/
 def condSimpTac

--- a/backends/lean/Aeneas/ScalarTac/CondSimpTac.lean
+++ b/backends/lean/Aeneas/ScalarTac/CondSimpTac.lean
@@ -202,10 +202,7 @@ def condSimpTacCore
         | .targets _ type => pure (Utils.Location.targets freshFvarIds type)
     else pure loc
   traceGoalWithNode `ScalarTac "Goal after simplifying"
-  /- Simplify the targets by using `scalar_tac` as a discharger.
-     TODO: scalar_tac should only be allowed to preprocess `scalarTacAsms`.
-     TODO: we should preprocess those.
-   -/
+  /- Simplify the targets by using `scalar_tac` as a discharger. -/
   let _ ← condSimpTacSimp simpConfig args nloc (toClear := toClear) (additionalHypsToUse := additionalSimpThms) (some (state, newAsms))
   if (← getUnsolvedGoals) == [] then pure none
   else pure (some (← getMainGoal))

--- a/backends/lean/Aeneas/ScalarTac/Init.lean
+++ b/backends/lean/Aeneas/ScalarTac/Init.lean
@@ -7,8 +7,6 @@ namespace Aeneas.ScalarTac
 # Tracing
 -/
 
-initialize registerTraceClass `CondSimpTac
-
 -- We can't define and use trace classes in the same file
 initialize registerTraceClass `ScalarTac
 

--- a/backends/lean/Aeneas/ScalarTac/Lemmas.lean
+++ b/backends/lean/Aeneas/ScalarTac/Lemmas.lean
@@ -253,6 +253,7 @@ attribute [scalar_tac_simps] Nat.not_eq Int.not_eq
 -/
 
 attribute [scalar_tac_simps, simp_scalar_simps] Nat.cast_add Nat.cast_mul Nat.cast_ofNat
+attribute [scalar_tac_simps, simp_lists_hyps_simps, simp_scalar_hyps_simps] Int.cast_subNatNat
 
 /-!
 # Min, Max

--- a/backends/lean/Aeneas/ScalarTac/Lemmas.lean
+++ b/backends/lean/Aeneas/ScalarTac/Lemmas.lean
@@ -1,6 +1,7 @@
 import Mathlib.Data.ZMod.Basic
 import Aeneas.ScalarTac.ScalarTac
 import Aeneas.Std.Scalar.Core
+import Aeneas.ReduceZMod.ReduceZMod
 
 namespace Aeneas
 
@@ -245,6 +246,14 @@ attribute [scalar_tac a.toNat] Int.toNat_eq_max
 @[scalar_tac_simps]
 theorem Nat_neq_zero_iff (x : ℕ) : x ≠ 0 ↔ 0 < x := by omega
 
+attribute [scalar_tac_simps] Nat.not_eq Int.not_eq
+
+/-!
+# Casts
+-/
+
+attribute [scalar_tac_simps, simp_scalar_simps] Nat.cast_add Nat.cast_mul Nat.cast_ofNat
+
 /-!
 # Min, Max
 -/
@@ -312,6 +321,8 @@ attribute [simp_scalar_simps] ZMod.val_natCast ZMod.val_intCast
 @[simp, simp_scalar_simps]
 theorem ZMod.cast_intCast {n : ℕ} (a : ℤ) [NeZero n] : ((a : ZMod n).cast : ℤ) = a % ↑n := by
   simp only [ZMod.cast_eq_val, ZMod.val_intCast]
+
+attribute [scalar_tac_simps, simp_scalar_simps] ReduceZMod.reduceZMod
 
 /-!
 # Sets

--- a/backends/lean/Aeneas/ScalarTac/ScalarTac.lean
+++ b/backends/lean/Aeneas/ScalarTac/ScalarTac.lean
@@ -347,8 +347,13 @@ def scalarTacPartialPreprocess (config : Config) (state : State)
           | trace[ScalarTac] "Goal proven by preprocessing!"; return none
         /- We apply `simpAll` to all the assumptions -/
         applySimpAll (hypsToUseForSimp ++ assumptions ++ nassumptions) simpTarget
+      else if hypsToUseForSimp.size > 0 && simpTarget then
+        /- Even though there is nothing to preprocess, we want to simplify the goal by using the hypotheses to use,
+           to make sure we propagate equalities for instance -/
         let some _ ← Simp.simpAt true {failIfUnchanged := false, maxDischargeDepth := 0}
           { hypsToUse := hypsToUseForSimp } (.targets #[] simpTarget)
+          | trace[ScalarTac] "Goal proven by preprocessing!"; return none
+        pure (some assumptions)
       else
         pure (some assumptions)
     let some assumptions := r

--- a/backends/lean/Aeneas/ScalarTac/ScalarTac.lean
+++ b/backends/lean/Aeneas/ScalarTac/ScalarTac.lean
@@ -198,7 +198,7 @@ def simpAsmsTarget (simpOnly : Bool) (config : Simp.Config) (args : Simp.SimpArg
   let decls ← lctx.getDecls
   let props ← decls.filterM (fun d => do pure (← inferType d.type).isProp)
   let props := (props.map fun d => d.fvarId).toArray
-  Aeneas.Simp.simpAt simpOnly config args (.targets props true)
+  let _ ← Aeneas.Simp.simpAt simpOnly config args (.targets props true)
 
 /-  Boosting a bit the `omega` tac. -/
 def scalarTacPreprocess (config : Config) : Tactic.TacticM Unit := do
@@ -241,7 +241,7 @@ def scalarTacPreprocess (config : Config) : Tactic.TacticM Unit := do
     return
   trace[ScalarTac] "Goal after simpAll: {← getMainGoal}"
   -- Call `simp` again, this time to inline the let-bindings (otherwise, omega doesn't always manage to deal with them)
-  Simp.simpAt true {zetaDelta := true, failIfUnchanged := false, maxDischargeDepth := 1} simpArgs .wildcard
+  let _ ← Simp.simpAt true {zetaDelta := true, failIfUnchanged := false, maxDischargeDepth := 1} simpArgs .wildcard
   -- We might have proven the goal
   if (← getGoals).isEmpty then
     trace[ScalarTac] "Goal proven by preprocessing!"
@@ -255,7 +255,7 @@ def scalarTacPreprocess (config : Config) : Tactic.TacticM Unit := do
     return
   trace[ScalarTac] "Goal after normCast: {← getMainGoal}"
   -- Call `simp` again because `normCast` sometimes does weird things
-  Simp.simpAt true {failIfUnchanged := false, maxDischargeDepth := 1} simpArgs .wildcard
+  let _ ← Simp.simpAt true {failIfUnchanged := false, maxDischargeDepth := 1} simpArgs .wildcard
   -- We might have proven the goal
   if (← getGoals).isEmpty then
     trace[ScalarTac] "Goal proven by preprocessing!"

--- a/backends/lean/Aeneas/ScalarTac/ScalarTac.lean
+++ b/backends/lean/Aeneas/ScalarTac/ScalarTac.lean
@@ -498,56 +498,6 @@ macro_rules
              | apply ScalarTac.to_int_sub_to_nat_lt) <;>
       simp_all <;> scalar_tac)
 
--- Checking that things happen correctly when there are several conjunctions
-example (x y : Int) (h0: 0 ≤ x) (h1: x ≠ 0) (h2 : 0 ≤ y) (h3 : y ≠ 0) : 0 < x ∧ 0 < y := by
-  scalar_tac
-
--- Checking that things happen correctly when there are several conjunctions
-example (x y : Int) (h0: 0 ≤ x) (h1: x ≠ 0) (h2 : 0 ≤ y) (h3 : y ≠ 0) : 0 < x ∧ 0 < y ∧ x + y ≥ 2 := by
-  scalar_tac
-
--- Checking that we can prove exfalso
-example (a : Prop) (x : Int) (h0: 0 < x) (h1: x < 0) : a := by
-  scalar_tac
-
--- Intermediate cast through natural numbers
-example (a : Prop) (x : Int) (h0: (0 : Nat) < x) (h1: x < 0) : a := by
-  scalar_tac
-
-example (x : Int) (h : x ≤ -3) : x ≤ -2 := by
-  scalar_tac
-
-example (x y : Int) (h : x + y = 3) :
-  let z := x + y
-  z = 3 := by
-  intro z
-  omega
-
-example (P : Nat → Prop) (z : Nat) (h : ∀ x, P x → x ≤ z) (y : Nat) (hy : P y) :
-  y + 2 ≤ z + 2 := by
-  have := h y hy
-  scalar_tac
-
--- Checking that we manage to split the cases/if then else
-example (x : Int) (b : Bool) (h : if b then x ≤ 0 else x ≤ 0) : x ≤ 0 := by
-  scalar_tac +split
-
-/-!
-Checking some non-linear problems
--/
-
-example (x y : Nat) (h0 : x ≤ 4) (h1 : y ≤ 5): x * y ≤ 4 * 5 := by
-  scalar_tac +nonLin
-
-example (x y : Nat) (h0 : x ≤ 4) (h1 : y < 5): x * y < 4 * 5 := by
-  scalar_tac +nonLin
-
-example (x y : Nat) (h0 : x < 4) (h1 : y < 5): x * y < 4 * 5 := by
-  scalar_tac +nonLin
-
-example (x y : Nat) (h0 : x < 4) (h1 : y ≤ 5): x * y < 4 * 5 := by
-  scalar_tac +nonLin
-
 end ScalarTac
 
 end Aeneas

--- a/backends/lean/Aeneas/ScalarTac/ScalarTac.lean
+++ b/backends/lean/Aeneas/ScalarTac/ScalarTac.lean
@@ -208,9 +208,7 @@ def getSimpThmNames : CoreM (Array Name) := do
    the assumptions *does* work, hence this peculiar way of simplifying the context. -/
 def simpAsmsTarget (simpOnly : Bool) (config : Simp.Config) (args : Simp.SimpArgs) : TacticM (Option (Array FVarId)) :=
   withMainContext do
-  let lctx ← getLCtx
-  let decls ← lctx.getDecls
-  let props ← decls.filterM (fun d => do pure (← inferType d.type).isProp)
+  let props ← (← getLCtx).getAssumptions
   let props := (props.map fun d => d.fvarId).toArray
   Aeneas.Simp.simpAt simpOnly config args (.targets props true)
 

--- a/backends/lean/Aeneas/ScalarTac/ScalarTac.lean
+++ b/backends/lean/Aeneas/ScalarTac/ScalarTac.lean
@@ -265,7 +265,7 @@ def scalarTacPreprocess (config : Config) : Tactic.TacticM Unit := do
     trace[ScalarTac] "Goal proven by preprocessing!"
     return
   trace[ScalarTac] "Goal after normCast: {← getMainGoal}"
-  -- Call `simp` again because `normCast` sometimes does weird things
+  -- Call `simp` again because `normCast` sometimes introduces strange terms
   let _ ← Simp.simpAt true {failIfUnchanged := false, maxDischargeDepth := 1} simpArgs .wildcard
   -- We might have proven the goal
   if (← getGoals).isEmpty then

--- a/backends/lean/Aeneas/ScalarTac/ScalarTac.lean
+++ b/backends/lean/Aeneas/ScalarTac/ScalarTac.lean
@@ -285,7 +285,7 @@ def State.new (config : Config) : MetaM State := do
   let saturateState := Saturate.State.new rules
   pure { saturateState }
 
-def scalarTacPartialPreprocess (config : Config) (state : State)
+def scalarTacPartialPreprocess (config : Config) (simpArgs : Simp.SimpArgs) (state : State)
   (zetaDelta : Bool) (hypsToUseForSimp assumptionsToPreprocess : Array FVarId) (simpTarget : Bool) :
   Tactic.TacticM (Option (State × Array FVarId)) := do
   Tactic.focus do
@@ -297,7 +297,6 @@ def scalarTacPartialPreprocess (config : Config) (state : State)
      typed expressions such as `UScalar.ofNat`.
   -/
   trace[ScalarTac] "Original goal before preprocessing: {← getMainGoal}"
-  let simpArgs : Simp.SimpArgs ← getSimpArgs
   let r ← Simp.simpAt true {dsimp := false, failIfUnchanged := false, maxDischargeDepth := 1}
     /- Remove the forall quantifiers to prepare for the call of `simp_all` (we
        don't want `simp_all` to use assumptions of the shape `∀ x, P x`)) -/
@@ -479,7 +478,7 @@ def incrScalarTac (config : Config) (state : State) (toClear : Array FVarId) (as
   let mvarId ← (← getMainGoal).tryClearMany toClear
   setGoals [mvarId]
   /- Saturate by exploring only the goal -/
-  let some (_, _) ← scalarTacPartialPreprocess config state (zetaDelta := true) assumptions #[] true
+  let some (_, _) ← scalarTacPartialPreprocess config (← ScalarTac.getSimpArgs) state (zetaDelta := true) assumptions #[] true
     | trace[ScalarTac] "incrScalarTac: goal proven by preprocessing"
   trace[ScalarTac] "Goal after final preprocessing: {← getMainGoal}"
   /- Call omega -/

--- a/backends/lean/Aeneas/ScalarTac/Tests.lean
+++ b/backends/lean/Aeneas/ScalarTac/Tests.lean
@@ -6,6 +6,57 @@ namespace Aeneas.Std.ScalarTac.Tests
 # Tests
 -/
 
+-- Checking that things happen correctly when there are several conjunctions
+example (x y : Int) (h0: 0 ≤ x) (h1: x ≠ 0) (h2 : 0 ≤ y) (h3 : y ≠ 0) : 0 < x ∧ 0 < y := by
+  scalar_tac
+
+-- Checking that things happen correctly when there are several conjunctions
+example (x y : Int) (h0: 0 ≤ x) (h1: x ≠ 0) (h2 : 0 ≤ y) (h3 : y ≠ 0) : 0 < x ∧ 0 < y ∧ x + y ≥ 2 := by
+  scalar_tac
+
+-- Checking that we can prove exfalso
+example (a : Prop) (x : Int) (h0: 0 < x) (h1: x < 0) : a := by
+  scalar_tac
+
+-- Intermediate cast through natural numbers
+example (a : Prop) (x : Int) (h0: (0 : Nat) < x) (h1: x < 0) : a := by
+  scalar_tac
+
+example (x : Int) (h : x ≤ -3) : x ≤ -2 := by
+  scalar_tac
+
+example (x y : Int) (h : x + y = 3) :
+  let z := x + y
+  z = 3 := by
+  intro z
+  omega
+
+example (P : Nat → Prop) (z : Nat) (h : ∀ x, P x → x ≤ z) (y : Nat) (hy : P y) :
+  y + 2 ≤ z + 2 := by
+  have := h y hy
+  scalar_tac
+
+-- Checking that we manage to split the cases/if then else
+example (x : Int) (b : Bool) (h : if b then x ≤ 0 else x ≤ 0) : x ≤ 0 := by
+  scalar_tac +split
+
+/-!
+Checking some non-linear problems
+-/
+
+example (x y : Nat) (h0 : x ≤ 4) (h1 : y ≤ 5): x * y ≤ 4 * 5 := by
+  scalar_tac +nonLin
+
+example (x y : Nat) (h0 : x ≤ 4) (h1 : y < 5): x * y < 4 * 5 := by
+  scalar_tac +nonLin
+
+example (x y : Nat) (h0 : x < 4) (h1 : y < 5): x * y < 4 * 5 := by
+  scalar_tac +nonLin
+
+example (x y : Nat) (h0 : x < 4) (h1 : y ≤ 5): x * y < 4 * 5 := by
+  scalar_tac +nonLin
+
+
 example (x _y : U32) : x.val ≤ UScalar.max .U32 := by
   scalar_tac_preprocess
 

--- a/backends/lean/Aeneas/Simp.lean
+++ b/backends/lean/Aeneas/Simp.lean
@@ -1,0 +1,1 @@
+import Aeneas.Simp.Simp

--- a/backends/lean/Aeneas/Simp.lean
+++ b/backends/lean/Aeneas/Simp.lean
@@ -1,1 +1,2 @@
 import Aeneas.Simp.Simp
+import Aeneas.Simp.SimpAllAssumptions

--- a/backends/lean/Aeneas/Simp/Simp.lean
+++ b/backends/lean/Aeneas/Simp/Simp.lean
@@ -136,6 +136,8 @@ where
 /- Call the simp tactic. -/
 def simpAt (simpOnly : Bool) (config : Simp.Config) (args : SimpArgs) (loc : Utils.Location) :
   TacticM (Option (Array FVarId)) := do
+  withMainContext do
+  withTraceNode `Simp (fun _ => pure m!"simpAt") do
   -- Initialize the simp context
   let (ctx, simprocs) ← mkSimpCtx simpOnly config .simp args
   -- Apply the simplifier
@@ -146,6 +148,8 @@ def simpAt (simpOnly : Bool) (config : Simp.Config) (args : SimpArgs) (loc : Uti
 -/
 def dsimpAt (simpOnly : Bool) (config : Simp.Config) (args : SimpArgs) (loc : Location) :
   TacticM Unit := do
+  withMainContext do
+  withTraceNode `Simp (fun _ => pure m!"dsimpAt") do
   -- Initialize the simp context
   let (ctx, simprocs) ← mkSimpCtx simpOnly config .dsimp args
   -- Apply the simplifier
@@ -154,6 +158,8 @@ def dsimpAt (simpOnly : Bool) (config : Simp.Config) (args : SimpArgs) (loc : Lo
 -- Call the simpAll tactic
 def simpAll (config : Simp.Config) (simpOnly : Bool) (args : SimpArgs) :
   TacticM Unit := do
+  withMainContext do
+  withTraceNode `Simp (fun _ => pure m!"simpAll") do
   -- Initialize the simp context
   let (ctx, simprocs) ← mkSimpCtx simpOnly config .simpAll args
   -- Apply the simplifier

--- a/backends/lean/Aeneas/Simp/Simp.lean
+++ b/backends/lean/Aeneas/Simp/Simp.lean
@@ -1,0 +1,133 @@
+import Aeneas.Utils
+
+namespace Aeneas.Simp
+
+open Lean Meta Elab Tactic
+
+structure SimpArgs where
+  simprocs : Simp.SimprocsArray := #[]
+  simpThms : Array SimpTheorems := #[]
+  addSimprocs : Array Name := #[]
+  declsToUnfold : Array Name := #[]
+  addSimpThms : Array Name := #[]
+  hypsToUse : Array FVarId := #[]
+
+/- Initialize a context for the `simp` function.
+
+   The initialization of the context is adapted from `elabSimpArgs`.
+   Something very annoying is that there is no function which allows to
+   initialize a simp context without doing an elaboration - as a consequence
+   we write our own here. -/
+def mkSimpCtx (simpOnly : Bool) (config : Simp.Config) (kind : SimpKind) (args : SimpArgs) :
+  MetaM (Simp.Context × Simp.SimprocsArray) := do
+  -- Initialize either with the builtin simp theorems or with all the simp theorems
+  let simpThms ←
+    if simpOnly then simpOnlyBuiltins.foldlM (·.addConst ·) ({} : SimpTheorems)
+    else getSimpTheorems
+  -- Add the equational theorems for the declarations to unfold
+  let addDeclToUnfold (thms : SimpTheorems) (decl : Name) : MetaM SimpTheorems :=
+    if kind == .dsimp then pure (thms.addDeclToUnfoldCore decl)
+    else thms.addDeclToUnfold decl
+  let simpThms ←
+    args.declsToUnfold.foldlM addDeclToUnfold simpThms
+  -- Add the hypotheses and the rewriting theorems
+  let simpThms ←
+    args.hypsToUse.foldlM (fun thms fvarId =>
+      -- post: TODO: don't know what that is. It seems to be true by default.
+      -- inv: invert the equality
+      thms.add (.fvar fvarId) #[] (mkFVar fvarId) (post := true) (inv := false)
+      -- thms.eraseCore (.fvar fvar)
+      ) simpThms
+  -- Add the rewriting theorems to use
+  let simpThms ←
+    args.addSimpThms.foldlM (fun thms thmName => do
+      let info ← getConstInfo thmName
+      if (← isProp info.type) then
+        -- post: TODO: don't know what that is
+        -- inv: invert the equality
+        thms.addConst thmName (post := false) (inv := false)
+      else
+        throwError "Not a proposition: {thmName}"
+      ) simpThms
+  let congrTheorems ← getSimpCongrTheorems
+  let defaultSimprocs ← if simpOnly then pure {} else Simp.getSimprocs
+  let addSimprocs ← args.addSimprocs.foldlM (fun simprocs name => simprocs.add name true) defaultSimprocs
+  let ctx ← Simp.mkContext config (simpTheorems := #[simpThms] ++ args.simpThms) congrTheorems
+  pure (ctx, #[addSimprocs] ++ args.simprocs)
+
+/- Adapted from `Lean.Elab.Tactic.simpLocation` so that:
+   - we can use our own `Location`
+   - we return the fvars which have been simplified (that is, the unmodified fvars,
+     and the fresh fvars introduced because of the simplification).
+     Note that we return an option: if `none`, it means that the goal was closed.
+-/
+def customSimpLocation (ctx : Simp.Context) (simprocs : Simp.SimprocsArray)
+  (discharge? : Option Simp.Discharge := none)
+  (loc : Utils.Location) : TacticM (Option (Array FVarId) × Simp.Stats) := do
+  match loc with
+  | .targets hyps simplifyTarget =>
+    -- Custom behavior: we directly provide the fvar ids of the assumption rather than syntax
+    withMainContext do
+      go hyps simplifyTarget
+  | .wildcard =>
+    -- Simply call the regular simpLocation
+    withMainContext do
+      go (← (← getMainGoal).getNondepPropHyps) (simplifyTarget := true)
+  | .wildcard_dep =>
+    -- Custom behavior
+    withMainContext do
+      -- Lookup *all* the declarations
+      let lctx ← Lean.MonadLCtx.getLCtx
+      let decls ← lctx.getDecls
+      let tgts := (decls.map (fun d => d.fvarId)).toArray
+      -- Call the regular simpLocation.go
+      go tgts (simplifyTarget := true)
+where
+  go (fvarIdsToSimp : Array FVarId) (simplifyTarget : Bool) : TacticM (Option (Array FVarId) × Simp.Stats) := do
+    let mvarId ← getMainGoal
+    let (result?, stats) ← simpGoal mvarId ctx (simprocs := simprocs) (simplifyTarget := simplifyTarget) (discharge? := discharge?) (fvarIdsToSimp := fvarIdsToSimp)
+    let freshFVarIds ←
+      match result? with
+      | none => replaceMainGoal []; pure none
+      | some (fvars, mvarId) => replaceMainGoal [mvarId]; pure fvars
+    /- We need to filter the `fvarIdsToSimp` to remove those which have been replaced with fresh fvars -/
+    let fvars ← do
+      match freshFVarIds with
+      | none => pure none
+      | some freshFVarIds =>
+        withMainContext do
+        let ctx ← getLCtx
+        let ldecls := ctx.foldl (fun set decl => set.insert decl.fvarId) Std.HashSet.emptyWithCapacity
+        pure (fvarIdsToSimp.filter ldecls.contains ++ freshFVarIds)
+    return (fvars, stats)
+
+/- Call the simp tactic. -/
+def simpAt (simpOnly : Bool) (config : Simp.Config) (args : SimpArgs) (loc : Utils.Location) :
+  TacticM (Option (Array FVarId)) := do
+  -- Initialize the simp context
+  let (ctx, simprocs) ← mkSimpCtx simpOnly config .simp args
+  -- Apply the simplifier
+  pure ((← customSimpLocation ctx simprocs (discharge? := .none) loc).fst)
+
+/- Call the dsimp tactic.
+   TODO: update to return the fresh fvar ids.
+-/
+def dsimpAt (simpOnly : Bool) (config : Simp.Config) (args : SimpArgs) (loc : Location) :
+  TacticM Unit := do
+  -- Initialize the simp context
+  let (ctx, simprocs) ← mkSimpCtx simpOnly config .dsimp args
+  -- Apply the simplifier
+  dsimpLocation ctx simprocs loc
+
+-- Call the simpAll tactic
+def simpAll (config : Simp.Config) (simpOnly : Bool) (args : SimpArgs) :
+  TacticM Unit := do
+  -- Initialize the simp context
+  let (ctx, simprocs) ← mkSimpCtx simpOnly config .simpAll args
+  -- Apply the simplifier
+  let (result?, _) ← Lean.Meta.simpAll (← getMainGoal) ctx (simprocs := simprocs)
+  match result? with
+  | none => replaceMainGoal []
+  | some mvarId => replaceMainGoal [mvarId]
+
+end Aeneas.Simp

--- a/backends/lean/Aeneas/Simp/SimpAllAssumptions.lean
+++ b/backends/lean/Aeneas/Simp/SimpAllAssumptions.lean
@@ -1,0 +1,171 @@
+import Lean.Meta.Tactic.Clear
+import Lean.Meta.Tactic.Util
+import Lean.Meta.Tactic.Simp.Main
+import Aeneas.Simp.Simp
+
+/-!
+This file is adapted from Lean.Meta.Tactic.Simp.SimpAll.lean
+We slightly modify `simpAll` to be able to simplify only a *subset* of the assumptions.
+-/
+
+namespace Aeneas.Simp
+
+open Lean Meta
+
+open Simp (Stats SimprocsArray)
+
+namespace SimpAll
+
+structure Entry where
+  fvarId   : FVarId -- original fvarId
+  userName : Name
+  id       : Origin -- id of the theorem at `SimpTheorems`
+  origType : Expr
+  type     : Expr
+  proof    : Expr
+  deriving Inhabited
+
+structure State where
+  modified     : Bool := false
+  mvarId       : MVarId
+  entries      : Array Entry := #[]
+  ctx          : Simp.Context
+  simprocs     : SimprocsArray
+  usedTheorems : Simp.UsedSimps := {}
+  diag         : Simp.Diagnostics := {}
+
+abbrev M := StateRefT State MetaM
+
+private def initEntries (fvars : Array FVarId) : M Unit := do
+  let hs := fvars
+  let hsNonDeps ← (← get).mvarId.getNondepPropHyps
+  let mut simpThms := (← get).ctx.simpTheorems
+  for h in hs do
+    unless simpThms.isErased (.fvar h) do
+      let localDecl ← h.getDecl
+      let proof  := localDecl.toExpr
+      let ctx := (← get).ctx
+      simpThms ← simpThms.addTheorem (.fvar h) proof (config := ctx.indexConfig)
+      modify fun s => { s with ctx := s.ctx.setSimpTheorems simpThms }
+      if hsNonDeps.contains h then
+        -- We only simplify nondependent hypotheses
+        let type ← instantiateMVars localDecl.type
+        let entry : Entry := { fvarId := h, userName := localDecl.userName, id := .fvar h, origType := type, type, proof }
+        modify fun s => { s with entries := s.entries.push entry }
+
+private abbrev getSimpTheorems : M SimpTheoremsArray :=
+  return (← get).ctx.simpTheorems
+
+private partial def loop : M Bool := do
+  modify fun s => { s with modified := false }
+  let simprocs := (← get).simprocs
+  -- simplify entries
+  let entries := (← get).entries
+  for h : i in [:entries.size] do
+    let entry := entries[i]
+    let ctx := (← get).ctx
+    -- We disable the current entry to prevent it to be simplified to `True`
+    let simpThmsWithoutEntry := (← getSimpTheorems).eraseTheorem entry.id
+    let ctx := ctx.setSimpTheorems simpThmsWithoutEntry
+    let (r, stats) ← simpStep (← get).mvarId entry.proof entry.type ctx simprocs (stats := { (← get) with })
+    modify fun s => { s with usedTheorems := stats.usedTheorems, diag := stats.diag }
+    match r with
+    | none => return true -- closed the goal
+    | some (proofNew, typeNew) =>
+      unless typeNew == entry.type do
+        /- We must erase the `id` for the simplified theorem. Otherwise,
+           the previous versions can be used to self-simplify the new version. For example, suppose we have
+           ```
+            x : Nat
+            h : x ≠ 0
+            ⊢ Unit
+           ```
+           In the first round, `h : x ≠ 0` is simplified to `h : ¬ x = 0`.
+
+           It is also important for avoiding identical hypotheses to simplify each other to `True`.
+           Example
+           ```
+           ...
+           h₁ : p a
+           h₂ : p a
+           ⊢ q a
+           ```
+           `h₁` is first simplified to `True`. If we don't remove `h₁` from the set of simp theorems, it will
+           be used to simplify `h₂` to `True` and information is lost.
+
+           We must use `mkExpectedTypeHint` because `inferType proofNew` may not be equal to `typeNew` when
+           we have theorems marked with `rfl`.
+        -/
+        trace[Aeneas.Meta.Tactic.simp.all] "entry.id: {← ppOrigin entry.id}, {entry.type} => {typeNew}"
+        let mut simpThmsNew := (← getSimpTheorems).eraseTheorem (.fvar entry.fvarId)
+        let idNew ← mkFreshId
+        simpThmsNew ← simpThmsNew.addTheorem (.other idNew) (← mkExpectedTypeHint proofNew typeNew) (config := ctx.indexConfig)
+        modify fun s => { s with
+          modified         := true
+          ctx              := ctx.setSimpTheorems simpThmsNew
+          entries[i]       := { entry with type := typeNew, proof := proofNew, id := .other idNew }
+        }
+  if (← get).modified then
+    loop
+  else
+    return false
+
+def main (fvars : Array FVarId) : M (Option (Array FVarId × MVarId)) := do
+  initEntries fvars
+  if (← loop) then
+    return none -- close the goal
+  else
+    let mvarId := (← get).mvarId
+    -- Prior to #2334, the logic here was to re-assert all hypotheses and call `tryClearMany` on them all.
+    -- This had the effect that the order of hypotheses was sometimes modified, whether or not any where simplified.
+    -- Now we only re-assert the first modified hypothesis,
+    -- along with all subsequent hypotheses, so as to preserve the order of hypotheses.
+    let mut toAssert := #[]
+    let mut toClear := #[]
+    let mut preserved := #[]
+    let mut modified := false
+    for e in (← get).entries do
+      if e.type.isTrue then
+        -- Do not assert `True` hypotheses
+        toClear := toClear.push e.fvarId
+      else if modified || e.type != e.origType then
+        toClear := toClear.push e.fvarId
+        toAssert := toAssert.push { userName := e.userName, type := e.type, value := e.proof }
+        modified := true
+      else
+        preserved := preserved.push e.fvarId
+    let (freshIds, mvarId) ← mvarId.assertHypotheses toAssert
+    let mvarId ← mvarId.tryClearMany toClear
+    pure (some (preserved ++ freshIds, mvarId))
+
+end SimpAll
+
+def simpAllAssumptionsAux (mvarId : MVarId) (ctx : Simp.Context) (fvars : Array FVarId) (simprocs : SimprocsArray := #[]) (stats : Stats := {}) :
+  MetaM (Option (Array FVarId × MVarId) × Stats) := do
+  mvarId.withContext do
+    let (r, s) ← (SimpAll.main fvars).run { stats with mvarId, ctx, simprocs }
+    if let .some (_, mvarIdNew) := r then
+      if ctx.config.failIfUnchanged && mvarId == mvarIdNew then
+        throwError "simp_all made no progress"
+    return (r, { s with })
+
+open Utils Simp Elab Tactic in
+def simpAllAssumptions (config : Simp.Config) (simpOnly : Bool) (args : SimpArgs) (mvarId : MVarId) (fvars : Array FVarId) :
+  MetaM (Option (Array FVarId × MVarId)) := do
+  -- Initialize the simp context
+  let (ctx, simprocs) ← mkSimpCtx simpOnly config .simpAll args
+  -- Apply the simplifier
+  let (result?, _) ← simpAllAssumptionsAux mvarId ctx fvars (simprocs := simprocs)
+  pure result?
+
+open Utils Simp Elab Tactic in
+def evalSimpAllAssumptions (config : Simp.Config) (simpOnly : Bool) (args : SimpArgs) (mvarId : MVarId) (fvars : Array FVarId) :
+  TacticM (Option (Array FVarId)) := do
+  match ← simpAllAssumptions config simpOnly args mvarId fvars with
+  | none => replaceMainGoal []; pure none
+  | some (fvarIds, mvarId) => replaceMainGoal [mvarId]; pure (some fvarIds)
+
+initialize
+  registerTraceClass `Aeneas.Meta.Tactic.simp.all
+
+end Aeneas.Simp

--- a/backends/lean/Aeneas/SimpBoolProp/Init.lean
+++ b/backends/lean/Aeneas/SimpBoolProp/Init.lean
@@ -36,4 +36,20 @@ initialize simpBoolPropSimprocExt : Simp.SimprocExtension ←
     Those simp procedures are used by several tactics such as `scalar_tac`, `simp_scalar`, `simp_ifs`, etc."
     none --(some simpListsSimprocsRef)
 
+/-- The `simp_bool_prop_hyps_simps` simp attribute. -/
+initialize simpBoolPropHypsSimpExt : SimpExtension ←
+  registerSimpAttr `simp_bool_prop_hyps_simps "\
+    The `simp_bool_prop_hyps_simps` attribute registers simp lemmas to be used to simplify booleans and propositions.
+    Those simp lemmas are used by several tactics such as `scalar_tac`, `simp_scalar`, `simp_ifs`, etc."
+
+-- TODO: initialization fails with this, while the same works for `scalar_tac`??
+--initialize simpListsSimprocsRef : IO.Ref Simprocs ← IO.mkRef {}
+
+/-- The `simp_bool_prop_hyps_simps_proc` simp attribute for the simp rocs. -/
+initialize simpBoolPropHypsSimprocExt : Simp.SimprocExtension ←
+  Simp.registerSimprocAttr `simp_bool_prop_hyps_simps_proc "\
+    The `simp_bool_prop_hyps_simps` attribute registers simp procedures to be used to simplify booleans and propositions.
+    Those simp procedures are used by several tactics such as `scalar_tac`, `simp_scalar`, `simp_ifs`, etc."
+    none --(some simpListsSimprocsRef)
+
 end Aeneas.SimpBoolProp

--- a/backends/lean/Aeneas/SimpIfs/Init.lean
+++ b/backends/lean/Aeneas/SimpIfs/Init.lean
@@ -29,4 +29,19 @@ initialize simpIfsSimprocExt : Simp.SimprocExtension ←
     The `simp_ifs_simps_proc` attribute registers simp procedures to be used by `simp_ifs`
     during its preprocessing phase." none --(some simpIfsSimprocsRef)
 
+/-- The `simp_ifs_hyps_simps` simp attribute. -/
+initialize simpIfsHypsSimpExt : SimpExtension ←
+  registerSimpAttr `simp_ifs_hyps_simps "\
+    The `simp_ifs_hyps_simps` attribute registers simp lemmas to be used by `simp_ifs` when preprocessing hypotheses."
+
+-- TODO: initialization fails with this, while the same works for `scalar_tac`??
+--initialize simpIfsSimprocsRef : IO.Ref Simprocs ← IO.mkRef {}
+
+/-- The `simp_ifs_hyps_simps_proc` simp attribute for the simp rocs. -/
+initialize simpIfsHypsSimprocExt : Simp.SimprocExtension ←
+  Simp.registerSimprocAttr `simp_ifs_hyps_simps_proc "\
+    The `simp_ifs_hyps_simps_proc` attribute registers simp procedures to be used by `simp_ifs`
+    during its preprocessing phase." none --(some simpIfsSimprocsRef)
+
+
 end Aeneas.SimpIfs

--- a/backends/lean/Aeneas/SimpIfs/SimpIfs.lean
+++ b/backends/lean/Aeneas/SimpIfs/SimpIfs.lean
@@ -15,6 +15,13 @@ open Lean Lean.Meta Lean.Parser.Tactic Lean.Elab.Tactic
 def simpIfsTac (config : ScalarTac.CondSimpTacConfig)
   (args : ScalarTac.CondSimpPartialArgs) (loc : Utils.Location) : TacticM Unit := do
   let addSimpThms : TacticM (Array FVarId) := pure #[]
+  let hypsArgs : ScalarTac.CondSimpArgs := {
+      simpThms := #[← simpIfsHypsSimpExt.getTheorems, ← SimpBoolProp.simpBoolPropHypsSimpExt.getTheorems],
+      simprocs := #[← simpIfsHypsSimprocExt.getSimprocs, ← SimpBoolProp.simpBoolPropHypsSimprocExt.getSimprocs],
+      declsToUnfold := #[],
+      addSimpThms := #[],
+      hypsToUse := #[],
+    }
   let args : ScalarTac.CondSimpArgs := {
       simpThms := #[← simpIfsSimpExt.getTheorems, ← SimpBoolProp.simpBoolPropSimpExt.getTheorems],
       simprocs := #[← simpIfsSimprocExt.getSimprocs, ← SimpBoolProp.simpBoolPropSimprocExt.getSimprocs],
@@ -22,7 +29,7 @@ def simpIfsTac (config : ScalarTac.CondSimpTacConfig)
       addSimpThms := args.addSimpThms,
       hypsToUse := args.hypsToUse,
     }
-  ScalarTac.condSimpTac "simp_ifs" config {maxDischargeDepth := 2, failIfUnchanged := false} args addSimpThms false loc
+  ScalarTac.condSimpTac "simp_ifs" config {maxDischargeDepth := 2, failIfUnchanged := false} hypsArgs args addSimpThms false loc
 
 syntax (name := simp_ifs) "simp_ifs" Parser.Tactic.optConfig ("[" term,* "]")? (location)? : tactic
 
@@ -35,11 +42,11 @@ theorem if_false {α} (b : Prop) [Decidable b] (x y : α) (hb : ¬ b) : (if b th
   simp only [hb, Bool.false_eq_true, ↓reduceIte]
 
 @[simp_ifs_simps]
-theorem dite_true (c : Prop) [Decidable c] (h : c) (t : c → α) (e : ¬c → α) :
+theorem dite_true {α} (c : Prop) [Decidable c] (h : c) (t : c → α) (e : ¬c → α) :
   dite c t e = t h := by simp [h]
 
 @[simp_ifs_simps]
-theorem dite_fase (c : Prop) [Decidable c] (h : ¬ c) (t : c → α) (e : ¬c → α) :
+theorem dite_fase {α} (c : Prop) [Decidable c] (h : ¬ c) (t : c → α) (e : ¬c → α) :
   dite c t e = e h := by simp [h]
 
 def parseSimpIfs :

--- a/backends/lean/Aeneas/SimpIfs/SimpIfs.lean
+++ b/backends/lean/Aeneas/SimpIfs/SimpIfs.lean
@@ -57,7 +57,7 @@ elab stx:simp_ifs : tactic =>
   let (config, args, loc) ← parseSimpIfs stx
   simpIfsTac config args loc
 
-example [Inhabited α] (i j : Nat) (h :i ≥ j ∧ i < j + 1) : (if i = j then 0 else 1) = 0 := by
+example {α} [Inhabited α] (i j : Nat) (h :i ≥ j ∧ i < j + 1) : (if i = j then 0 else 1) = 0 := by
   simp_ifs
 
 end Aeneas.SimpIfs

--- a/backends/lean/Aeneas/SimpLists/Init.lean
+++ b/backends/lean/Aeneas/SimpLists/Init.lean
@@ -29,4 +29,18 @@ initialize simpListsSimprocExt : Simp.SimprocExtension ←
     The `simp_lists_simps_proc` attribute registers simp procedures to be used by `simp_lists`
     during its preprocessing phase." none --(some simpListsSimprocsRef)
 
+/-- The `simp_lists_hyps_simp` simp attribute. -/
+initialize simpListsHypsSimpExt : SimpExtension ←
+  registerSimpAttr `simp_lists_hyps_simps "\
+    The `simp_lists_hyps_simp` attribute registers simp lemmas to be used by `simp_lists`."
+
+-- TODO: initialization fails with this, while the same works for `scalar_tac`??
+--initialize simpListsSimprocsRef : IO.Ref Simprocs ← IO.mkRef {}
+
+/-- The `simp_lists_hyps_simp_proc` simp attribute for the simp rocs. -/
+initialize simpListsHypsSimprocExt : Simp.SimprocExtension ←
+  Simp.registerSimprocAttr `simp_lists_hyps_simps_proc "\
+    The `simp_lists_hyps_simp_proc` attribute registers simp procedures to be used by `simp_lists`
+    during its preprocessing phase." none --(some simpListsSimprocsRef)
+
 end Aeneas.SimpLists

--- a/backends/lean/Aeneas/SimpLists/SimpLists.lean
+++ b/backends/lean/Aeneas/SimpLists/SimpLists.lean
@@ -40,6 +40,13 @@ attribute [simp_lists_simps] Fin.getElem!_fin
 def simpListsTac (config : ScalarTac.CondSimpTacConfig)
   (args : ScalarTac.CondSimpPartialArgs) (loc : Utils.Location) : TacticM Unit := do
   let addSimpThms : TacticM (Array FVarId) := pure #[]
+  let hypsArgs : ScalarTac.CondSimpArgs := {
+      simpThms := #[← simpListsHypsSimpExt.getTheorems, ← SimpBoolProp.simpBoolPropHypsSimpExt.getTheorems],
+      simprocs := #[← simpListsHypsSimprocExt.getSimprocs, ← SimpBoolProp.simpBoolPropHypsSimprocExt.getSimprocs],
+      declsToUnfold := #[],
+      addSimpThms := #[],
+      hypsToUse := #[],
+    }
   let args : ScalarTac.CondSimpArgs := {
       simpThms := #[← simpListsSimpExt.getTheorems, ← SimpBoolProp.simpBoolPropSimpExt.getTheorems],
       simprocs := #[← simpListsSimprocExt.getSimprocs, ← SimpBoolProp.simpBoolPropSimprocExt.getSimprocs],
@@ -47,7 +54,7 @@ def simpListsTac (config : ScalarTac.CondSimpTacConfig)
       addSimpThms := args.addSimpThms,
       hypsToUse := args.hypsToUse,
     }
-  ScalarTac.condSimpTac "simp_lists" config {maxDischargeDepth := 2, failIfUnchanged := false, contextual := true} args addSimpThms false loc
+  ScalarTac.condSimpTac "simp_lists" config {maxDischargeDepth := 2, failIfUnchanged := false, contextual := true} hypsArgs args addSimpThms false loc
 
 syntax (name := simp_lists) "simp_lists" Parser.Tactic.optConfig ("[" (term<|>"*"),* "]")? (location)? : tactic
 

--- a/backends/lean/Aeneas/SimpLists/SimpLists.lean
+++ b/backends/lean/Aeneas/SimpLists/SimpLists.lean
@@ -35,6 +35,7 @@ attribute [simp_lists_simps]
   Nat.testBit_two_pow_add_eq
 
 attribute [simp_lists_simps] List.map_map List.map_id_fun List.map_id_fun' id_eq
+attribute [simp_lists_simps] Fin.getElem!_fin
 
 def simpListsTac (config : ScalarTac.CondSimpTacConfig)
   (args : ScalarTac.CondSimpPartialArgs) (loc : Utils.Location) : TacticM Unit := do

--- a/backends/lean/Aeneas/SimpLists/Tests.lean
+++ b/backends/lean/Aeneas/SimpLists/Tests.lean
@@ -1,5 +1,6 @@
 import Aeneas.SimpLists.SimpLists
 import Aeneas.List.List
+import Aeneas.Std.Slice
 
 example [Inhabited α] (l : List α) (x : α) (i j : Nat) (hj : i ≠ j) : (l.set j x)[i]! = l[i]! := by
   simp_lists
@@ -23,4 +24,20 @@ example (CList : Type) (l : CList) (get : CList → Nat → Bool) (set : CList �
 
 example (CList : Type) (l : CList) (get : CList → Nat → Bool) (set : CList → Nat → Bool → CList)
   (h : ∀ i j l x, i ≠ j → get (set l i x) j = get l j) (i j : Nat) (hi : i < j) : get (set l i x) j = get l j := by
+  simp_lists [*]
+
+example
+  (T : Type)
+  [Inhabited T]
+  (i : ℕ)
+  (tl : List T)
+  (h : i < tl.length + 1)
+  (hi : ¬i = 0)
+  (i1 : ℕ)
+  (_ : i1 = i - 1)
+  (_ : 1 ≤ i)
+  (x : T)
+  (_ : x = tl[i1]!) :
+  x = tl[i - 1]!
+  := by
   simp_lists [*]

--- a/backends/lean/Aeneas/SimpLists/Tests.lean
+++ b/backends/lean/Aeneas/SimpLists/Tests.lean
@@ -41,3 +41,14 @@ example
   x = tl[i - 1]!
   := by
   simp_lists [*]
+
+abbrev Zq := ZMod 3329
+
+example
+  (x y : ℕ)
+  (l : List ℕ)
+  (h : ∀ (j : ℕ), (↑l[j]! : Zq) = (↑x : Zq) - (↑y : Zq))
+  (j : ℕ) :
+  (↑l[j]! : Zq) = (↑x : Zq) - (↑y : Zq)
+  := by
+  simp_lists [h]

--- a/backends/lean/Aeneas/SimpLists/Tests.lean
+++ b/backends/lean/Aeneas/SimpLists/Tests.lean
@@ -2,6 +2,8 @@ import Aeneas.SimpLists.SimpLists
 import Aeneas.List.List
 import Aeneas.Std.Slice
 
+open Aeneas Std
+
 example {α} [Inhabited α] (l : List α) (x : α) (i j : Nat) (hj : i ≠ j) : (l.set j x)[i]! = l[i]! := by
   simp_lists
 
@@ -43,3 +45,38 @@ example
   (↑l[j]! : ZMod 3329) = (↑x : ZMod 3329) - (↑y : ZMod 3329)
   := by
   simp_lists [h]
+
+/- This test comes from SymCrypt -/
+example
+    (f : Std.Array U16 256#usize)
+    (g : Std.Array U16 256#usize)
+    (B0 : ℕ)
+    (B1 : ℕ)
+    (i0 : ℕ)
+    (i : Usize)
+    (c0 : U32)
+    (c1 : U32)
+    (paDst0 : Std.Array U32 256#usize)
+    (paDst : Std.Array U32 256#usize)
+    (hi0 : i0 < 128)
+    (hc0bound : (↑c0 : ℕ) ≤ B0 + B1)
+    (hc1bound : (↑c1 : ℕ) ≤ B0 + B1)
+    (hc1 : (↑c1 : ℕ) =
+    (↑paDst0[(↑i : ℕ) + 1]! : ℕ) + (↑f[(↑i : ℕ)]! : ℕ) * (↑g[(↑i : ℕ) + 1]! : ℕ) +
+      (↑f[(↑i : ℕ) + 1]! : ℕ) * (↑g[(↑i : ℕ)]! : ℕ))
+    (hi : (↑i : ℕ) = 2 * i0)
+    (paDst1 : Std.Array U32 256#usize)
+    (paDst1_post : paDst1 = paDst.set i c0)
+    (i' : Usize)
+    (i'_post : (↑i' : ℕ) = (↑i : ℕ) + 1)
+    (paDst2 : Std.Array U32 256#usize)
+    (paDst2_post : paDst2 = paDst1.set i' c1)
+    (h0 : ∀ j < i0, (↑paDst[2 * j]! : ℕ) ≤ B0 + B1 ∧ (↑paDst[2 * j + 1]! : ℕ) ≤ B0 + B1)
+    (h1 : ∀ (j : ℕ), i0 ≤ j → j < 128 → (↑paDst0[2 * j]! : ℕ) ≤ B0 ∧ (↑paDst0[2 * j + 1]! : ℕ) ≤ B0)
+    (h3 : ∀ (j : ℕ), i0 ≤ j → j < 128 → paDst[2 * j]! = paDst0[2 * j]! ∧ paDst[2 * j + 1]! = paDst0[2 * j + 1]!)
+    (j : ℕ)
+    (hj : j < i0 + 1)
+    (hjeq : j = i0) :
+    (↑paDst2[2 * j]! : ℕ) ≤ B0 + B1 ∧ (↑paDst2[2 * j + 1]! : ℕ) ≤ B0 + B1
+    := by
+    simp_lists [*]

--- a/backends/lean/Aeneas/SimpLists/Tests.lean
+++ b/backends/lean/Aeneas/SimpLists/Tests.lean
@@ -2,27 +2,20 @@ import Aeneas.SimpLists.SimpLists
 import Aeneas.List.List
 import Aeneas.Std.Slice
 
-example [Inhabited α] (l : List α) (x : α) (i j : Nat) (hj : i ≠ j) : (l.set j x)[i]! = l[i]! := by
+example {α} [Inhabited α] (l : List α) (x : α) (i j : Nat) (hj : i ≠ j) : (l.set j x)[i]! = l[i]! := by
   simp_lists
 
-example [Inhabited α] (l : List α) (x : α) (i : Nat) (hi : i < l.length) : (l.set i x)[i]! = x := by
+example {α} [Inhabited α] (l : List α) (x : α) (i : Nat) (hi : i < l.length) : (l.set i x)[i]! = x := by
   simp_lists
 
-/-- We use this lemma to "normalize" successive calls to `List.set` -/
-@[simp_lists_simps]
-theorem List.set_comm_lt (a b : α) (n m : Nat) (l : List α) (h : n < m) :
-  (l.set m a).set n b = (l.set n b).set m a := by
-  rw [List.set_comm]
-  omega
-
-example [Inhabited α] (l : List α) (x y : α) (i j : Nat) (hj : i < j) : (l.set i x).set j y = (l.set j y).set i x := by
+example {α} [Inhabited α] (l : List α) (x y : α) (i j : Nat) (hj : i < j) : (l.set i x).set j y = (l.set j y).set i x := by
   simp_lists
 
-example (CList : Type) (l : CList) (get : CList → Nat → Bool) (set : CList → Nat → Bool → CList)
+example (CList : Type) (l : CList) (x : Bool) (get : CList → Nat → Bool) (set : CList → Nat → Bool → CList)
   (h : ∀ i j l x, i ≠ j → get (set l i x) j = get l j) (i j : Nat) (hi : i < j) : get (set l i x) j = get l j := by
   simp_lists [h]
 
-example (CList : Type) (l : CList) (get : CList → Nat → Bool) (set : CList → Nat → Bool → CList)
+example (CList : Type) (l : CList) (x : Bool) (get : CList → Nat → Bool) (set : CList → Nat → Bool → CList)
   (h : ∀ i j l x, i ≠ j → get (set l i x) j = get l j) (i j : Nat) (hi : i < j) : get (set l i x) j = get l j := by
   simp_lists [*]
 
@@ -42,13 +35,11 @@ example
   := by
   simp_lists [*]
 
-abbrev Zq := ZMod 3329
-
 example
   (x y : ℕ)
   (l : List ℕ)
-  (h : ∀ (j : ℕ), (↑l[j]! : Zq) = (↑x : Zq) - (↑y : Zq))
+  (h : ∀ (j : ℕ), (↑l[j]! : ZMod 3329) = (↑x : ZMod 3329) - (↑y : ZMod 3329))
   (j : ℕ) :
-  (↑l[j]! : Zq) = (↑x : Zq) - (↑y : Zq)
+  (↑l[j]! : ZMod 3329) = (↑x : ZMod 3329) - (↑y : ZMod 3329)
   := by
   simp_lists [h]

--- a/backends/lean/Aeneas/SimpListsScalar.lean
+++ b/backends/lean/Aeneas/SimpListsScalar.lean
@@ -14,6 +14,20 @@ open Lean Lean.Meta Lean.Parser.Tactic Lean.Elab.Tactic
 def simpListsScalarTac (config : ScalarTac.CondSimpTacConfig)
   (args : ScalarTac.CondSimpPartialArgs) (loc : Utils.Location) : TacticM Unit := do
   let addSimpThms : TacticM (Array FVarId) := pure #[]
+  let hypsArgs : ScalarTac.CondSimpArgs := {
+      simpThms := #[
+        ← SimpBoolProp.simpBoolPropHypsSimpExt.getTheorems,
+        ← SimpLists.simpListsHypsSimpExt.getTheorems,
+        ← SimpScalar.simpScalarHypsSimpExt.getTheorems],
+      simprocs := #[
+        ← SimpBoolProp.simpBoolPropHypsSimprocExt.getSimprocs,
+        ← SimpLists.simpListsHypsSimprocExt.getSimprocs,
+        ← SimpScalar.simpScalarHypsSimprocExt.getSimprocs
+        ],
+      declsToUnfold := #[],
+      addSimpThms := #[],
+      hypsToUse := #[],
+    }
   let args : ScalarTac.CondSimpArgs := {
       simpThms := #[
         ← SimpBoolProp.simpBoolPropSimpExt.getTheorems,
@@ -28,7 +42,7 @@ def simpListsScalarTac (config : ScalarTac.CondSimpTacConfig)
       addSimpThms := args.addSimpThms,
       hypsToUse := args.hypsToUse,
     }
-  ScalarTac.condSimpTac "simp_lists_scalar" config {maxDischargeDepth := 2, failIfUnchanged := false, contextual := true} args addSimpThms false loc
+  ScalarTac.condSimpTac "simp_lists_scalar" config {maxDischargeDepth := 2, failIfUnchanged := false, contextual := true} hypsArgs args addSimpThms false loc
 
 syntax (name := simp_lists) "simp_lists_scalar" Parser.Tactic.optConfig ("[" (term<|>"*"),* "]")? (location)? : tactic
 

--- a/backends/lean/Aeneas/SimpScalar.lean
+++ b/backends/lean/Aeneas/SimpScalar.lean
@@ -1,1 +1,2 @@
 import Aeneas.SimpScalar.SimpScalar
+import Aeneas.SimpScalar.Tests

--- a/backends/lean/Aeneas/SimpScalar/Init.lean
+++ b/backends/lean/Aeneas/SimpScalar/Init.lean
@@ -29,4 +29,18 @@ initialize simpScalarSimprocExt : Simp.SimprocExtension ←
     The `simp_scalar_simps_proc` attribute registers simp procedures to be used by `simp_scalar`
     during its preprocessing phase." none --(some simpScalarSimprocsRef)
 
+/-- The `simp_scalar_hyps_simp` simp attribute. -/
+initialize simpScalarHypsSimpExt : SimpExtension ←
+  registerSimpAttr `simp_scalar_hyps_simps "\
+    The `simp_scalar_hyps_simp` attribute registers simp lemmas to be used by `simp_scalar`."
+
+-- TODO: initialization fails with this, while the same works for `scalar_tac`??
+--initialize simpScalarSimprocsRef : IO.Ref Simprocs ← IO.mkRef {}
+
+/-- The `simp_scalar_hyps_simp_proc` simp attribute for the simp rocs. -/
+initialize simpScalarHypsSimprocExt : Simp.SimprocExtension ←
+  Simp.registerSimprocAttr `simp_scalar_hyps_simps_proc "\
+    The `simp_scalar_hyps_simp_proc` attribute registers simp procedures to be used by `simp_scalar`
+    during its preprocessing phase." none --(some simpScalarSimprocsRef)
+
 end Aeneas.SimpScalar

--- a/backends/lean/Aeneas/SimpScalar/SimpScalar.lean
+++ b/backends/lean/Aeneas/SimpScalar/SimpScalar.lean
@@ -175,6 +175,13 @@ attribute [simp_scalar_simps] BitVec.setWidth_eq BitVec.ofNat_eq_ofNat
 def simpScalarTac (config : ScalarTac.CondSimpTacConfig)
   (args : ScalarTac.CondSimpPartialArgs) (loc : Utils.Location) : TacticM Unit := do
   let addSimpThms : TacticM (Array FVarId) := pure #[]
+  let hypsArgs : ScalarTac.CondSimpArgs := {
+      simpThms := #[← simpScalarHypsSimpExt.getTheorems, ← SimpBoolProp.simpBoolPropHypsSimpExt.getTheorems],
+      simprocs := #[← simpScalarHypsSimprocExt.getSimprocs, ← SimpBoolProp.simpBoolPropHypsSimprocExt.getSimprocs],
+      declsToUnfold := #[],
+      addSimpThms := #[],
+      hypsToUse := #[],
+    }
   let args : ScalarTac.CondSimpArgs := {
       simpThms := #[← simpScalarSimpExt.getTheorems, ← SimpBoolProp.simpBoolPropSimpExt.getTheorems],
       simprocs := #[← simpScalarSimprocExt.getSimprocs, ← SimpBoolProp.simpBoolPropSimprocExt.getSimprocs],
@@ -184,7 +191,7 @@ def simpScalarTac (config : ScalarTac.CondSimpTacConfig)
     }
   ScalarTac.condSimpTac "simp_scalar" config
     {maxDischargeDepth := 2, failIfUnchanged := false, contextual := true}
-    args addSimpThms false loc
+    hypsArgs args addSimpThms false loc
 
 syntax (name := simp_scalar) "simp_scalar" Parser.Tactic.optConfig ("[" (term<|>"*"),* "]")? (location)? : tactic
 

--- a/backends/lean/Aeneas/Std/Array/Array.lean
+++ b/backends/lean/Aeneas/Std/Array/Array.lean
@@ -119,12 +119,12 @@ def Array.set {α : Type u} {n : Usize} (v: Array α n) (i: Usize) (x: α) : Arr
 def Array.set_opt {α : Type u} {n : Usize} (v: Array α n) (i: Usize) (x: Option α) : Array α n :=
   ⟨ v.val.set_opt i.val x, by have := v.property; simp [*] ⟩
 
-@[simp]
+@[simp, simp_lists_simps]
 theorem Array.set_val_eq {α : Type u} {n : Usize} (v: Array α n) (i: Usize) (x: α) :
   (v.set i x).val = v.val.set i.val x := by
   simp [set]
 
-@[simp]
+@[simp, simp_lists_simps]
 theorem Array.set_opt_val_eq {α : Type u} {n : Usize} (v: Array α n) (i: Usize) (x: Option α) :
   (v.set_opt i x).val = v.val.set_opt i.val x := by
   simp [set_opt]

--- a/backends/lean/Aeneas/Std/Array/Array.lean
+++ b/backends/lean/Aeneas/Std/Array/Array.lean
@@ -59,10 +59,10 @@ example : Result (Array Int (Usize.ofNat 2)) := do
 @[reducible] instance {α : Type u} {n : Usize} : GetElem? (Array α n) Nat α (fun a i => i < a.val.length) where
   getElem? a i := getElem? a.val i
 
-@[simp, scalar_tac_simps, simp_lists_simps]
+@[simp, scalar_tac_simps, simp_lists_hyps_simps]
 theorem Array.getElem?_Nat_eq {α : Type u} {n : Usize} (v : Array α n) (i : Nat) : v[i]? = v.val[i]? := by rfl
 
-@[simp, scalar_tac_simps, simp_lists_simps]
+@[simp, scalar_tac_simps, simp_lists_hyps_simps]
 theorem Array.getElem!_Nat_eq {α : Type u} [Inhabited α] {n : Usize} (v : Array α n) (i : Nat) : v[i]! = v.val[i]! := by
   simp only [instGetElem?ArrayNatLtLengthValListEqVal, List.getElem!_eq_getElem?_getD]; split <;> simp_all
   rfl
@@ -73,13 +73,13 @@ theorem Array.getElem!_Nat_eq {α : Type u} [Inhabited α] {n : Usize} (v : Arra
 @[reducible] instance {α : Type u} {n : Usize} : GetElem? (Array α n) Usize α (fun a i => i.val < a.val.length) where
   getElem? a i := getElem? a.val i.val
 
-@[simp, scalar_tac_simps] theorem Array.getElem?_Usize_eq {α : Type u} {n : Usize} (v : Array α n) (i : Usize) : v[i]? = v.val[i.val]? := by rfl
-@[simp, scalar_tac_simps] theorem Array.getElem!_Usize_eq {α : Type u} [Inhabited α] {n : Usize} (v : Array α n) (i : Usize) : v[i]! = v.val[i.val]! := by
+@[simp, scalar_tac_simps, simp_lists_hyps_simps] theorem Array.getElem?_Usize_eq {α : Type u} {n : Usize} (v : Array α n) (i : Usize) : v[i]? = v.val[i.val]? := by rfl
+@[simp, scalar_tac_simps, simp_lists_hyps_simps] theorem Array.getElem!_Usize_eq {α : Type u} [Inhabited α] {n : Usize} (v : Array α n) (i : Usize) : v[i]! = v.val[i.val]! := by
   simp [instGetElem?ArrayUsizeLtNatValLengthValListEq]; split <;> simp_all
   rfl
 
-@[simp, scalar_tac_simps] abbrev Array.get? {α : Type u} {n : Usize} (v : Array α n) (i : Nat) : Option α := getElem? v i
-@[simp, scalar_tac_simps] abbrev Array.get! {α : Type u} {n : Usize} [Inhabited α] (v : Array α n) (i : Nat) : α := getElem! v i
+@[simp, scalar_tac_simps, simp_lists_hyps_simps] abbrev Array.get? {α : Type u} {n : Usize} (v : Array α n) (i : Nat) : Option α := getElem? v i
+@[simp, scalar_tac_simps, simp_lists_hyps_simps] abbrev Array.get! {α : Type u} {n : Usize} [Inhabited α] (v : Array α n) (i : Nat) : α := getElem! v i
 
 @[simp]
 abbrev Array.slice {α : Type u} {n : Usize} [Inhabited α] (v : Array α n) (i j : Nat) : List α :=
@@ -119,12 +119,12 @@ def Array.set {α : Type u} {n : Usize} (v: Array α n) (i: Usize) (x: α) : Arr
 def Array.set_opt {α : Type u} {n : Usize} (v: Array α n) (i: Usize) (x: Option α) : Array α n :=
   ⟨ v.val.set_opt i.val x, by have := v.property; simp [*] ⟩
 
-@[simp, simp_lists_simps]
+@[simp, scalar_tac_simps, simp_lists_hyps_simps]
 theorem Array.set_val_eq {α : Type u} {n : Usize} (v: Array α n) (i: Usize) (x: α) :
   (v.set i x).val = v.val.set i.val x := by
   simp [set]
 
-@[simp, simp_lists_simps]
+@[simp, scalar_tac_simps, simp_lists_hyps_simps]
 theorem Array.set_opt_val_eq {α : Type u} {n : Usize} (v: Array α n) (i: Usize) (x: Option α) :
   (v.set_opt i x).val = v.val.set_opt i.val x := by
   simp [set_opt]

--- a/backends/lean/Aeneas/Std/Scalar/Core.lean
+++ b/backends/lean/Aeneas/Std/Scalar/Core.lean
@@ -751,6 +751,14 @@ instance (ty : UScalarTy) : Inhabited (UScalar ty) := by
 instance (ty : IScalarTy) : Inhabited (IScalar ty) := by
   constructor; cases ty <;> apply (IScalar.ofInt 0 (by simp [IScalar.cMin, IScalar.cMax, IScalar.rMin, IScalar.rMax]; simp_bounds))
 
+@[simp, simp_scalar_simps]
+theorem UScalar.default_val {ty} : (default : UScalar ty).val = 0 := by
+  simp only [default]; cases ty <;> simp
+
+@[simp, simp_scalar_simps]
+theorem UScalar.default_bv {ty} : (default : UScalar ty).bv = 0 := by
+  simp only [default]; cases ty <;> simp
+
 theorem IScalar.min_lt_max (ty : IScalarTy) : IScalar.min ty < IScalar.max ty := by
   cases ty <;> simp [IScalar.min, IScalar.max] <;> (try simp_bounds)
   have : (0 : Int) < 2 ^ (System.Platform.numBits - 1) := by simp

--- a/backends/lean/Aeneas/Std/Scalar/CoreConvertNum.lean
+++ b/backends/lean/Aeneas/Std/Scalar/CoreConvertNum.lean
@@ -116,65 +116,84 @@ private theorem BitVec.setWidth_toNat_le (m : Nat) (x : BitVec n) (h : n ≤ m) 
   apply Nat.mod_eq_of_lt
   omega
 
-@[simp, scalar_tac_simps] theorem FromUsizeU8.from_val_eq (x : U8) : (FromUsizeU8.from x).val = x.val := by
+@[simp, scalar_tac_simps, simp_scalar_simps]
+theorem FromUsizeU8.from_val_eq (x : U8) : (FromUsizeU8.from x).val = x.val := by
   simp only [FromUsizeU8.from]; apply BitVec.setWidth_toNat_le
   cases System.Platform.numBits_eq <;> simp [*]
 
-@[simp, scalar_tac_simps] theorem FromUsizeU16.from_val_eq (x : U16) : (FromUsizeU16.from x).val = x.val := by
+@[simp, scalar_tac_simps, simp_scalar_simps]
+theorem FromUsizeU16.from_val_eq (x : U16) : (FromUsizeU16.from x).val = x.val := by
   simp only [FromUsizeU16.from]; apply BitVec.setWidth_toNat_le
   cases System.Platform.numBits_eq <;> simp [*]
 
-@[simp, scalar_tac_simps] theorem FromUsizeU32.from_val_eq (x : U32) : (FromUsizeU32.from x).val = x.val := by
+@[simp, scalar_tac_simps, simp_scalar_simps]
+theorem FromUsizeU32.from_val_eq (x : U32) : (FromUsizeU32.from x).val = x.val := by
   simp only [FromUsizeU32.from]; apply BitVec.setWidth_toNat_le
   cases System.Platform.numBits_eq <;> simp [*]
 
-@[simp, scalar_tac_simps] theorem FromUsizeUsize.from_val_eq (x : Usize) : (FromUsizeUsize.from x).val = x.val := by
+@[simp, scalar_tac_simps, simp_scalar_simps]
+theorem FromUsizeUsize.from_val_eq (x : Usize) : (FromUsizeUsize.from x).val = x.val := by
   simp only [FromUsizeUsize.from]; apply BitVec.setWidth_toNat_le
   cases System.Platform.numBits_eq <;> simp [*]
 
-@[simp, scalar_tac_simps] theorem FromU8U8.from_val_eq (x : U8) : (FromU8U8.from x).val = x.val := by
+@[simp, scalar_tac_simps, simp_scalar_simps]
+theorem FromU8U8.from_val_eq (x : U8) : (FromU8U8.from x).val = x.val := by
   simp only [FromU8U8.from]; apply BitVec.setWidth_toNat_le; simp
 
-@[simp, scalar_tac_simps] theorem FromU16U8.from_val_eq (x : U8) : (FromU16U8.from x).val = x.val := by
+@[simp, scalar_tac_simps, simp_scalar_simps]
+theorem FromU16U8.from_val_eq (x : U8) : (FromU16U8.from x).val = x.val := by
   simp only [FromU16U8.from]; apply BitVec.setWidth_toNat_le; simp
 
-@[simp, scalar_tac_simps] theorem FromU16U16.from_val_eq (x : U16) : (FromU16U16.from x).val = x.val := by
+@[simp, scalar_tac_simps, simp_scalar_simps]
+theorem FromU16U16.from_val_eq (x : U16) : (FromU16U16.from x).val = x.val := by
   simp only [FromU16U16.from]; apply BitVec.setWidth_toNat_le; simp
 
-@[simp, scalar_tac_simps] theorem FromU32U8.from_val_eq (x : U8) : (FromU32U8.from x).val = x.val := by
+@[simp, scalar_tac_simps, simp_scalar_simps]
+theorem FromU32U8.from_val_eq (x : U8) : (FromU32U8.from x).val = x.val := by
   simp only [FromU32U8.from]; apply BitVec.setWidth_toNat_le; simp
 
-@[simp, scalar_tac_simps] theorem FromU32U16.from_val_eq (x : U16) : (FromU32U16.from x).val = x.val := by
+@[simp, scalar_tac_simps, simp_scalar_simps]
+theorem FromU32U16.from_val_eq (x : U16) : (FromU32U16.from x).val = x.val := by
   simp only [FromU32U16.from]; apply BitVec.setWidth_toNat_le; simp
 
-@[simp, scalar_tac_simps] theorem FromU32U32.from_val_eq (x : U32) : (FromU32U32.from x).val = x.val := by
+@[simp, scalar_tac_simps, simp_scalar_simps]
+theorem FromU32U32.from_val_eq (x : U32) : (FromU32U32.from x).val = x.val := by
   simp only [FromU32U32.from]; apply BitVec.setWidth_toNat_le; simp
 
-@[simp, scalar_tac_simps] theorem FromU64U8.from_val_eq (x : U8) : (FromU64U8.from x).val = x.val := by
+@[simp, scalar_tac_simps, simp_scalar_simps]
+theorem FromU64U8.from_val_eq (x : U8) : (FromU64U8.from x).val = x.val := by
   simp only [FromU64U8.from]; apply BitVec.setWidth_toNat_le; simp
 
-@[simp, scalar_tac_simps] theorem FromU64U16.from_val_eq (x : U16) : (FromU64U16.from x).val = x.val := by
+@[simp, scalar_tac_simps, simp_scalar_simps]
+theorem FromU64U16.from_val_eq (x : U16) : (FromU64U16.from x).val = x.val := by
   simp only [FromU64U16.from]; apply BitVec.setWidth_toNat_le; simp
 
-@[simp, scalar_tac_simps] theorem FromU64U32.from_val_eq (x : U32) : (FromU64U32.from x).val = x.val := by
+@[simp, scalar_tac_simps, simp_scalar_simps]
+theorem FromU64U32.from_val_eq (x : U32) : (FromU64U32.from x).val = x.val := by
   simp only [FromU64U32.from]; apply BitVec.setWidth_toNat_le; simp
 
-@[simp, scalar_tac_simps] theorem FromU64U64.from_val_eq (x : U64) : (FromU64U64.from x).val = x.val := by
+@[simp, scalar_tac_simps, simp_scalar_simps]
+theorem FromU64U64.from_val_eq (x : U64) : (FromU64U64.from x).val = x.val := by
   simp only [FromU64U64.from]; apply BitVec.setWidth_toNat_le; simp
 
-@[simp, scalar_tac_simps] theorem FromU128U8.from_val_eq (x : U8) : (FromU128U8.from x).val = x.val := by
+@[simp, scalar_tac_simps, simp_scalar_simps]
+theorem FromU128U8.from_val_eq (x : U8) : (FromU128U8.from x).val = x.val := by
   simp only [FromU128U8.from]; apply BitVec.setWidth_toNat_le; simp
 
-@[simp, scalar_tac_simps] theorem FromU128U16.from_val_eq (x : U16) : (FromU128U16.from x).val = x.val := by
+@[simp, scalar_tac_simps, simp_scalar_simps]
+theorem FromU128U16.from_val_eq (x : U16) : (FromU128U16.from x).val = x.val := by
   simp only [FromU128U16.from]; apply BitVec.setWidth_toNat_le; simp
 
-@[simp, scalar_tac_simps] theorem FromU128U32.from_val_eq (x : U32) : (FromU128U32.from x).val = x.val := by
+@[simp, scalar_tac_simps, simp_scalar_simps]
+theorem FromU128U32.from_val_eq (x : U32) : (FromU128U32.from x).val = x.val := by
   simp only [FromU128U32.from]; apply BitVec.setWidth_toNat_le; simp
 
-@[simp, scalar_tac_simps] theorem FromU128U64.from_val_eq (x : U64) : (FromU128U64.from x).val = x.val := by
+@[simp, scalar_tac_simps, simp_scalar_simps]
+theorem FromU128U64.from_val_eq (x : U64) : (FromU128U64.from x).val = x.val := by
   simp only [FromU128U64.from]; apply BitVec.setWidth_toNat_le; simp
 
-@[simp, scalar_tac_simps] theorem FromU128U128.from_val_eq (x : U128) : (FromU128U128.from x).val = x.val := by
+@[simp, scalar_tac_simps, simp_scalar_simps]
+theorem FromU128U128.from_val_eq (x : U128) : (FromU128U128.from x).val = x.val := by
   simp only [FromU128U128.from]; apply BitVec.setWidth_toNat_le; simp
 
 @[simp, bvify_simps] theorem FromUsizeU8.from_bv_eq (x : U8) : (FromUsizeU8.from x).bv = x.bv.setWidth _ := by
@@ -248,78 +267,97 @@ private theorem bmod_pow2_eq_of_inBounds' (n : ℕ) (x : ℤ) (h : 0 < n ∧ -2 
   simp [hn] at this
   apply this
 
-@[simp, scalar_tac_simps] theorem FromIsizeI8.from_val_eq (x : I8) : (FromIsizeI8.from x).val = x.val := by
+@[simp, scalar_tac_simps, simp_scalar_simps]
+theorem FromIsizeI8.from_val_eq (x : I8) : (FromIsizeI8.from x).val = x.val := by
   cases System.Platform.numBits_eq <;>
   simp only [FromIsizeI8.from, IScalar.val, BitVec.signExtend] <;> simp <;>
   apply bmod_pow2_eq_of_inBounds' _ x.val (by scalar_tac)
 
-@[simp, scalar_tac_simps] theorem FromIsizeI16.from_val_eq (x : I16) : (FromIsizeI16.from x).val = x.val := by
+@[simp, scalar_tac_simps, simp_scalar_simps]
+theorem FromIsizeI16.from_val_eq (x : I16) : (FromIsizeI16.from x).val = x.val := by
   cases System.Platform.numBits_eq <;>
   simp only [FromIsizeI16.from, IScalar.val, BitVec.signExtend] <;> simp <;>
   apply bmod_pow2_eq_of_inBounds' _ x.val (by scalar_tac)
 
-@[simp, scalar_tac_simps] theorem FromIsizeI32.from_val_eq (x : I32) : (FromIsizeI32.from x).val = x.val := by
+@[simp, scalar_tac_simps, simp_scalar_simps]
+theorem FromIsizeI32.from_val_eq (x : I32) : (FromIsizeI32.from x).val = x.val := by
   cases System.Platform.numBits_eq <;>
   simp only [FromIsizeI32.from, IScalar.val, BitVec.signExtend] <;> simp <;>
   apply bmod_pow2_eq_of_inBounds' _ x.val (by scalar_tac)
 
-@[simp, scalar_tac_simps] theorem FromIsizeIsize.from_val_eq (x : Isize) : (FromIsizeIsize.from x).val = x.val := by
+@[simp, scalar_tac_simps, simp_scalar_simps]
+theorem FromIsizeIsize.from_val_eq (x : Isize) : (FromIsizeIsize.from x).val = x.val := by
   cases System.Platform.numBits_eq <;>
   simp only [FromIsizeIsize.from, IScalar.val, BitVec.signExtend] <;> simp
 
-@[simp, scalar_tac_simps] theorem FromI8I8.from_val_eq (x : I8) : (FromI8I8.from x).val = x.val := by
+@[simp, scalar_tac_simps, simp_scalar_simps]
+theorem FromI8I8.from_val_eq (x : I8) : (FromI8I8.from x).val = x.val := by
   simp only [FromI8I8.from, IScalar.val, BitVec.signExtend]; simp
 
-@[simp, scalar_tac_simps] theorem FromI16I8.from_val_eq (x : I8) : (FromI16I8.from x).val = x.val := by
+@[simp, scalar_tac_simps, simp_scalar_simps]
+theorem FromI16I8.from_val_eq (x : I8) : (FromI16I8.from x).val = x.val := by
   simp only [FromI16I8.from, IScalar.val, BitVec.signExtend]; simp
   apply bmod_pow2_eq_of_inBounds' 16 x.val (by scalar_tac)
 
-@[simp, scalar_tac_simps] theorem FromI16I16.from_val_eq (x : I16) : (FromI16I16.from x).val = x.val := by
+@[simp, scalar_tac_simps, simp_scalar_simps]
+theorem FromI16I16.from_val_eq (x : I16) : (FromI16I16.from x).val = x.val := by
   simp only [FromI16I16.from, IScalar.val, BitVec.signExtend]; simp
 
-@[simp, scalar_tac_simps] theorem FromI32I8.from_val_eq (x : I8) : (FromI32I8.from x).val = x.val := by
+@[simp, scalar_tac_simps, simp_scalar_simps]
+theorem FromI32I8.from_val_eq (x : I8) : (FromI32I8.from x).val = x.val := by
   simp only [FromI32I8.from, IScalar.val, BitVec.signExtend]; simp
   apply bmod_pow2_eq_of_inBounds' 32 x.val (by scalar_tac)
 
-@[simp, scalar_tac_simps] theorem FromI32I16.from_val_eq (x : I16) : (FromI32I16.from x).val = x.val := by
+@[simp, scalar_tac_simps, simp_scalar_simps]
+theorem FromI32I16.from_val_eq (x : I16) : (FromI32I16.from x).val = x.val := by
   simp only [FromI32I16.from, IScalar.val, BitVec.signExtend]; simp
   apply bmod_pow2_eq_of_inBounds' 32 x.val (by scalar_tac)
 
-@[simp, scalar_tac_simps] theorem FromI32I32.from_val_eq (x : I32) : (FromI32I32.from x).val = x.val := by
+@[simp, scalar_tac_simps, simp_scalar_simps]
+theorem FromI32I32.from_val_eq (x : I32) : (FromI32I32.from x).val = x.val := by
   simp only [FromI32I32.from, IScalar.val, BitVec.signExtend]; simp
 
-@[simp, scalar_tac_simps] theorem FromI64I8.from_val_eq (x : I8) : (FromI64I8.from x).val = x.val := by
+@[simp, scalar_tac_simps, simp_scalar_simps]
+theorem FromI64I8.from_val_eq (x : I8) : (FromI64I8.from x).val = x.val := by
   simp only [FromI64I8.from, IScalar.val, BitVec.signExtend]; simp
   apply bmod_pow2_eq_of_inBounds' 64 x.val (by scalar_tac)
 
-@[simp, scalar_tac_simps] theorem FromI64I16.from_val_eq (x : I16) : (FromI64I16.from x).val = x.val := by
+@[simp, scalar_tac_simps, simp_scalar_simps]
+theorem FromI64I16.from_val_eq (x : I16) : (FromI64I16.from x).val = x.val := by
   simp only [FromI64I16.from, IScalar.val, BitVec.signExtend]; simp
   apply bmod_pow2_eq_of_inBounds' 64 x.val (by scalar_tac)
 
-@[simp, scalar_tac_simps] theorem FromI64I32.from_val_eq (x : I32) : (FromI64I32.from x).val = x.val := by
+@[simp, scalar_tac_simps, simp_scalar_simps]
+theorem FromI64I32.from_val_eq (x : I32) : (FromI64I32.from x).val = x.val := by
   simp only [FromI64I32.from, IScalar.val, BitVec.signExtend]; simp
   apply bmod_pow2_eq_of_inBounds' 64 x.val (by scalar_tac)
 
-@[simp, scalar_tac_simps] theorem FromI64I64.from_val_eq (x : I64) : (FromI64I64.from x).val = x.val := by
+@[simp, scalar_tac_simps, simp_scalar_simps]
+theorem FromI64I64.from_val_eq (x : I64) : (FromI64I64.from x).val = x.val := by
   simp only [FromI64I64.from, IScalar.val, BitVec.signExtend]; simp
 
-@[simp, scalar_tac_simps] theorem FromI128I8.from_val_eq (x : I8) : (FromI128I8.from x).val = x.val := by
+@[simp, scalar_tac_simps, simp_scalar_simps]
+theorem FromI128I8.from_val_eq (x : I8) : (FromI128I8.from x).val = x.val := by
   simp only [FromI128I8.from, IScalar.val, BitVec.signExtend]; simp
   apply bmod_pow2_eq_of_inBounds' 128 x.val (by scalar_tac)
 
-@[simp, scalar_tac_simps] theorem FromI128I16.from_val_eq (x : I16) : (FromI128I16.from x).val = x.val := by
+@[simp, scalar_tac_simps, simp_scalar_simps]
+theorem FromI128I16.from_val_eq (x : I16) : (FromI128I16.from x).val = x.val := by
   simp only [FromI128I16.from, IScalar.val, BitVec.signExtend]; simp
   apply bmod_pow2_eq_of_inBounds' 128 x.val (by scalar_tac)
 
-@[simp, scalar_tac_simps] theorem FromI128I32.from_val_eq (x : I32) : (FromI128I32.from x).val = x.val := by
+@[simp, scalar_tac_simps, simp_scalar_simps]
+theorem FromI128I32.from_val_eq (x : I32) : (FromI128I32.from x).val = x.val := by
   simp only [FromI128I32.from, IScalar.val, BitVec.signExtend]; simp
   apply bmod_pow2_eq_of_inBounds' 128 x.val (by scalar_tac)
 
-@[simp, scalar_tac_simps] theorem FromI128I64.from_val_eq (x : I64) : (FromI128I64.from x).val = x.val := by
+@[simp, scalar_tac_simps, simp_scalar_simps]
+theorem FromI128I64.from_val_eq (x : I64) : (FromI128I64.from x).val = x.val := by
   simp only [FromI128I64.from, IScalar.val, BitVec.signExtend]; simp
   apply bmod_pow2_eq_of_inBounds' 128 x.val (by scalar_tac)
 
-@[simp, scalar_tac_simps] theorem FromI128I128.from_val_eq (x : I128) : (FromI128I128.from x).val = x.val := by
+@[simp, scalar_tac_simps, simp_scalar_simps]
+theorem FromI128I128.from_val_eq (x : I128) : (FromI128I128.from x).val = x.val := by
   simp only [FromI128I128.from, IScalar.val, BitVec.signExtend]; simp
 
 @[simp, bvify_simps] theorem FromIsizeI8.from_bv_eq (x : I8) : (FromIsizeI8.from x).bv = x.bv.signExtend _ := by

--- a/backends/lean/Aeneas/Std/Slice.lean
+++ b/backends/lean/Aeneas/Std/Slice.lean
@@ -54,10 +54,10 @@ theorem Slice.len_val {α : Type u} (v : Slice α) : (Slice.len v).val = v.lengt
 @[reducible] instance {α : Type u} : GetElem? (Slice α) Nat α (fun a i => i < a.val.length) where
   getElem? a i := getElem? a.val i
 
-@[simp, scalar_tac_simps, simp_lists_simps]
+@[simp, scalar_tac_simps, simp_lists_hyps_simps]
 theorem Slice.getElem?_Nat_eq {α : Type u} (v : Slice α) (i : Nat) : v[i]? = v.val[i]? := by rfl
 
-@[simp, scalar_tac_simps, simp_lists_simps]
+@[simp, scalar_tac_simps, simp_lists_hyps_simps]
 theorem Slice.getElem!_Nat_eq {α : Type u} [Inhabited α] (v : Slice α) (i : Nat) : v[i]! = v.val[i]! := by
   simp only [instGetElem?SliceNatLtLengthValListLeMax, List.getElem!_eq_getElem?_getD]; split <;> simp_all
   rfl
@@ -68,13 +68,13 @@ theorem Slice.getElem!_Nat_eq {α : Type u} [Inhabited α] (v : Slice α) (i : N
 @[reducible] instance {α : Type u} : GetElem? (Slice α) Usize α (fun a i => i < a.val.length) where
   getElem? a i := getElem? a.val i.val
 
-@[simp, scalar_tac_simps] theorem Slice.getElem?_Usize_eq {α : Type u} (v : Slice α) (i : Usize) : v[i]? = v.val[i.val]? := by rfl
-@[simp, scalar_tac_simps] theorem Slice.getElem!_Usize_eq {α : Type u} [Inhabited α] (v : Slice α) (i : Usize) : v[i]! = v.val[i.val]! := by
+@[simp, scalar_tac_simps, simp_lists_hyps_simps] theorem Slice.getElem?_Usize_eq {α : Type u} (v : Slice α) (i : Usize) : v[i]? = v.val[i.val]? := by rfl
+@[simp, scalar_tac_simps, simp_lists_hyps_simps] theorem Slice.getElem!_Usize_eq {α : Type u} [Inhabited α] (v : Slice α) (i : Usize) : v[i]! = v.val[i.val]! := by
   simp only [instGetElem?SliceUsizeLtNatValLengthValListLeMax, List.getElem!_eq_getElem?_getD]; split <;> simp_all
   rfl
 
-@[simp, scalar_tac_simps] abbrev Slice.get? {α : Type u} (v : Slice α) (i : Nat) : Option α := getElem? v i
-@[simp, scalar_tac_simps] abbrev Slice.get! {α : Type u} [Inhabited α] (v : Slice α) (i : Nat) : α := getElem! v i
+@[simp, scalar_tac_simps, simp_lists_hyps_simps] abbrev Slice.get? {α : Type u} (v : Slice α) (i : Nat) : Option α := getElem? v i
+@[simp, scalar_tac_simps, simp_lists_hyps_simps] abbrev Slice.get! {α : Type u} [Inhabited α] (v : Slice α) (i : Nat) : α := getElem! v i
 
 def Slice.set {α : Type u} (v: Slice α) (i: Usize) (x: α) : Slice α :=
   ⟨ v.val.set i.val x, by have := v.property; simp [*] ⟩
@@ -115,12 +115,12 @@ theorem Slice.index_usize_spec {α : Type u} [Inhabited α] (v: Slice α) (i: Us
   simp only [length, getElem?_Usize_eq, exists_eq_right] at *
   simp only [List.getElem?_eq_getElem, List.getElem!_eq_getElem?_getD, Option.getD_some, hbound]
 
-@[simp, scalar_tac_simps, simp_lists_simps]
+@[simp, scalar_tac_simps, simp_lists_hyps_simps]
 theorem Slice.set_val_eq {α : Type u} (v: Slice α) (i: Usize) (x: α) :
   (v.set i x) = v.val.set i.val x := by
   simp [set]
 
-@[simp, scalar_tac_simps, simp_lists_simps]
+@[simp, scalar_tac_simps, simp_lists_hyps_simps]
 theorem Slice.set_opt_val_eq {α : Type u} (v: Slice α) (i: Usize) (x: Option α) :
   (v.set_opt i x) = v.val.set_opt i.val x := by
   simp [set_opt]

--- a/backends/lean/Aeneas/Std/Vec.lean
+++ b/backends/lean/Aeneas/Std/Vec.lean
@@ -60,10 +60,10 @@ theorem Vec.len_val {α : Type u} (v : Vec α) : (Vec.len v).val = v.length :=
   getElem? a i := getElem? a.val i
   getElem! a i := getElem! a.val i
 
-@[simp, scalar_tac_simps, simp_lists_simps]
+@[simp, scalar_tac_simps, simp_lists_hyps_simps]
 theorem Vec.getElem?_Nat_eq {α : Type u} (v : Vec α) (i : Nat) : v[i]? = v.val[i]? := by rfl
 
-@[simp, scalar_tac_simps, simp_lists_simps]
+@[simp, scalar_tac_simps, simp_lists_hyps_simps]
 theorem Vec.getElem!_Nat_eq {α : Type u} [Inhabited α] (v : Vec α) (i : Nat) : v[i]! = v.val[i]! := by rfl
 
 @[reducible] instance {α : Type u} : GetElem (Vec α) Usize α (fun a i => i < a.val.length) where
@@ -73,11 +73,11 @@ theorem Vec.getElem!_Nat_eq {α : Type u} [Inhabited α] (v : Vec α) (i : Nat) 
   getElem? a i := getElem? a.val i.val
   getElem! a i := getElem! a.val i.val
 
-@[simp, scalar_tac_simps] theorem Vec.getElem?_Usize_eq {α : Type u} (v : Vec α) (i : Usize) : v[i]? = v.val[i.val]? := by rfl
-@[simp, scalar_tac_simps] theorem Vec.getElem!_Usize_eq {α : Type u} [Inhabited α] (v : Vec α) (i : Usize) : v[i]! = v.val[i.val]! := by rfl
+@[simp, scalar_tac_simps, simp_lists_hyps_simps] theorem Vec.getElem?_Usize_eq {α : Type u} (v : Vec α) (i : Usize) : v[i]? = v.val[i.val]? := by rfl
+@[simp, scalar_tac_simps, simp_lists_hyps_simps] theorem Vec.getElem!_Usize_eq {α : Type u} [Inhabited α] (v : Vec α) (i : Usize) : v[i]! = v.val[i.val]! := by rfl
 
-@[simp, scalar_tac_simps] abbrev Vec.get? {α : Type u} (v : Vec α) (i : Nat) : Option α := getElem? v i
-@[simp, scalar_tac_simps] abbrev Vec.get! {α : Type u} [Inhabited α] (v : Vec α) (i : Nat) : α := getElem! v i
+@[simp, scalar_tac_simps, simp_lists_hyps_simps] abbrev Vec.get? {α : Type u} (v : Vec α) (i : Nat) : Option α := getElem? v i
+@[simp, scalar_tac_simps, simp_lists_hyps_simps] abbrev Vec.get! {α : Type u} [Inhabited α] (v : Vec α) (i : Nat) : α := getElem! v i
 
 def Vec.set {α : Type u} (v: Vec α) (i: Usize) (x: α) : Vec α :=
   ⟨ v.val.set i.val x, by have := v.property; simp [*] ⟩
@@ -85,12 +85,12 @@ def Vec.set {α : Type u} (v: Vec α) (i: Usize) (x: α) : Vec α :=
 def Vec.set_opt {α : Type u} (v: Vec α) (i: Usize) (x: Option α) : Vec α :=
   ⟨ v.val.set_opt i.val x, by have := v.property; simp [*] ⟩
 
-@[simp]
+@[simp, scalar_tac_simps, simp_lists_hyps_simps]
 theorem Vec.set_val_eq {α : Type u} (v: Vec α) (i: Usize) (x: α) :
   (v.set i x) = v.val.set i.val x := by
   simp [set]
 
-@[simp]
+@[simp, scalar_tac_simps, simp_lists_hyps_simps]
 theorem Vec.set_opt_val_eq {α : Type u} (v: Vec α) (i: Usize) (x: Option α) :
   (v.set_opt i x) = v.val.set_opt i.val x := by
   simp [set_opt]

--- a/backends/lean/Aeneas/Utils.lean
+++ b/backends/lean/Aeneas/Utils.lean
@@ -342,9 +342,6 @@ def firstTacSolve (tacl : List (TacticM Unit)) : TacticM Unit := do
   match tacl with
   | [] => throwError "no tactic succeeded"
   | tac :: tacl =>
-    -- Should use try ... catch or Lean.observing?
-    -- Generally speaking we should use Lean.observing? to restore the state,
-    -- but with tactics the try ... catch variant seems to work
     try do
       tac
       -- Check that there are no remaining goals

--- a/backends/lean/Aeneas/Utils.lean
+++ b/backends/lean/Aeneas/Utils.lean
@@ -487,9 +487,9 @@ example (x y : Nat) (_ : y * 3000 ≤ 1) (_ : x * 3000 ≤ 1) : y * 3000 ≤ 1 :
   fassumption
 
 -- List all the local declarations matching the goal
-def getAllMatchingAssumptions (type : Expr) : MetaM (List (LocalDecl × Name)) := do
+def getMatchingAssumptions (type : Expr) : MetaM (List (LocalDecl × Name)) := do
   let typeType ← inferType type
-  let decls ← (← getLCtx).getAllDecls
+  let decls ← (← getLCtx).getDecls
   decls.filterMapM fun localDecl => do
     -- Make sure we revert the meta-variables instantiations by saving the state and restoring it
     let s ← saveState
@@ -525,7 +525,7 @@ def singleAssumptionTacCore (dtree : DiscrTree FVarId) : TacticM Unit := do
        several times, but discrimination trees don't work if the expression we match over
        contains meta-variables.
      -/
-    match ← (getAllMatchingAssumptions goal) with
+    match ← (getMatchingAssumptions goal) with
     | [(localDecl, _)] =>
       /- There is a single assumption which matches the goal: use it
          Note that we need to call isDefEq again to properly instantiate the meta-variables -/

--- a/backends/lean/Aeneas/Utils.lean
+++ b/backends/lean/Aeneas/Utils.lean
@@ -1637,22 +1637,6 @@ def optElabTerm (e : Option (TSyntax `term)) : TacticM (Option Expr) := do
   | none => pure none
   | some e => pure (some (← Lean.Elab.Tactic.elabTerm e none))
 
-/-- Compute the list of assumptions which:
-    - either belong to `keep`
-    - or do not belong to `ignore`
-
-    This is useful to refresh a list of fvar ids after applying a tactic such as `simp`
-    to them. Indeed, whenever we apply a simplification to some assumptions, the only way
-    to retrieve their new ids is to go through the context and filter the ids which we know
-    do not come from the duplicated assumptions.
--/
-def refreshFVarIds (keep ignore : Std.HashSet FVarId) : TacticM (Array FVarId) := do
-  withMainContext do
-  let decls := (← (← getLCtx).getDecls).toArray
-  decls.filterMapM fun d => do
-    if (← inferType d.type).isProp ∧ (d.fvarId ∈ keep ∨ d.fvarId ∉ ignore)
-    then pure (some d.fvarId) else pure none
-
 end Utils
 
 end Aeneas

--- a/backends/lean/Aeneas/Utils.lean
+++ b/backends/lean/Aeneas/Utils.lean
@@ -1671,6 +1671,12 @@ def optElabTerm (e : Option (TSyntax `term)) : TacticM (Option Expr) := do
   | none => pure none
   | some e => pure (some (← Lean.Elab.Tactic.elabTerm e none))
 
+def traceGoalWithNode (cls : Name) (msg : String) : TacticM Unit := do
+  withTraceNode cls (fun _ => do pure msg) do
+    if ← isTracingEnabledFor cls then do
+        addTrace cls m!"{← getMainGoal}"
+    else pure ()
+
 end Utils
 
 end Aeneas

--- a/backends/lean/Aeneas/ZModify/Init.lean
+++ b/backends/lean/Aeneas/ZModify/Init.lean
@@ -3,6 +3,10 @@ open Lean Meta
 
 namespace Aeneas.ZModify
 
+/-!
+# ZMod-ify
+-/
+
 /-- The `zmodify_simps` simp attribute. -/
 initialize zmodifySimpExt : SimpExtension ←
   registerSimpAttr `zmodify_simps "\
@@ -15,5 +19,18 @@ initialize zmodifySimprocExt : Simp.SimprocExtension ←
   Simp.registerSimprocAttr `zmodify_simps_proc "\
     The `zmodify_simps_proc` attribute registers simp procedures to be used by `zmodify`
     during its preprocessing phase." (some zmodifySimprocsRef)
+
+/-- The `zmodify_hyps_simp` simp attribute. -/
+initialize zmodifyHypsSimpExt : SimpExtension ←
+  registerSimpAttr `zmodify_hyps_simps "\
+    The `zmodify_hyps_simp` attribute registers simp lemmas to be used by `zmodify`."
+
+initialize zmodifyHypsSimprocsRef : IO.Ref Simprocs ← IO.mkRef {}
+
+/-- The `zmodify_hyps_simp_proc` simp attribute for the simp rocs. -/
+initialize zmodifyHypsSimprocExt : Simp.SimprocExtension ←
+  Simp.registerSimprocAttr `zmodify_hyps_simps_proc "\
+    The `zmodify_hyps_simp_proc` attribute registers simp procedures to be used by `zmodify`
+    during its preprocessing phase." (some zmodifyHypsSimprocsRef)
 
 end Aeneas.ZModify

--- a/backends/lean/Aeneas/ZModify/ZModify.lean
+++ b/backends/lean/Aeneas/ZModify/ZModify.lean
@@ -9,7 +9,7 @@ import Aeneas.ScalarTac.CondSimpTac
 import Aeneas.SimpBoolProp.SimpBoolProp
 
 /-!
-# `zmodify` tactic
+# ZMod-ify tactic
 
 The `zmodify` tactic is used to shift propositions about, e.g., `Nat`, to `ZMod`.
 This tactic is adapted from `zify`.
@@ -52,6 +52,13 @@ def zmodifyTac (config : Config)
         let thm ← mkAppM thName #[n]
         Utils.addDeclTac (← Utils.mkFreshAnonPropUserName) thm (← inferType thm) (asLet := false) fun thm => pure thm.fvarId!
       pure #[← addThm ``Nat.lt_imp_eq_iff_eq_ZMod]
+  let hypsArgs : ScalarTac.CondSimpArgs := {
+      simpThms := #[← zmodifyHypsSimpExt.getTheorems, ← SimpBoolProp.simpBoolPropHypsSimpExt.getTheorems],
+      simprocs := #[← zmodifyHypsSimprocExt.getSimprocs, ← SimpBoolProp.simpBoolPropHypsSimprocExt.getSimprocs],
+      declsToUnfold := #[],
+      addSimpThms := #[],
+      hypsToUse := #[],
+    }
   let args : ScalarTac.CondSimpArgs := {
       -- Note that we also add the push_cast theorems
       simpThms := #[← zmodifySimpExt.getTheorems, ← SimpBoolProp.simpBoolPropSimpExt.getTheorems, ← Lean.Meta.NormCast.pushCastExt.getTheorems],
@@ -61,7 +68,7 @@ def zmodifyTac (config : Config)
       hypsToUse := args.hypsToUse,
     }
   let config := { nonLin := config.nonLin, saturationPasses := config.saturationPasses }
-  ScalarTac.condSimpTac "zmodify" config {maxDischargeDepth := 2, failIfUnchanged := false, contextual := true} args addSimpThms false loc
+  ScalarTac.condSimpTac "zmodify" config {maxDischargeDepth := 2, failIfUnchanged := false, contextual := true} hypsArgs args addSimpThms false loc
 
 syntax (name := zmodify) "zmodify" Parser.Tactic.optConfig ("to" term)? ("[" (term<|>"*"),* "]")? (location)? : tactic
 

--- a/tests/lean/Hashmap/Properties.lean
+++ b/tests/lean/Hashmap/Properties.lean
@@ -239,9 +239,8 @@ theorem new_with_capacity_spec
   . simp_all [HashMap.v, length]
   . fsimp [lookup]
     intro k
-    simp at Hnil -- TODO: this is annoying
     simp_lists [Hnil]
-    simp -- TODO: remove
+    simp
 
 @[progress]
 theorem new_spec (α : Type) :


### PR DESCRIPTION
This PR improves the performance of `condSimpTac` and the tactics which are built on top of it (`simp_scalar`, `simp_lists`,  `bvify`, etc.). It does it by factoring out a big chunk of the preprocessing of `scalar_tac`, before actually performing the conditional simplification. Doing this leads to dramatic performance improvements: for instance, [this proof](https://github.com/AeneasVerif/symcrust/blob/2466f51d16c1a8496764e3a4144bed7f6f7db86d/proofs/Symcrust/Properties/Ntt.lean#L837) in SymCrust goes from 60s to 12s.