### PR TITLE
Use `charon-portable` in released artifact

### DIFF
--- a/charon-pin
+++ b/charon-pin
@@ -1,2 +1,2 @@
 # This is the commit from https://github.com/AeneasVerif/charon that should be used with this version of aeneas.
-980159f0c979a702099aa7904334e534772e0bdb
+419f53b6eed3fe487a8427fd290a734c49634366

--- a/flake.lock
+++ b/flake.lock
@@ -9,11 +9,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1774026172,
-        "narHash": "sha256-kn2tpbSGg/86qq0N9oXPUXG/rtWfwK3JifpIUYOaXEI=",
+        "lastModified": 1774026783,
+        "narHash": "sha256-AVPK72oQ89u0w4ymr4hS4gNZ+Eb0vTNOk0YrQMAfGIk=",
         "owner": "aeneasverif",
         "repo": "charon",
-        "rev": "980159f0c979a702099aa7904334e534772e0bdb",
+        "rev": "419f53b6eed3fe487a8427fd290a734c49634366",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -77,6 +77,7 @@
         ocamlPackagesStatic = pkgs.pkgsStatic.ocaml-ng.ocamlPackages_5_2;
         coqPackages = pkgs.coqPackages_8_18;
         charon = inputs.charon.packages.${system}.charon;
+        charon-portable = inputs.charon.packages.${system}.charon-portable;
         charon-ml = inputs.charon.packages.${system}.charon-ml.override { inherit ocamlPackages; };
 
         easy_logging = pkgs.callPackage
@@ -142,17 +143,17 @@
             charon-ml = charon-ml.override { inherit ocamlPackages; };
           };
 
-        mk-aeneas-release = { aeneas, charon }: pkgs.runCommand "aeneas-release.tar.gz" { } ''
+        mk-aeneas-release = { aeneas, charon-portable }: pkgs.runCommand "aeneas-release.tar.gz" { } ''
           mkdir release
           cd release
-          cp ${charon}/bin/charon ${charon}/bin/charon-driver .
+          cp ${charon-portable}/bin/charon ${charon-portable}/bin/charon-driver .
           cp ${aeneas}/bin/aeneas .
           cp -r ${./backends} backends
           tar -czvf $out *
         '';
 
-        aeneas-release = mk-aeneas-release { inherit charon aeneas; };
-        aeneas-static-release = mk-aeneas-release { inherit charon; aeneas = aeneas-static; };
+        aeneas-release = mk-aeneas-release { inherit charon-portable aeneas; };
+        aeneas-static-release = mk-aeneas-release { inherit charon-portable; aeneas = aeneas-static; };
 
         aeneas-check-tidiness = pkgs.stdenv.mkDerivation rec {
           name = "aeneas-check-tidiness";


### PR DESCRIPTION
Builds on https://github.com/AeneasVerif/charon/pull/1070 – I'll need to update this PR once that merges.