### PR TITLE
Add immutable theorems for Array and Slice indexing.

### DIFF
--- a/backends/lean/Aeneas/Std/Array/ArraySlice.lean
+++ b/backends/lean/Aeneas/Std/Array/ArraySlice.lean
@@ -220,4 +220,11 @@ def core.array.Array.as_mut_slice
     else a
   ok (⟨ a.val, by scalar_tac ⟩, back)
 
+@[simp, progress_simps]
+theorem Array.index_SliceIndexRangeUsizeSlice {T : Type} {N : Usize}
+    (a : Array T N) (r : core.ops.range.Range Usize) :
+    core.array.Array.index (core.ops.index.IndexSlice
+      (core.slice.index.SliceIndexRangeUsizeSlice T)) a r =
+    core.slice.index.SliceIndexRangeUsizeSlice.index r a.to_slice := by rfl
+
 end Aeneas.Std

--- a/backends/lean/Aeneas/Std/Slice.lean
+++ b/backends/lean/Aeneas/Std/Slice.lean
@@ -660,6 +660,20 @@ theorem core.slice.index.SliceIndexRangeUsizeSlice.index_mut.progress_spec (r : 
   . scalar_tac
 
 @[progress]
+theorem core.slice.index.SliceIndexRangeUsizeSlice.index.progress_spec {α : Type}
+    (r : core.ops.range.Range Usize) (s : Slice α) (h0 : r.start ≤ r.end) (h1 : r.end ≤ s.length) :
+    core.slice.index.SliceIndexRangeUsizeSlice.index r s ⦃ (s1 : Slice α) =>
+      s1.val = s.val.slice r.start r.end ∧
+      s1.length = r.end - r.start ⦄ := by
+  simp only [core.slice.index.SliceIndexRangeUsizeSlice.index, UScalar.le_equiv, Slice.length]
+  split
+  · simp only [spec_ok, true_and]
+    simp_lists
+    omega
+  · simp only [spec_fail]
+    scalar_tac
+
+@[progress]
 theorem core.slice.Slice.copy_from_slice.progress_spec (copyInst : core.marker.Copy α) (s0 s1 : Slice α)
   (h : s0.length = s1.length) :
   core.slice.Slice.copy_from_slice copyInst s0 s1 ⦃ s1' => s1 = s1' ⦄ := by


### PR DESCRIPTION
- Add theorems `Aeneas.Std.Array.index_SliceIndexRangeUsizeSlice` and  `core.slice.index.SliceIndexRangeUsizeSlice.index.progress_spec`.

  * `Aeneas.Std.Array.index_SliceIndexRangeUsizeSlice` bridges the trait dispatch chain for immutable range-based array indexing. The mutable counterpart `Slice.index_mut_SliceIndexRangeUsizeSliceInst` exists in Slice.lean but this immutable version is missing.
  
  * `core.slice.index.SliceIndexRangeUsizeSlice.index.progress_spec` is a progress spec for immutable range-based slice indexing. The mutable counterpart `SliceIndexRangeUsizeSlice.index_mut.progress_spec` exists in Slice.lean but this immutable version is missing.