### PR TITLE
Bump Charon

### DIFF
--- a/charon-pin
+++ b/charon-pin
@@ -1,2 +1,2 @@
 # This is the commit from https://github.com/AeneasVerif/charon that should be used with this version of aeneas.
-56e0268dbfae33c07b5f0721e8cbf304f42faf55
+125f0551fd9844ff2375ed8e0bc340756083a737

--- a/flake.lock
+++ b/flake.lock
@@ -9,11 +9,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1768609831,
-        "narHash": "sha256-cgEeDmfK78v+rICgvp+K5I9k23l02HoKxGIwNhGQdeA=",
+        "lastModified": 1769528585,
+        "narHash": "sha256-ifpA+fqD0r30oxTG2J9CxCkpMCQbG3KjE+3zddjBBeU=",
         "owner": "aeneasverif",
         "repo": "charon",
-        "rev": "56e0268dbfae33c07b5f0721e8cbf304f42faf55",
+        "rev": "125f0551fd9844ff2375ed8e0bc340756083a737",
         "type": "github"
       },
       "original": {

--- a/src/PrePasses.ml
+++ b/src/PrePasses.ml
@@ -128,7 +128,8 @@ let update_array_default (crate : crate) : crate =
          [
            TArray
              ( (TVar (Free _) as elem_ty),
-               (CgValue (VScalar (UnsignedScalar (Usize, nv))) as n) );
+               ({ kind = CLiteral (VScalar (UnsignedScalar (Usize, nv))); _ } as
+                n) );
          ];
        const_generics = [];
        trait_refs = _;
@@ -146,7 +147,9 @@ let update_array_default (crate : crate) : crate =
           | None ->
               (* Update the implementation in place *)
               let cg_id = ConstGenericVarId.zero in
-              let cg = CgVar (Free cg_id) in
+              let cg : Types.constant_expr =
+                { kind = CVar (Free cg_id); ty = TypesUtils.mk_usize_ty }
+              in
               let generics =
                 {
                   impl.impl_trait.generics with
@@ -158,7 +161,9 @@ let update_array_default (crate : crate) : crate =
                 {
                   impl.generics with
                   const_generics =
-                    [ { index = cg_id; name = "N"; ty = TUInt Usize } ];
+                    [
+                      { index = cg_id; name = "N"; ty = TypesUtils.mk_usize_ty };
+                    ];
                 }
               in
               let impl = { impl with impl_trait; generics = params } in
@@ -201,7 +206,9 @@ let update_array_default (crate : crate) : crate =
             if id = merged_method then (
               (* Update the method *)
               let cg_id = ConstGenericVarId.zero in
-              let cg = CgVar (Free cg_id) in
+              let cg : Types.constant_expr =
+                { kind = CVar (Free cg_id); ty = TypesUtils.mk_usize_ty }
+              in
               let sg = fdecl.signature in
               assert (sg.inputs = []);
               match sg.output with
@@ -210,7 +217,13 @@ let update_array_default (crate : crate) : crate =
                     {
                       fdecl.generics with
                       const_generics =
-                        [ { index = cg_id; name = "N"; ty = TUInt Usize } ];
+                        [
+                          {
+                            index = cg_id;
+                            name = "N";
+                            ty = TypesUtils.mk_usize_ty;
+                          };
+                        ];
                     }
                   in
                   let sg = { sg with output = TArray (elem_ty, cg) } in

--- a/src/interp/InterpBorrowsCore.ml
+++ b/src/interp/InterpBorrowsCore.ml
@@ -1899,8 +1899,8 @@ and norm_proj_trait_refs_union (span : Meta.span) (tr1 : trait_ref)
   [%sanity_check] span (decl_ref1 = decl_ref2);
   tr1
 
-and norm_proj_const_generics_union (span : Meta.span) (cg1 : const_generic)
-    (cg2 : const_generic) : const_generic =
+and norm_proj_const_generics_union (span : Meta.span) (cg1 : constant_expr)
+    (cg2 : constant_expr) : constant_expr =
   [%sanity_check] span (cg1 = cg2);
   cg1
 

--- a/src/interp/InterpExpressions.ml
+++ b/src/interp/InterpExpressions.ml
@@ -1049,7 +1049,7 @@ let eval_rvalue_aggregate (config : config) (span : Meta.span)
                    values)
             ^ "]"));
         (* Sanity check: the number of values is consistent with the length *)
