### PR TITLE
Bump Charon

### DIFF
--- a/charon-pin
+++ b/charon-pin
@@ -1,2 +1,2 @@
 # This is the commit from https://github.com/AeneasVerif/charon that should be used with this version of aeneas.
-43459f88e30db00fd0dd839fd73b03e972149233
+eb7e0fb79a20d1ee338c3d47fe16243d6ab81f66

--- a/flake.lock
+++ b/flake.lock
@@ -9,11 +9,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1770853160,
-        "narHash": "sha256-aHJv9VTpHlAEj+6HA9Uv1Pg4wPoEJlLOEVYr3e3QGgw=",
+        "lastModified": 1771437768,
+        "narHash": "sha256-krVwC21DtygsLTM7RUYcZJCwQVoOEnxy/aupelGi9s8=",
         "owner": "aeneasverif",
         "repo": "charon",
-        "rev": "43459f88e30db00fd0dd839fd73b03e972149233",
+        "rev": "eb7e0fb79a20d1ee338c3d47fe16243d6ab81f66",
         "type": "github"
       },
       "original": {

--- a/tests/lean/LoopsIssues.lean
+++ b/tests/lean/LoopsIssues.lean
@@ -73,7 +73,7 @@ def loop_access_array_loop
       if start1 < 4#usize
       then
         do
-        massert (k < 4#usize)
+        let _ ← Array.index_usize CARRAY k
         let start2 ← start1 + 1#usize
         ok (cont start2)
       else ok (done ()))


### PR DESCRIPTION
Companion PR to https://github.com/AeneasVerif/charon/pull/1023

Removed the `unify_drops` pass, as `Deinit` is now gone, and manually creating a `Drop` from a `StorageDead` felt very dubious; instead both statements are handled (basically the same way).

Added `PlaceMention` which for now is a no-op.