### PR TITLE
Fix rust_const syntax

### DIFF
--- a/backends/lean/Aeneas/Extract/Extract.lean
+++ b/backends/lean/Aeneas/Extract/Extract.lean
@@ -753,7 +753,7 @@ syntax (name := rustConst) "rust_const" str Parser.Tactic.optConfig : attr
 def elabConstNameInfo (stx : Syntax) : AttrM (String × ConstInfo) :=
   withRef stx do
     match stx with
-    | `(attr| rust_trait_impl $pat $config) => do
+    | `(attr| rust_const $pat $config) => do
       let pat := pat.getString
       if pat = "" then throwError "Not a valid name pattern: {pat}"
       let info ← liftCommandElabM (elabRustConstInfo config)


### PR DESCRIPTION
Hi,

Maybe this was missed when the syntax for rust_const was copy/pasted from the syntax for rust_trait_impl? I did not immediately see anything else that was missed, but someone else should take a look as I'm not familiar with this codebase at all.

 I encountered this when I was trying to use Aeneas with a project that uses the `u64::BITS` constant. I would get `internal exception: unsupportedSyntax` when I tried to fill in the `FunsExternal.lean` file. My change here appears to fix the issue.

Best,
Franklin