### PR TITLE
Update charon

### DIFF
--- a/charon-pin
+++ b/charon-pin
@@ -1,2 +1,2 @@
 # This is the commit from https://github.com/AeneasVerif/charon that should be used with this version of aeneas.
-360ff1302a608b304ab7b1c43421884d688c3f21
+71112cccfdcd4f22a9d89401b14b4d9156cac748

--- a/flake.lock
+++ b/flake.lock
@@ -9,11 +9,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1763091316,
-        "narHash": "sha256-wS80Rg0ijidv3GQshhBmwBz/iQWKYOXxyQ1oadN3//s=",
+        "lastModified": 1763418150,
+        "narHash": "sha256-0HF824N+Rb66truWoFyv+xziQkTU+DcP9VnfRwvlcAs=",
         "owner": "aeneasverif",
         "repo": "charon",
-        "rev": "360ff1302a608b304ab7b1c43421884d688c3f21",
+        "rev": "71112cccfdcd4f22a9d89401b14b4d9156cac748",
         "type": "github"
       },
       "original": {

--- a/tests/coq/hashmap/Hashmap_Funs.v
+++ b/tests/coq/hashmap/Hashmap_Funs.v
@@ -96,7 +96,7 @@ Definition hashMap_new (T : Type) (n : nat) : result (HashMap_t T) :=
 .
 
 (** [hashmap::{hashmap::HashMap<T>}::clear]: loop 0:
-    Source: 'tests/src/hashmap.rs', lines 104:8-108:5 *)
+    Source: 'tests/src/hashmap.rs', lines 104:8-107:9 *)
 Fixpoint hashMap_clear_loop
   {T : Type} (n : nat) (slots : alloc_vec_Vec (AList_t T)) (i : usize) :
   result (alloc_vec_Vec (AList_t T))
@@ -122,14 +122,14 @@ Fixpoint hashMap_clear_loop
     Source: 'tests/src/hashmap.rs', lines 100:4-108:5 *)
 Definition hashMap_clear
   {T : Type} (n : nat) (self : HashMap_t T) : result (HashMap_t T) :=
-  v <- hashMap_clear_loop n self.(hashMap_slots) 0%usize;
+  slots <- hashMap_clear_loop n self.(hashMap_slots) 0%usize;
   Ok
     {|
       hashMap_num_entries := 0%usize;
       hashMap_max_load_factor := self.(hashMap_max_load_factor);
       hashMap_max_load := self.(hashMap_max_load);
       hashMap_saturated := self.(hashMap_saturated);
-      hashMap_slots := v
+      hashMap_slots := slots
     |}
 .
 
@@ -140,7 +140,7 @@ Definition hashMap_len {T : Type} (self : HashMap_t T) : result usize :=
 .
 
 (** [hashmap::{hashmap::HashMap<T>}::insert_in_list]: loop 0:
-    Source: 'tests/src/hashmap.rs', lines 118:8-134:5 *)
+    Source: 'tests/src/hashmap.rs', lines 1:0-133:9 *)
 Fixpoint hashMap_insert_in_list_loop
   {T : Type} (n : nat) (key : usize) (value : T) (ls : AList_t T) :
   result (bool * (AList_t T))
@@ -211,7 +211,7 @@ Definition hashMap_insert_no_resize
 .
 
 (** [hashmap::{hashmap::HashMap<T>}::move_elements_from_list]: loop 0:
-    Source: 'tests/src/hashmap.rs', lines 199:12-209:5 *)
+    Source: 'tests/src/hashmap.rs', lines 199:12-206:17 *)
 Fixpoint hashMap_move_elements_from_list_loop
   {T : Type} (n : nat) (ntable : HashMap_t T) (ls : AList_t T) :
   result (HashMap_t T)