-        let len = get_val (literal_as_scalar (const_generic_as_literal cg)) in
+        let len = get_val (literal_as_scalar (constant_expr_as_literal cg)) in
         [%sanity_check] span (len = Z.of_int (List.length values));
         let ty = TArray (ety, cg) in
         (* In order to generate a better AST, we introduce a symbolic

--- a/src/interp/InterpUtils.ml
+++ b/src/interp/InterpUtils.ml
@@ -714,9 +714,9 @@ let initialize_eval_ctx (span : Meta.span option) (ctx : decls_ctx)
     ConstGenericVarId.Map.of_list
       (List.map
          (fun (cg : const_generic_param) ->
-           let ty = TLiteral cg.ty in
            let cv =
-             mk_fresh_symbolic_tvalue_opt_span span fresh_symbolic_value_id ty
+             mk_fresh_symbolic_tvalue_opt_span span fresh_symbolic_value_id
+               cg.ty
            in
            (cg.index, cv))
          const_generic_vars)

--- a/src/interp/Invariants.ml
+++ b/src/interp/Invariants.ml
@@ -456,7 +456,7 @@ let check_typing_invariant_visitor span ctx (lookups : bool) =
           let len =
             Scalars.get_val
               (ValuesUtils.literal_as_scalar
-                 (TypesUtils.const_generic_as_literal len))
+                 (TypesUtils.constant_expr_as_literal len))
           in
           [%sanity_check] span (Z.of_int (List.length av.fields) = len)
       | VAdt _, TSlice _ -> [%craise] span "Unexpected slice value"

--- a/src/llbc/Builtin.ml
+++ b/src/llbc/Builtin.ml
@@ -41,7 +41,7 @@ module Sig = struct
   let tvar_id_0 = TypeVarId.of_int 0
   let tvar_0 : ty = TVar (Free tvar_id_0)
   let cgvar_id_0 = ConstGenericVarId.of_int 0
-  let cgvar_0 : const_generic = CgVar (Free cgvar_id_0)
+  let cgvar_0 : constant_expr_kind = CVar (Free cgvar_id_0)
 
   (** Region 'a of id 0 *)
   let region_param_0 : region_param = { index = rvar_id_0; name = Some "'a" }
@@ -57,7 +57,7 @@ module Sig = struct
 
   (** Const generic parameter [const N : usize] of id 0 *)
   let cg_param_0 : const_generic_param =
-    { index = cgvar_id_0; name = "N"; ty = TUInt Usize }
+    { index = cgvar_id_0; name = "N"; ty = TLiteral (TUInt Usize) }
 
   let empty_const_generic_params : const_generic_param list = []
 
@@ -79,7 +79,7 @@ module Sig = struct
     let ref_kind = if is_mut then RMut else RShared in
     mk_ref_ty r ty ref_kind
 
-  let mk_array_ty (ty : ty) (cg : const_generic) : ty = TArray (ty, cg)
+  let mk_array_ty (ty : ty) (cg : constant_expr) : ty = TArray (ty, cg)
   let mk_slice_ty (ty : ty) : ty = TSlice ty
 
   let mk_sig generics inputs output : bound_fun_sig =
@@ -148,12 +148,13 @@ module Sig = struct
 
   let mk_array_slice_index_sig (is_array : bool) (is_mut : bool) : bound_fun_sig
       =
-    (* Array<T, N> *)
-    let input_ty ty =
-      if is_array then mk_array_ty ty cgvar_0 else mk_slice_ty ty
-    in
     (* usize *)
     let index_ty = usize_ty in
+    (* Array<T, N> *)
+    let input_ty ty =
+      if is_array then mk_array_ty ty { kind = cgvar_0; ty = index_ty }
+      else mk_slice_ty ty
+    in
     (* T *)
     let output_ty ty = ty in
     let cgs = if is_array then [ cg_param_0 ] else [] in
@@ -164,7 +165,7 @@ module Sig = struct
 
   let array_to_slice_sig (is_mut : bool) : bound_fun_sig =
     (* Array<T, N> *)
-    let input_ty ty = mk_array_ty ty cgvar_0 in
+    let input_ty ty = mk_array_ty ty { kind = cgvar_0; ty = usize_ty } in
     (* Slice<T> *)
     let output_ty ty = mk_slice_ty ty in
     let cgs = [ cg_param_0 ] in
@@ -178,7 +179,7 @@ module Sig = struct
     let inputs = [ tvar_0 (* T *) ] in
     let output =
       (* [T; N] *)
-      mk_array_ty tvar_0 cgvar_0
+      mk_array_ty tvar_0 { kind = cgvar_0; ty = usize_ty }
     in
     mk_sig generics inputs output
 

--- a/src/llbc/Substitute.ml
+++ b/src/llbc/Substitute.ml
@@ -33,7 +33,7 @@ let fresh_regions_with_substs_from_vars (region_vars : region_param list)
     associated to that signature. *)
 let substitute_signature (asubst : RegionGroupId.id -> AbsId.id)
     (r_id_subst : RegionId.id -> RegionId.id) (ty_sb_subst : TypeVarId.id -> ty)
