### PR TITLE
Fix an issue in `InterpMatchCtxs.match_types`

### DIFF
--- a/src/interp/InterpJoin.ml
+++ b/src/interp/InterpJoin.ml
@@ -1322,8 +1322,9 @@ let match_ctx_with_target (config : config) (span : Meta.span)
       { empty_ids_sets with aids = ctx_get_frozen_abs_set src_ctx }
     in
     match
-      match_ctxs span ~check_equiv:false ~check_kind:false ~check_can_end:false
-        fixed_ids lookup_in_src lookup_in_joined src_ctx joined_ctx
+      try_match_ctxs span ~check_equiv:false ~check_kind:false
+        ~check_can_end:false fixed_ids lookup_in_src lookup_in_joined src_ctx
+        joined_ctx
     with
     | Some ctx -> ctx
     | None -> [%craise] span "Could not match the contexts"

--- a/src/interp/InterpMatchCtxs.mli
+++ b/src/interp/InterpMatchCtxs.mli
@@ -90,7 +90,7 @@ module MakeCheckEquivMatcher : functor (_ : MatchCheckEquivState) ->
 
     We return an optional ids map: [Some] if the match succeeded, [None]
     otherwise. *)
-val match_ctxs :
+val try_match_ctxs :
   Meta.span ->
   check_equiv:bool ->
   ?check_kind:bool ->
@@ -101,6 +101,21 @@ val match_ctxs :
   eval_ctx ->
   eval_ctx ->
   ids_maps option
+
+(** See [try_match_ctxs]: [try_match_ctxs] calls [match_ctxs], the latter
+    raising exceptions of type [Distinct] and [ValueMatchFailure], and the
+    former catching those exceptions. *)
+val match_ctxs :
+  Meta.span ->
+  check_equiv:bool ->
+  ?check_kind:bool ->
+  ?check_can_end:bool ->
+  ids_sets ->
+  (loan_id -> tvalue) ->
+  (loan_id -> tvalue) ->
+  eval_ctx ->
+  eval_ctx ->
+  ids_maps
 
 (** Compute whether two contexts are equivalent modulo an identifier
     substitution.


### PR DESCRIPTION
`InterpMatchCtxs.match_types` did not take into account some types like `TRawPtr`.