### PR TITLE
chore: fix proof for forward compatibility with v4.22.0

### DIFF
--- a/backends/lean/Aeneas/Range/DivRange/Lemmas.lean
+++ b/backends/lean/Aeneas/Range/DivRange/Lemmas.lean
@@ -106,8 +106,7 @@ private theorem forIn'_loop_eq_forIn'_divRange [Monad m] (r : DivRange)
     simp only [forIn'.loop, divRange.loop, gt_iff_lt]
     dcases hStop : r.stop < i <;> simp only [hStop, ↓reduceDIte, ↓reduceIte, List.not_mem_nil,
       IsEmpty.forall_iff, implies_true, List.forIn'_nil, List.forIn'_cons]
-    apply letFun_val_congr
-    apply funext
+    apply bind_congr
     intro x
     cases x
     . simp


### PR DESCRIPTION
`letFun_val_congr` was an internal implementation detail which disappears on `v4.22.0`. `bind_congr` is a better choice at this point.