### PR TITLE
fix: check head is Std.WP.spec within tryMatch

### DIFF
--- a/backends/lean/Aeneas/Progress/Progress.lean
+++ b/backends/lean/Aeneas/Progress/Progress.lean
@@ -1387,7 +1387,7 @@ info: example
   /--
   error: unsolved goals
 case a
-α : Type ?u.255089
+α : Type ?u.255154
 P : ℕ → List α → Prop
 f✝ : List α → Result Bool
 f_spec : ∀ (l : List α) (i : ℕ), P i l → f✝ l ⦃ x✝ => True ⦄


### PR DESCRIPTION
Bug: The `progress` tactic iterated over all local hypotheses in `tryAssumptions`, and for each one, `tryMatch` would perform expensive operations before discovering the hypothesis wasn't a spec. When hypotheses had computationally expensive types (e.g., Finset.sum, Nat.ModEq), this caused timeouts (as is the case for examples like in issue #778). 

Fix: Added an early guard at the top of `tryMatch` (Progress.lean:260-262) that checks if the theorem head is `Std.WP.spec` before doing any heavy work. Non-spec hypotheses are now rejected instantly and timeout error avoided.

Additional edit to correct `guard_msgs` output elsewhere. 

The fix has been tested again the example of the issue. It's possible to add the test file to the repo but perhaps not worthwhile in this case?

closes #778