--- a/tests/fstar/hashmap/Hashmap.Clauses.Template.fst
+++ b/tests/fstar/hashmap/Hashmap.Clauses.Template.fst
@@ -14,21 +14,21 @@ let hashMap_allocate_slots_loop_decreases (#t : Type0)
   admit ()
 
 (** [hashmap::{hashmap::HashMap<T>}::clear]: decreases clause
-    Source: 'tests/src/hashmap.rs', lines 104:8-108:5 *)
+    Source: 'tests/src/hashmap.rs', lines 104:8-107:9 *)
 unfold
 let hashMap_clear_loop_decreases (#t : Type0)
   (slots : alloc_vec_Vec (aList_t t)) (i : usize) : nat =
   admit ()
 
 (** [hashmap::{hashmap::HashMap<T>}::insert_in_list]: decreases clause
-    Source: 'tests/src/hashmap.rs', lines 118:8-134:5 *)
+    Source: 'tests/src/hashmap.rs', lines 1:0-133:9 *)
 unfold
 let hashMap_insert_in_list_loop_decreases (#t : Type0) (key : usize)
   (value : t) (ls : aList_t t) : nat =
   admit ()
 
 (** [hashmap::{hashmap::HashMap<T>}::move_elements_from_list]: decreases clause
-    Source: 'tests/src/hashmap.rs', lines 199:12-209:5 *)
+    Source: 'tests/src/hashmap.rs', lines 199:12-206:17 *)
 unfold
 let hashMap_move_elements_from_list_loop_decreases (#t : Type0)
   (ntable : hashMap_t t) (ls : aList_t t) : nat =

--- a/tests/fstar/hashmap/Hashmap.Funs.fst
+++ b/tests/fstar/hashmap/Hashmap.Funs.fst
@@ -78,7 +78,7 @@ let hashMap_new (t : Type0) : result (hashMap_t t) =
   hashMap_new_with_capacity t 32 { dividend = 4; divisor = 5 }
 
 (** [hashmap::{hashmap::HashMap<T>}::clear]: loop 0:
-    Source: 'tests/src/hashmap.rs', lines 104:8-108:5 *)
+    Source: 'tests/src/hashmap.rs', lines 104:8-107:9 *)
 let rec hashMap_clear_loop
   (#t : Type0) (slots : alloc_vec_Vec (aList_t t)) (i : usize) :
   Tot (result (alloc_vec_Vec (aList_t t)))
@@ -99,8 +99,8 @@ let rec hashMap_clear_loop
 (** [hashmap::{hashmap::HashMap<T>}::clear]:
     Source: 'tests/src/hashmap.rs', lines 100:4-108:5 *)
 let hashMap_clear (#t : Type0) (self : hashMap_t t) : result (hashMap_t t) =
-  let* v = hashMap_clear_loop self.slots 0 in
-  Ok { self with num_entries = 0; slots = v }
+  let* slots = hashMap_clear_loop self.slots 0 in
+  Ok { self with num_entries = 0; slots }
 
 (** [hashmap::{hashmap::HashMap<T>}::len]:
     Source: 'tests/src/hashmap.rs', lines 110:4-112:5 *)
@@ -108,7 +108,7 @@ let hashMap_len (#t : Type0) (self : hashMap_t t) : result usize =
   Ok self.num_entries
 
 (** [hashmap::{hashmap::HashMap<T>}::insert_in_list]: loop 0:
-    Source: 'tests/src/hashmap.rs', lines 118:8-134:5 *)
+    Source: 'tests/src/hashmap.rs', lines 1:0-133:9 *)
 let rec hashMap_insert_in_list_loop
   (#t : Type0) (key : usize) (value : t) (ls : aList_t t) :
   Tot (result (bool & (aList_t t)))
@@ -155,7 +155,7 @@ let hashMap_insert_no_resize
   else let v = index_mut_back a1 in Ok { self with slots = v }
 
 (** [hashmap::{hashmap::HashMap<T>}::move_elements_from_list]: loop 0:
-    Source: 'tests/src/hashmap.rs', lines 199:12-209:5 *)
+    Source: 'tests/src/hashmap.rs', lines 199:12-206:17 *)
 let rec hashMap_move_elements_from_list_loop
   (#t : Type0) (ntable : hashMap_t t) (ls : aList_t t) :
   Tot (result (hashMap_t t))

--- a/tests/lean/Hashmap/Funs.lean
+++ b/tests/lean/Hashmap/Funs.lean
@@ -88,7 +88,7 @@ def HashMap.new (T : Type) : Result (HashMap T) := do
     { dividend := 4#usize, divisor := 5#usize }
 
 /- [hashmap::{hashmap::HashMap<T>}::clear]: loop 0:
-   Source: 'tests/src/hashmap.rs', lines 104:8-108:5 -/
+   Source: 'tests/src/hashmap.rs', lines 104:8-107:9 -/
 def HashMap.clear_loop
   {T : Type} (slots : alloc.vec.Vec (AList T)) (i : Usize) :
   Result (alloc.vec.Vec (AList T))
@@ -108,8 +108,8 @@ partial_fixpoint
 /- [hashmap::{hashmap::HashMap<T>}::clear]:
    Source: 'tests/src/hashmap.rs', lines 100:4-108:5 -/
 def HashMap.clear {T : Type} (self : HashMap T) : Result (HashMap T) := do
-  let v ← HashMap.clear_loop self.slots 0#usize
-  ok { self with num_entries := 0#usize, slots := v }
+  let slots ← HashMap.clear_loop self.slots 0#usize
+  ok { self with num_entries := 0#usize, slots }
 
 /- [hashmap::{hashmap::HashMap<T>}::len]:
    Source: 'tests/src/hashmap.rs', lines 110:4-112:5 -/
@@ -117,7 +117,7 @@ def HashMap.len {T : Type} (self : HashMap T) : Result Usize := do
   ok self.num_entries
 
 /- [hashmap::{hashmap::HashMap<T>}::insert_in_list]: loop 0:
-   Source: 'tests/src/hashmap.rs', lines 118:8-134:5 -/
+   Source: 'tests/src/hashmap.rs', lines 1:0-133:9 -/
 def HashMap.insert_in_list_loop
   {T : Type} (key : Usize) (value : T) (ls : AList T) :
   Result (Bool × (AList T))
@@ -164,7 +164,7 @@ def HashMap.insert_no_resize
        ok { self with slots := v }
 
 /- [hashmap::{hashmap::HashMap<T>}::move_elements_from_list]: loop 0:
-   Source: 'tests/src/hashmap.rs', lines 199:12-209:5 -/
+   Source: 'tests/src/hashmap.rs', lines 199:12-206:17 -/
 def HashMap.move_elements_from_list_loop
   {T : Type} (ntable : HashMap T) (ls : AList T) : Result (HashMap T) := do
   match ls with

--- a/tests/lean/Loops.lean
+++ b/tests/lean/Loops.lean
@@ -796,7 +796,7 @@ inductive AList (T : Type) where
 | Nil : AList T
 
 /- [loops::insert_in_list]: loop 0:
-   Source: 'tests/src/loops.rs', lines 513:4-529:1 -/
+   Source: 'tests/src/loops.rs', lines 1:0-528:5 -/
 def insert_in_list_loop
   {T : Type} (key : Usize) (value : T) (ls : AList T) :
   Result (Bool × (AList T))

--- a/tests/lean/Tutorial/Tutorial.lean
+++ b/tests/lean/Tutorial/Tutorial.lean
@@ -202,7 +202,7 @@ def append_in_place
   ok (list_tail_back l1)
 
 /- [tutorial::reverse]: loop 0:
-   Source: 'src/lib.rs', lines 148:4-154:1 -/
+   Source: 'src/lib.rs', lines 148:4-152:5 -/
 def reverse_loop
   {T : Type} (l : CList T) (out : CList T) : Result (CList T) := do
   match l with


### PR DESCRIPTION
Companion for https://github.com/AeneasVerif/charon/pull/898. This reverts the span wins we got in https://github.com/AeneasVerif/aeneas/pull/638. The reason was a mishandling of unwind paths. The upcoming reconstruction rewrite will mess up the spans a lot anyway.