### PR TITLE
Do not join break contexts when there is a single break statement in a loop

### DIFF
--- a/src/interp/InterpJoin.mli
+++ b/src/interp/InterpJoin.mli
@@ -361,6 +361,10 @@ val loop_join_break_ctxs :
   eval_ctx list ->
   eval_ctx
 
+(** TODO: this is a bit of a hack: remove once the avalues are properly
+    destructured. *)
+val destructure_shared_loans : Meta.span -> AbsId.Set.t -> Cps.cm_fun
+
 val loop_match_break_ctx_with_target :
   config ->
   Meta.span ->

--- a/src/interp/InterpLoops.ml
+++ b/src/interp/InterpLoops.ml
@@ -120,13 +120,19 @@ let eval_loop_symbolic_apply_loop (config : config) (span : span)
 
 (** Auxiliary function for {!eval_loop_symbolic}.
 
-    Synthesize the body of the loop. *)
+    Synthesize the body of the loop.
+
+    Note that the information about the break context is optional: if not
+    present, it means we didn't have to compute a join (there is a single break
+    statement in the loop). In case no break information is provided as input,
+    we output the (ordered) fresh abs ids and symbolic value ids that we find in
+    the context at the break. *)
 let eval_loop_symbolic_synthesize_loop_body (config : config) (span : span)
     (eval_loop_body : stl_cm_fun) (loop_id : LoopId.id) (fp_ctx : eval_ctx)
     (fp_input_abs : AbsId.id list) (fp_input_svalues : SymbolicValueId.id list)
     (fixed_aids : AbsId.Set.t) (fixed_dids : DummyVarId.Set.t)
