### PR TITLE
Update Charon

### DIFF
--- a/charon-pin
+++ b/charon-pin
@@ -1,2 +1,2 @@
 # This is the commit from https://github.com/AeneasVerif/charon that should be used with this version of aeneas.
-56390cbe453b63e286b08c69e111cf6694908448
+acbe869d840dfd2318f2e9de9006ea22e80351fa

--- a/flake.lock
+++ b/flake.lock
@@ -9,11 +9,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1753196272,
-        "narHash": "sha256-yWVsllJgEzE7UxMRoj5+y6jdWsL+mT/uioqgVhbtB1w=",
+        "lastModified": 1753344598,
+        "narHash": "sha256-cHSuyVRZGcdHFzFKiOAVZas2VfihGlzutf4UHHGdjpI=",
         "owner": "aeneasverif",
         "repo": "charon",
-        "rev": "56390cbe453b63e286b08c69e111cf6694908448",
+        "rev": "acbe869d840dfd2318f2e9de9006ea22e80351fa",
         "type": "github"
       },
       "original": {

--- a/src/interp/InterpreterExpressions.mli
+++ b/src/interp/InterpreterExpressions.mli
@@ -52,13 +52,13 @@ val eval_operands :
   * eval_ctx
   * (SymbolicAst.expression -> SymbolicAst.expression)
 
-(** Evaluate an rvalue which is not a global (globals are handled elsewhere).
+(** Evaluate an rvalue.
 
     Transmits the computed rvalue to the received continuation.
 
     Note that this function fails on {!Aeneas.Expressions.rvalue.Discriminant}:
     discriminant reads should have been eliminated from the AST. *)
-val eval_rvalue_not_global :
+val eval_rvalue :
   config ->
   Meta.span ->
   rvalue ->

--- a/src/interp/InterpreterPaths.mli
+++ b/src/interp/InterpreterPaths.mli
@@ -29,7 +29,8 @@ val update_ctx_along_write_place :
 
     Note that we only access the value at the place, and do not check that the
     value is "well-formed" (for instance that it doesn't contain bottoms). *)
-val read_place : Meta.span -> access_kind -> place -> eval_ctx -> typed_value
+val read_place :
+  config -> Meta.span -> access_kind -> place -> eval_ctx -> typed_value
 
 (** Update the value at a given place.
 
@@ -41,7 +42,13 @@ val read_place : Meta.span -> access_kind -> place -> eval_ctx -> typed_value
     the overwritten value contains borrows, loans, etc. and will simply
     overwrite it. *)
 val write_place :
-  Meta.span -> access_kind -> place -> typed_value -> eval_ctx -> eval_ctx
+  config ->
+  Meta.span ->
+  access_kind ->
+  place ->
+  typed_value ->
+  eval_ctx ->
+  eval_ctx
 
 (** Compute an expanded tuple ⊥ value.
 

--- a/src/interp/InterpreterUtils.ml
+++ b/src/interp/InterpreterUtils.ml
@@ -324,8 +324,6 @@ let rvalue_get_place (rv : rvalue) : place option =
   | NullaryOp _
   | UnaryOp _
   | BinaryOp _
-  | Global _
-  | GlobalRef _
   | Discriminant _
   | Aggregate _
   | Repeat _

--- a/src/llbc/FunsAnalysis.ml
+++ b/src/llbc/FunsAnalysis.ml
@@ -112,8 +112,6 @@ let analyze_module (m : crate) (funs_map : fun_decl FunDeclId.Map.t)
             match rv with
             | Use _
             | RvRef _
-            | Global _
-            | GlobalRef _
             | Discriminant _
             | Aggregate _
             | Len _

--- a/src/pure/PrintPure.ml
+++ b/src/pure/PrintPure.ml
@@ -317,6 +317,8 @@ let rec mplace_to_string (env : fmt_env) (p : mplace) : string =
   | PlaceProjection (p, pe) ->
       let inside = mplace_to_string env p in
       mprojection_elem_to_string env inside pe
+  | PlaceGlobal (id, generics) ->
+      global_decl_id_to_string env id ^ generic_args_to_string env generics
 
 let adt_variant_to_string ?(span = None) (env : fmt_env) (adt_id : type_id)
     (variant_id : VariantId.id option) : string =

--- a/src/pure/Pure.ml
+++ b/src/pure/Pure.ml
@@ -684,6 +684,7 @@ type mprojection_elem = { pkind : field_proj_kind; field_id : field_id }
 type mplace =
   | PlaceLocal of E.LocalId.id * string option
   | PlaceProjection of mplace * mprojection_elem
+  | PlaceGlobal of T.global_decl_id * generic_args
 [@@deriving show, ord]
 
 type variant_id = VariantId.id [@@deriving show, ord]

--- a/src/pure/PureUtils.ml
+++ b/src/pure/PureUtils.ml
@@ -979,10 +979,13 @@ let opt_destruct_ret (e : texpression) : texpression option =
   | _ -> None
 
 let decompose_mplace (p : mplace) :
-    E.LocalId.id * string option * mprojection_elem list =
+    (E.LocalId.id, T.global_decl_id * generic_args) Either.t
+    * string option
+    * mprojection_elem list =
   let rec decompose (proj : mprojection_elem list) (p : mplace) =
     match p with
-    | PlaceLocal (id, name) -> (id, name, proj)
+    | PlaceLocal (id, name) -> (Either.Left id, name, proj)
+    | PlaceGlobal (id, generics) -> (Either.Right (id, generics), None, proj)
     | PlaceProjection (p, pe) -> decompose (pe :: proj) p
   in
   decompose [] p

--- a/src/symbolic/SymbolicAst.ml
+++ b/src/symbolic/SymbolicAst.ml
@@ -21,6 +21,7 @@ type mplace =
           id, because the most important information in a place is the name of
           the variable! *)
   | PlaceProjection of mplace * projection_elem
+  | PlaceGlobal of global_decl_ref
 [@@deriving show]
 
 type call_id =

--- a/src/symbolic/SymbolicToPure.ml
+++ b/src/symbolic/SymbolicToPure.ml
@@ -2302,6 +2302,9 @@ let translate_mprojection_elem (pe : E.projection_elem) :
 let rec translate_mplace (p : S.mplace) : mplace =
   match p with
   | PlaceLocal bv -> PlaceLocal (bv.index, bv.name)
+  | PlaceGlobal gref ->
+      let generics = translate_sgeneric_args None gref.generics in
+      PlaceGlobal (gref.id, generics)
   | PlaceProjection (p, pe) -> (
       let p = translate_mplace p in
       let pe = translate_mprojection_elem pe in

--- a/src/symbolic/SynthesizeSymbolic.ml
+++ b/src/symbolic/SynthesizeSymbolic.ml
@@ -14,6 +14,7 @@ let mk_mplace (span : Meta.span) (p : place) (ctx : Contexts.eval_ctx) : mplace
         PlaceLocal (Contexts.ctx_lookup_real_var_binder span ctx var_id)
     | PlaceProjection (subplace, pe) ->
         PlaceProjection (place_to_mplace subplace, pe)
+    | PlaceGlobal gref -> PlaceGlobal gref
   in
   place_to_mplace p
 


### PR DESCRIPTION
Based on https://github.com/AeneasVerif/charon/pull/783

This is a rather invasive change, as globals are now places -- to do this I moved +/- what the `Global` operand did to evaluate place, but only for symbolic mode, as in concrete mode this would require evaluating the function, which isn't possible from `InterpreterPaths`, as that requires `InterpreterStatements`, which itself already uses `InterpreterPaths`, which would create a circular dependency...

An (even more) invasive solution would be to pass a function-evaluation function to anywhere that resolves places, but that's a mess :p 