-    (cg_sb_subst : ConstGenericVarId.id -> const_generic)
+    (cg_sb_subst : ConstGenericVarId.id -> constant_expr_kind)
     (tr_sb_subst : TraitClauseId.id -> trait_ref_kind)
     (tr_sb_self : trait_ref_kind) (sg : bound_fun_sig)
     (regions_hierarchy : region_var_groups) : inst_fun_sig =

--- a/src/llbc/TypesAnalysis.ml
+++ b/src/llbc/TypesAnalysis.ml
@@ -624,7 +624,7 @@ let compute_outlive_proj_ty (span : Meta.span option)
                 in
                 List.iter (self#visit_region outer) regions;
                 List.iter (self#visit_ty outer) types;
-                List.iter (self#visit_const_generic outer) const_generics;
+                List.iter (self#visit_constant_expr outer) const_generics;
                 (* TODO: we need to handle those *)
                 [%sanity_check_opt_span] span (trait_refs = []);
 

--- a/src/llbc/Values.ml
+++ b/src/llbc/Values.ml
@@ -34,7 +34,6 @@ class ['self] iter_tvalue_base =
     method visit_symbolic_value_id : 'env -> symbolic_value_id -> unit =
       fun _ _ -> ()
 
-    method visit_variant_id : 'env -> variant_id -> unit = fun _ _ -> ()
     method visit_borrow_id : 'env -> borrow_id -> unit = fun _ _ -> ()
 
     method visit_shared_borrow_id : 'env -> shared_borrow_id -> unit =
@@ -58,7 +57,6 @@ class ['self] map_tvalue_base =
         'env -> symbolic_value_id -> symbolic_value_id =
       fun _ x -> x
 
-    method visit_variant_id : 'env -> variant_id -> variant_id = fun _ x -> x
     method visit_borrow_id : 'env -> borrow_id -> borrow_id = fun _ id -> id
 
     method visit_shared_borrow_id : 'env -> shared_borrow_id -> shared_borrow_id

--- a/src/pure/PrintPure.ml
+++ b/src/pure/PrintPure.ml
@@ -146,6 +146,8 @@ let type_db_var_to_string (env : fmt_env) (var : type_var_id de_bruijn_var) :
   | None -> Print.Types.type_db_var_to_pretty_string var
   | Some x -> Print.Types.type_param_to_string x
 
+let const_generic_param_to_string (v : const_generic_param) : string = v.name
+
 let const_generic_db_var_to_string (env : fmt_env)
     (var : const_generic_var_id de_bruijn_var) : string =
   let find (generics : generic_params) varid =
@@ -155,7 +157,7 @@ let const_generic_db_var_to_string (env : fmt_env)
   in
   match lookup_var_in_env env find var with
   | None -> Print.Types.const_generic_db_var_to_pretty_string var
-  | Some x -> Print.Types.const_generic_param_to_string x
+  | Some x -> const_generic_param_to_string x
 
 let bvar_to_pretty_string (v : bvar) : string =
   "^(" ^ string_of_int v.scope ^ "," ^ BVarId.to_string v.id ^ ")"

--- a/src/pure/Pure.ml
+++ b/src/pure/Pure.ml
@@ -35,8 +35,6 @@ module ConstGenericVarId = T.ConstGenericVarId
 type llbc_name = T.name [@@deriving show, ord]
 type integer_type = T.integer_type [@@deriving show, ord]
 type float_type = T.float_type [@@deriving show, ord]
-type const_generic_param = T.const_generic_param [@@deriving show, ord]
-type const_generic = T.const_generic [@@deriving show, ord]
 type const_generic_var_id = T.const_generic_var_id [@@deriving show, ord]
 type trait_decl_id = T.trait_decl_id [@@deriving show, ord]
 type trait_impl_id = T.trait_impl_id [@@deriving show, ord]
@@ -236,8 +234,11 @@ type type_var_id = TypeVarId.id [@@deriving show, ord]
 (** Ancestor for iter visitor for [ty] *)
 class ['self] iter_type_id_base =
   object (_self : 'self)
-    inherit [_] VisitorsRuntime.iter
-    method visit_type_decl_id : 'env -> type_decl_id -> unit = fun _ _ -> ()
+    inherit [_] T.iter_ty_base
+
+    method visit_const_generic_var_id : 'env -> const_generic_var_id -> unit =
+      fun _ _ -> ()
+
     method visit_builtin_ty : 'env -> builtin_ty -> unit = fun _ _ -> ()
     method visit_overflow_mode : 'env -> overflow_mode -> unit = fun _ _ -> ()
   end
@@ -245,9 +246,10 @@ class ['self] iter_type_id_base =
 (** Ancestor for map visitor for [ty] *)
 class ['self] map_type_id_base =
   object (_self : 'self)
-    inherit [_] VisitorsRuntime.map
+    inherit [_] T.map_ty_base
 
-    method visit_type_decl_id : 'env -> type_decl_id -> type_decl_id =
+    method visit_const_generic_var_id :
+        'env -> const_generic_var_id -> const_generic_var_id =
       fun _ x -> x
 
     method visit_builtin_ty : 'env -> builtin_ty -> builtin_ty = fun _ x -> x
@@ -259,11 +261,12 @@ class ['self] map_type_id_base =
 (** Ancestor for reduce visitor for [ty] *)
 class virtual ['self] reduce_type_id_base =
   object (self : 'self)
-    inherit [_] VisitorsRuntime.reduce
+    inherit [_] T.reduce_type_vars
 
-    method visit_type_decl_id : 'env -> type_decl_id -> 'a =
+    method visit_const_generic_var_id : 'env -> const_generic_var_id -> 'a =
       fun _ _ -> self#zero
 
+    method visit_span : 'env -> span -> 'a = fun _ _ -> self#zero
     method visit_builtin_ty : 'env -> builtin_ty -> 'a = fun _ _ -> self#zero
 
     method visit_overflow_mode : 'env -> overflow_mode -> 'a =
@@ -273,10 +276,13 @@ class virtual ['self] reduce_type_id_base =
 (** Ancestor for mapreduce visitor for [ty] *)
 class virtual ['self] mapreduce_type_id_base =
   object (self : 'self)
-    inherit [_] VisitorsRuntime.mapreduce
+    inherit [_] T.mapreduce_type_vars
 
-    method visit_type_decl_id : 'env -> type_decl_id -> type_decl_id * 'a =
+    method visit_const_generic_var_id :
+        'env -> const_generic_var_id -> const_generic_var_id * 'a =
       fun _ x -> (x, self#zero)
+
+    method visit_span : 'env -> span -> span * 'a = fun _ x -> (x, self#zero)
 
     method visit_builtin_ty : 'env -> builtin_ty -> builtin_ty * 'a =
       fun _ x -> (x, self#zero)
@@ -286,6 +292,19 @@ class virtual ['self] mapreduce_type_id_base =
   end
 
 type type_id = TAdtId of type_decl_id | TTuple | TBuiltin of builtin_ty
+
+and const_generic =
+  | CgGlobal of global_decl_id  (** A global constant *)
+  | CgVar of const_generic_var_id de_bruijn_var  (** A const generic variable *)
+  | CgValue of V.literal  (** A concrete value *)
+
+and const_generic_param = {
+  index : const_generic_var_id;
+      (** Index identifying the variable among other variables bound at the same
+          level. *)
+  name : string;  (** Const generic name *)
+  ty : T.literal_type;  (** Type of the const generic *)
+}
 [@@deriving
   show,
   ord,
@@ -334,28 +353,24 @@ type literal_type = T.literal_type [@@deriving show, ord]
 class ['self] iter_ty_base =
   object (_self : 'self)
     inherit [_] iter_type_id
-    inherit! [_] T.iter_const_generic
   end
 
 (** Ancestor for map visitor for [ty] *)
 class ['self] map_ty_base =
   object (_self : 'self)
     inherit [_] map_type_id
-    inherit! [_] T.map_const_generic
   end
 
 (** Ancestor for reduce visitor for [ty] *)
 class virtual ['self] reduce_ty_base =
   object (_self : 'self)
     inherit [_] reduce_type_id
-    inherit! [_] T.reduce_const_generic
   end
 
 (** Ancestor for mapreduce visitor for [ty] *)
 class virtual ['self] mapreduce_ty_base =
   object (_self : 'self)
     inherit [_] mapreduce_type_id
-    inherit! [_] T.mapreduce_const_generic
   end
 
 type ty =
@@ -496,12 +511,6 @@ class ['self] iter_type_decl_base =
         self#visit_type_var_id e var.index;
         self#visit_string e var.name
 
-    method visit_const_generic_param : 'env -> const_generic_param -> unit =
-      fun e var ->
-        self#visit_const_generic_var_id e var.index;
-        self#visit_string e var.name;
-        self#visit_literal_type e var.ty
-
     method visit_item_meta : 'env -> T.item_meta -> unit = fun _ _ -> ()
 
     method visit_builtin_type_info : 'env -> builtin_type_info -> unit =
@@ -521,15 +530,6 @@ class ['self] map_type_decl_base =
         {
           index = self#visit_type_var_id e var.index;
           name = self#visit_string e var.name;
-        }
-
-    method visit_const_generic_param :
-        'env -> const_generic_param -> const_generic_param =
-      fun e var ->
-        {
-          index = self#visit_const_generic_var_id e var.index;
-          name = self#visit_string e var.name;
-          ty = self#visit_literal_type e var.ty;
         }
 
     method visit_item_meta : 'env -> T.item_meta -> T.item_meta = fun _ x -> x
@@ -553,13 +553,6 @@ class virtual ['self] reduce_type_decl_base =
         let x1 = self#visit_string e var.name in
         self#plus x0 x1
 
-    method visit_const_generic_param : 'env -> const_generic_param -> 'a =
-      fun e var ->
-        let x0 = self#visit_const_generic_var_id e var.index in
-        let x1 = self#visit_string e var.name in
-        let x2 = self#visit_literal_type e var.ty in
-        self#plus (self#plus x0 x1) x2
-
     method visit_item_meta : 'env -> T.item_meta -> 'a = fun _ _ -> self#zero
 
     method visit_builtin_type_info : 'env -> builtin_type_info -> 'a =
@@ -579,14 +572,6 @@ class virtual ['self] mapreduce_type_decl_base =
         let index, x0 = self#visit_type_var_id e var.index in
         let name, x1 = self#visit_string e var.name in
         ({ index; name }, self#plus x0 x1)
-
-    method visit_const_generic_param :
-        'env -> const_generic_param -> const_generic_param * 'a =
-      fun e var ->
-        let index, x0 = self#visit_const_generic_var_id e var.index in
-        let name, x1 = self#visit_string e var.name in
-        let ty, x2 = self#visit_literal_type e var.ty in
-        ({ index; name; ty }, self#plus (self#plus x0 x1) x2)
 
     method visit_item_meta : 'env -> T.item_meta -> T.item_meta * 'a =
       fun _ x -> (x, self#zero)
@@ -1128,7 +1113,6 @@ class ['self] iter_expr_base =
   object (_self : 'self)
     inherit [_] iter_qualif
     inherit! [_] iter_type_id
-    method visit_span : 'env -> Meta.span -> unit = fun _ _ -> ()
     method visit_db_scope_id : 'env -> db_scope_id -> unit = fun _ _ -> ()
   end
 
@@ -1137,7 +1121,6 @@ class ['self] map_expr_base =
   object (_self : 'self)
     inherit [_] map_qualif
     inherit! [_] map_type_id
-    method visit_span : 'env -> Meta.span -> Meta.span = fun _ x -> x
     method visit_db_scope_id : 'env -> db_scope_id -> db_scope_id = fun _ x -> x
   end
 
@@ -1146,7 +1129,6 @@ class virtual ['self] reduce_expr_base =
   object (self : 'self)
     inherit [_] reduce_qualif
     inherit! [_] reduce_type_id
-    method visit_span : 'env -> Meta.span -> 'a = fun _ _ -> self#zero
     method visit_db_scope_id : 'env -> db_scope_id -> 'a = fun _ _ -> self#zero
   end
 
@@ -1155,9 +1137,6 @@ class virtual ['self] mapreduce_expr_base =
   object (self : 'self)
     inherit [_] mapreduce_qualif
     inherit! [_] mapreduce_type_id
-
-    method visit_span : 'env -> Meta.span -> Meta.span * 'a =
-      fun _ x -> (x, self#zero)
 
     method visit_db_scope_id : 'env -> db_scope_id -> db_scope_id * 'a =
       fun _ x -> (x, self#zero)

--- a/src/pure/PureMicroPasses.ml
+++ b/src/pure/PureMicroPasses.ml
@@ -6926,7 +6926,7 @@ let add_type_annotations_to_fun_decl (trans_ctx : trans_ctx)
   (* The const generic holes are not really useful, but while we're at it we
      can keep track of them *)
   let cg_hole : const_generic =
-    T.CgVar (T.Free (ConstGenericVarId.of_int (-1)))
+    CgVar (T.Free (ConstGenericVarId.of_int (-1)))
   in
 
   (* Small helper to add a type annotation *)

--- a/tests/coq/misc/Traits.v
+++ b/tests/coq/misc/Traits.v
@@ -331,21 +331,21 @@ Definition with_const_ty_len2_default (Self : Type) (LEN : usize) : usize :=
   (with_const_ty_len2_default_body Self LEN)%global
 .
 
-(** [traits::{traits::WithConstTy<u8, u64, 32usize> for bool}::LEN1]
+(** [traits::{traits::WithConstTy<u8, u64, (32usize : usize)> for bool}::LEN1]
     Source: 'tests/src/traits.rs', lines 177:4-177:27 *)
 Definition with_const_ty_bool_u8_u6432_len1_body : result usize := Ok 12%usize.
 Definition with_const_ty_bool_u8_u6432_len1 : usize :=
   with_const_ty_bool_u8_u6432_len1_body%global
 .
 
-(** [traits::{traits::WithConstTy<u8, u64, 32usize> for bool}::f]:
+(** [traits::{traits::WithConstTy<u8, u64, (32usize : usize)> for bool}::f]:
     Source: 'tests/src/traits.rs', lines 182:4-182:42 *)
 Definition withConstTyBoolU8U6432_f
   (i : u64) (a : array u8 32%usize) : result u64 :=
   Ok i
 .
 
-(** Trait implementation: [traits::{traits::WithConstTy<u8, u64, 32usize> for bool}]
+(** Trait implementation: [traits::{traits::WithConstTy<u8, u64, (32usize : usize)> for bool}]
     Source: 'tests/src/traits.rs', lines 176:0-183:1 *)
 Definition WithConstTyBoolU8U6432 : WithConstTy_t bool u8 u64 32%usize := {|
   WithConstTy_tWithConstTy_t_LEN1 := with_const_ty_bool_u8_u6432_len1;

--- a/tests/fstar/misc/Traits.fst
+++ b/tests/fstar/misc/Traits.fst
@@ -264,18 +264,18 @@ let with_const_ty_len2_default_body (self : Type0) (len : usize)
 let with_const_ty_len2_default (self : Type0) (len : usize) : usize =
   eval_global (with_const_ty_len2_default_body self len)
 
-(** [traits::{traits::WithConstTy<u8, u64, 32usize> for bool}::LEN1]
+(** [traits::{traits::WithConstTy<u8, u64, (32usize : usize)> for bool}::LEN1]
     Source: 'tests/src/traits.rs', lines 177:4-177:27 *)
 let with_const_ty_bool_u8_u6432_len1_body : result usize = Ok 12
 let with_const_ty_bool_u8_u6432_len1 : usize =
   eval_global with_const_ty_bool_u8_u6432_len1_body
 
-(** [traits::{traits::WithConstTy<u8, u64, 32usize> for bool}::f]:
+(** [traits::{traits::WithConstTy<u8, u64, (32usize : usize)> for bool}::f]:
     Source: 'tests/src/traits.rs', lines 182:4-182:42 *)
 let withConstTyBoolU8U6432_f (i : u64) (a : array u8 32) : result u64 =
   Ok i
 
-(** Trait implementation: [traits::{traits::WithConstTy<u8, u64, 32usize> for bool}]
+(** Trait implementation: [traits::{traits::WithConstTy<u8, u64, (32usize : usize)> for bool}]
     Source: 'tests/src/traits.rs', lines 176:0-183:1 *)
 let withConstTyBoolU8U6432 : withConstTy_t bool u8 u64 32 = {
   cLEN1 = with_const_ty_bool_u8_u6432_len1;

--- a/tests/lean/Traits.lean
+++ b/tests/lean/Traits.lean
@@ -284,7 +284,7 @@ def WithConstTy.LEN2_default_body (Self : Type) (LEN : Std.Usize)
 def WithConstTy.LEN2_default (Self : Type) (LEN : Std.Usize) : Std.Usize :=
   eval_global (WithConstTy.LEN2_default_body Self LEN)
 
-/- [traits::{traits::WithConstTy<u8, u64, 32usize> for bool}::LEN1]
+/- [traits::{traits::WithConstTy<u8, u64, (32usize : usize)> for bool}::LEN1]
    Source: 'tests/src/traits.rs', lines 177:4-177:27 -/
 @[global_simps]
 def WithConstTyBoolU8U6432.LEN1_body : Result Std.Usize := do ok 12#usize
@@ -292,13 +292,13 @@ def WithConstTyBoolU8U6432.LEN1_body : Result Std.Usize := do ok 12#usize
 def WithConstTyBoolU8U6432.LEN1 : Std.Usize :=
   eval_global WithConstTyBoolU8U6432.LEN1_body
 
-/- [traits::{traits::WithConstTy<u8, u64, 32usize> for bool}::f]:
+/- [traits::{traits::WithConstTy<u8, u64, (32usize : usize)> for bool}::f]:
    Source: 'tests/src/traits.rs', lines 182:4-182:42 -/
 def WithConstTyBoolU8U6432.f
   (i : Std.U64) (a : Array Std.U8 32#usize) : Result Std.U64 := do
   ok i
 
-/- Trait implementation: [traits::{traits::WithConstTy<u8, u64, 32usize> for bool}]
+/- Trait implementation: [traits::{traits::WithConstTy<u8, u64, (32usize : usize)> for bool}]
    Source: 'tests/src/traits.rs', lines 176:0-183:1 -/
 @[reducible]
 def WithConstTyBoolU8U6432 : WithConstTy Bool Std.U8 Std.U64 32#usize := {


### PR DESCRIPTION
Companion PR to https://github.com/AeneasVerif/charon/pull/984
The changes ended up being less bad than expected; duplicated `const_generic` from Charon before the bump, and we just convert between that and `constant_expr` when needed.