-    (break_ctx : eval_ctx) (break_input_abs : AbsId.id list)
-    (break_input_svalues : SymbolicValueId.id list) : SA.expr =
+    (break_info : (eval_ctx * AbsId.id list * SymbolicValueId.id list) option) :
+    (eval_ctx * abs list * symbolic_value list) option * SA.expr =
   [%ldebug "fp_ctx:\n" ^ eval_ctx_to_string fp_ctx];
 
   (* Save a snapshot of the context as meta-information: it is useful to
@@ -146,6 +152,8 @@ let eval_loop_symbolic_synthesize_loop_body (config : config) (span : span)
     List.map (fun id -> SymbolicValueId.Map.find id map) values
   in
 
+  let ctx_info_at_break = ref None in
+
   (* Then, do a special treatment of the break and continue cases.
      For now, we forbid having breaks in loops (and eliminate breaks
      in the prepasses) *)
@@ -156,38 +164,129 @@ let eval_loop_symbolic_synthesize_loop_body (config : config) (span : span)
         (* We don't support early returns *)
         [%craise] span "Unexpected return"
     | Panic -> SA.Panic
-    | Break i ->
+    | Break i -> (
         (* We don't support nested loops for now *)
         [%cassert] span (i = 0) "Nested loops are not supported yet";
 
-        [%ltrace
-          "about to match the break context with the context at a break:\n\
-           - src ctx (break ctx):\n"
-          ^ eval_ctx_to_string ~span:(Some span) break_ctx
-          ^ "\n\n-tgt ctx (ctx at this break):\n"
-          ^ eval_ctx_to_string ~span:(Some span) ctx];
-        let (_ctx, tgt_ctx, input_values, input_abs), cc =
-          loop_match_break_ctx_with_target config span loop_id fixed_aids
-            fixed_dids break_input_abs break_input_svalues break_ctx ctx
-        in
-        [%ldebug
-          "after matching the break context with the context at a break:\n\
-           - src ctx (break ctx):\n"
-          ^ eval_ctx_to_string ~span:(Some span) break_ctx
-          ^ "\n\n-tgt ctx (ctx at this break):\n"
-          ^ eval_ctx_to_string ~span:(Some span) ctx
-          ^ "\n\n-input_abs:\n"
-          ^ AbsId.Map.to_string None
-              (fun abs -> AbsId.to_string abs.abs_id)
-              input_abs
-          ^ "\n\n-break_input_abs:\n"
-          ^ Print.list_to_string AbsId.to_string break_input_abs];
-        let input_values =
-          reorder_input_values input_values break_input_svalues
-        in
-        let input_abs = reorder_input_abs input_abs break_input_abs in
-        (* Reorder the input values and the abstractions *)
-        cc (SA.LoopBreak (tgt_ctx, loop_id, input_values, input_abs))
+        (* Case disjunction depending on whether we need to join or not *)
+        match break_info with
+        | None ->
+            (* There is a single context: we perform no join *)
+            [%sanity_check] span (!ctx_info_at_break = None);
+
+            (* Reduce the context *)
+            let ctx, cc =
+              comp cc
+                (InterpBorrows.simplify_dummy_values_useless_abs config span ctx)
+            in
+            [%ltrace
+              "- ctx after simplify_dummy_values_useless_abs:\n"
+              ^ eval_ctx_to_string ctx];
+
+            (* Removed the ended shared loans and destructure the shared loans.
+               We destructure the shared loans in the abstractions which appear in
+               [ctx] but not [fp_ctx]. TODO: generalize. *)
+            let ctx, cc =
+              comp cc (InterpJoin.destructure_shared_loans span fixed_aids ctx)
+            in
+            [%ltrace
+              "- ctx after simplify_ended_shared_loans:\n"
+              ^ eval_ctx_to_string ctx];
+
+            (* Reduce the context - TODO: generalize the join so that we don't need to do this *)
+            let ctx =
+              InterpReduceCollapse.reduce_ctx config span ~with_abs_conts:true
+                WithCont fixed_aids fixed_dids ctx
+            in
+            [%ltrace "- ctx after reduce_ctx:\n" ^ eval_ctx_to_string ctx];
+
+            (* Compute and order the fresh values and abstractions *)
+            let output_svalues =
+              compute_ctx_fresh_ordered_symbolic_values span
+                ~only_modified_svalues:false fp_ctx ctx
+            in
+            let get_fresh_abs (e : env_elem) : abs option =
+              match e with
+              | EAbs abs ->
+                  if not (AbsId.Set.mem abs.abs_id fixed_aids) then Some abs
+                  else None
+              | EBinding _ | EFrame -> None
+            in
+            (* Pay attention to the fact that the elements are stored in reverse order *)
+            let break_abs = List.rev (List.filter_map get_fresh_abs ctx.env) in
+            let output_abs =
+              AbsId.Set.of_list (List.map (fun abs -> abs.abs_id) break_abs)
+            in
+            (* We need to update the abstractions appearing in the output context,
+               to mark them as outputs of the loop (and forget their current
+               continuation expressions, which might refer to symbolic values
+               introduced in the loop and not available outside) *)
+            let output_ctx =
+              let add_abs_cont_to_abs (abs : abs) (loop_id : loop_id) : abs =
+                InterpAbs.add_abs_cont_to_abs span ctx abs
+                  (ELoop (abs.abs_id, loop_id))
+              in
+              let add_abs_conts ctx =
+                let visitor =
+                  object
+                    inherit [_] map_eval_ctx
+
+                    method! visit_abs _ abs =
+                      if AbsId.Set.mem abs.abs_id output_abs then
+                        add_abs_cont_to_abs abs loop_id
+                      else abs
+                  end
+                in
+                visitor#visit_eval_ctx () ctx
+              in
+              add_abs_conts ctx
+            in
+            let output_abs =
+              List.rev (List.filter_map get_fresh_abs output_ctx.env)
+            in
+
+            (* Save the information *)
+            ctx_info_at_break := Some (output_ctx, output_abs, output_svalues);
+
+            (* Create the symbolic expression.
+
+               The break values are exactly the fresh symbolic values. *)
+            let break_values =
+              List.map ValuesUtils.mk_tvalue_from_symbolic_value output_svalues
+            in
+            cc (SA.LoopBreak (output_ctx, loop_id, break_values, break_abs))
+        | Some (break_ctx, break_input_abs, break_input_svalues) ->
+            (* Join with the break context *)
+            [%ltrace
+              "about to match the break context with the context at a break:\n\
+               - src ctx (break ctx):\n"
+              ^ eval_ctx_to_string ~span:(Some span) break_ctx
+              ^ "\n\n-tgt ctx (ctx at this break):\n"
+              ^ eval_ctx_to_string ~span:(Some span) ctx];
+
+            let (_ctx, tgt_ctx, input_values, input_abs), cc =
+              loop_match_break_ctx_with_target config span loop_id fixed_aids
+                fixed_dids break_input_abs break_input_svalues break_ctx ctx
+            in
+            [%ldebug
+              "after matching the break context with the context at a break:\n\
+               - src ctx (break ctx):\n"
+              ^ eval_ctx_to_string ~span:(Some span) break_ctx
+              ^ "\n\n-tgt ctx (ctx at this break):\n"
+              ^ eval_ctx_to_string ~span:(Some span) ctx
+              ^ "\n\n-input_abs:\n"
+              ^ AbsId.Map.to_string None
+                  (fun abs -> AbsId.to_string abs.abs_id)
+                  input_abs
+              ^ "\n\n-break_input_abs:\n"
+              ^ Print.list_to_string AbsId.to_string break_input_abs];
+            (* Reorder the input values and the abstractions *)
+            let input_values =
+              reorder_input_values input_values break_input_svalues
+            in
+            let input_abs = reorder_input_abs input_abs break_input_abs in
+            (* Create the symbolic expression *)
+            cc (SA.LoopBreak (tgt_ctx, loop_id, input_values, input_abs)))
     | Continue i ->
         (* We don't support nested loops for now *)
         [%cassert] span (i = 0) "Nested loops are not supported yet";
@@ -220,7 +319,8 @@ let eval_loop_symbolic_synthesize_loop_body (config : config) (span : span)
 
   (* Apply and compose *)
   let el = List.map eval_after_loop_iter ctx_resl in
-  cf_loop el
+  let break_info = !ctx_info_at_break in
+  (break_info, cf_loop el)
 
 (** Evaluate a loop in symbolic mode *)
 let eval_loop_symbolic (config : config) (span : span)
@@ -258,12 +358,6 @@ let eval_loop_symbolic (config : config) (span : span)
     compute_loop_break_context config span loop_id eval_loop_body fp_ctx
       fixed_aids fixed_dids
   in
-  [%cassert] span
-    (Option.is_some break_info)
-    "(Infinite) loops which do not contain breaks are not supported yet";
-  let break_ctx, break_abs = Option.get break_info in
-  let break_input_abs_ids = List.map (fun (a : abs) -> a.abs_id) break_abs in
-
   (* Debug *)
   [%ltrace
     "- Initial context:\n"
@@ -271,7 +365,11 @@ let eval_loop_symbolic (config : config) (span : span)
     ^ "\n\n- Fixed point:\n"
     ^ eval_ctx_to_string ~span:(Some span) ~filter:false fp_ctx
     ^ "\n\n- break_ctx:\n"
-    ^ eval_ctx_to_string ~span:(Some span) break_ctx];
+    ^
+    match break_info with
+    | NoBreak -> "no break ctx"
+    | Single -> "single break ctx"
+    | Multiple (break_ctx, _) -> eval_ctx_to_string ~span:(Some span) break_ctx];
 
   (* Compute the loop input parameters *)
   let fp_input_svalues =
@@ -281,22 +379,39 @@ let eval_loop_symbolic (config : config) (span : span)
   let fp_input_svalue_ids =
     List.map (fun (sv : symbolic_value) -> sv.sv_id) fp_input_svalues
   in
-
-  let break_input_svalues =
-    compute_ctx_fresh_ordered_symbolic_values span ~only_modified_svalues:false
-      ctx break_ctx
-  in
-  let break_input_svalue_ids =
-    List.map (fun (sv : symbolic_value) -> sv.sv_id) break_input_svalues
-  in
-
   [%ltrace
     "\n- fp_input_svalues: "
     ^ String.concat ", "
-        (List.map (symbolic_value_to_string ctx) fp_input_svalues)
-    ^ "\n- break_input_svalues: "
-    ^ String.concat ", "
-        (List.map (symbolic_value_to_string ctx) break_input_svalues)];
+        (List.map (symbolic_value_to_string ctx) fp_input_svalues)];
+
+  let break_info, break_abs_values =
+    match break_info with
+    | NoBreak ->
+        [%craise] span
+          "(Infinite) loops which do not contain breaks are not supported yet"
+    | Single ->
+        [%ltrace "No break context"];
+        (None, None)
+    | Multiple (break_ctx, break_abs) ->
+        let break_input_abs_ids =
+          List.map (fun (a : abs) -> a.abs_id) break_abs
+        in
+
+        let break_input_svalues =
+          compute_ctx_fresh_ordered_symbolic_values span
+            ~only_modified_svalues:false ctx break_ctx
+        in
+        let break_input_svalue_ids =
+          List.map (fun (sv : symbolic_value) -> sv.sv_id) break_input_svalues
+        in
+
+        [%ltrace
+          "- break_input_svalues: "
+          ^ String.concat ", "
+              (List.map (symbolic_value_to_string ctx) break_input_svalues)];
+        ( Some (break_ctx, break_input_abs_ids, break_input_svalue_ids),
+          Some (break_abs, break_input_svalues) )
+  in
 
   (* "Call" the loop *)
   let (_ctx_after_loop, entry_loop_ctx, input_values, input_abs), cf_before_loop
@@ -308,12 +423,23 @@ let eval_loop_symbolic (config : config) (span : span)
   [%ltrace "matched the fixed-point context with the original context."];
 
   (* Synthesize the loop body *)
-  let loop_body =
+  let break_info', loop_body =
     let fixed_aids = InterpJoinCore.compute_fixed_abs_ids ctx fp_ctx in
     let fixed_dids = ctx_get_dummy_var_ids ctx in
     eval_loop_symbolic_synthesize_loop_body config span eval_loop_body loop_id
       fp_ctx input_abs_ids_list fp_input_svalue_ids fixed_aids fixed_dids
-      break_ctx break_input_abs_ids break_input_svalue_ids
+      break_info
+  in
+
+  let break_ctx, break_abs, break_input_svalues =
+    match break_info with
+    | Some (ctx, _, _) ->
+        let abs, values = Option.get break_abs_values in
+        (ctx, abs, values)
+    | None -> (
+        match break_info' with
+        | Some (ctx, abs, values) -> (ctx, abs, values)
+        | None -> [%internal_error] span)
   in
 
   [%ltrace

--- a/src/interp/InterpLoopsFixedPoint.mli
+++ b/src/interp/InterpLoopsFixedPoint.mli
@@ -27,6 +27,13 @@ val compute_loop_entry_fixed_point :
   eval_ctx ->
   eval_ctx * ids_sets
 
+type break_ctx =
+  | NoBreak  (** The loop doesn't contain any break *)
+  | Single
+      (** There is a single break statement, so we don't join the break contexts
+      *)
+  | Multiple of (eval_ctx * abs list)  (** We joined multiple break contexts *)
+
 val compute_loop_break_context :
   config ->
   Meta.span ->
@@ -35,4 +42,4 @@ val compute_loop_break_context :
   eval_ctx ->
   AbsId.Set.t ->
   DummyVarId.Set.t ->
-  (eval_ctx * abs list) option
+  break_ctx


### PR DESCRIPTION
This slightly improves the handling of loops.