### PR TITLE
Make minor improvements

### DIFF
--- a/src/Main.ml
+++ b/src/Main.ml
@@ -592,10 +592,11 @@ let () =
       if !test_unit_functions then Test.test_unit_functions m;
 
       (* Translate or borrow-check the crate *)
+      let extracted_opaque = ref false in
       if !borrow_check then Aeneas.BorrowCheck.borrow_check_crate m marked_ids
       else
         Aeneas.Translate.translate_crate filename dest_dir !Config.subdir m
-          marked_ids;
+          extracted_opaque marked_ids;
 
       let has_errors =
         if !Errors.error_list <> [] then true
@@ -604,6 +605,15 @@ let () =
             log#linfo (lazy "Crate successfully borrow-checked");
           false)
       in
+
+      (* Print a warning if we had to extract opaque definitions and the option
+         [-split-file] is not on *)
+      if !extracted_opaque && not !split_files then
+        log#lwarning
+          (lazy
+            "The crate contains extracted external, unknown definitions: we \
+             advise using the option -split-files to allow manually providing \
+             these definitions in separate files.");
 
       (* Print total elapsed time *)
       log#linfo

--- a/src/extract/ExtractBase.ml
+++ b/src/extract/ExtractBase.ml
@@ -544,6 +544,10 @@ type extraction_ctx = {
   trait_impls_filter_type_args_map : bool list TraitImplId.Map.t;
       (** Same as {!types_filter_type_args_map}, but for trait implementations
       *)
+  extracted_opaque : bool ref;
+      (** Set to true if at some point we extract a definition which is opaque,
+          meaning we generate an axiom. If yes, and in case the user does not
+          use the option [-split-files] we suggest it to the user. *)
 }
 
 let extraction_ctx_to_fmt_env (ctx : extraction_ctx) : PrintPure.fmt_env =


### PR DESCRIPTION
This PR fixes 2 issues:
- a bug in `ctx_prepare_name` which was triggered if a definition used a name which is exactly the crate's name
- Aeneas now emits a warning if the crate contains unknown, external definition and the user did not pass the `-split-files` option