### PR TITLE
fix: switch to using our own version of `TryThis`

### DIFF
--- a/backends/lean/Aeneas/Tactic/Step/Deprecated.lean
+++ b/backends/lean/Aeneas/Tactic/Step/Deprecated.lean
@@ -72,7 +72,7 @@ def evalDeprecatedProgressStarTac : Tactic := fun stx => do
     let info ← StepStar.evalStepStar cfg fuel
     let suggestion ← info.script.toSyntax
     let suggestion ← `(tacticSeq|$(suggestion)*)
-    Aesop.addTryThisTacticSeqSuggestion stx suggestion (origSpan? := ← getRef)
+    Aeneas.Utils.addTryThisTacticSeqSuggestion stx suggestion (origSpan? := ← getRef)
   | _ => throwUnsupportedSyntax
 
 /-!

--- a/backends/lean/Aeneas/Tactic/Step/StepStar.lean
+++ b/backends/lean/Aeneas/Tactic/Step/StepStar.lean
@@ -828,11 +828,7 @@ def evalStepStarTac : Tactic := fun stx => do
     let info ← evalStepStar cfg fuel
     let suggestion ← info.script.toSyntax
     let suggestion ← `(tacticSeq|$(suggestion)*)
-    /- TODO: do not use the Aesop helper but our own (it mentions Aesop in the message)
-       See https://github.com/AeneasVerif/aeneas/issues/476 -/
-    Aesop.addTryThisTacticSeqSuggestion stx suggestion (origSpan? := ← getRef)
-    --TODO: if we use this the indentation is not correct
-    --Meta.Tactic.TryThis.addSuggestion stx suggestion (origSpan? := ← getRef)
+    Aeneas.Utils.addTryThisTacticSeqSuggestion stx suggestion (origSpan? := ← getRef)
   | _ => throwUnsupportedSyntax
 
 end StepStar

--- a/backends/lean/AeneasMeta/Utils.lean
+++ b/backends/lean/AeneasMeta/Utils.lean
@@ -1767,6 +1767,38 @@ def traceGoalWithNode (cls : Name) (msg : String) : TacticM Unit := do
         addTrace cls m!"{← getMainGoal}"
     else pure ()
 
+/--
+Register a "Try this" suggestion for a tactic sequence.
+
+NOTE: This is lifted straight from Aesop. The reason we're not using it is because it has the code
+action title hard-coded to `Replace aesop with...`.
+-/
+def addTryThisTacticSeqSuggestion (ref : Syntax)
+    (suggestion : TSyntax ``Lean.Parser.Tactic.tacticSeq)
+    (origSpan? : Option Syntax := none) : MetaM Unit := do
+  let fmt ← PrettyPrinter.ppCategory ``Lean.Parser.Tactic.tacticSeq suggestion
+  let msgText := fmt.pretty (indent := 0) (column := 0)
+  if let some range := (origSpan?.getD ref).getRange? then
+    let map ← getFileMap
+    let (indent, column) := Lean.Meta.Tactic.TryThis.getIndentAndColumn map range
+    let text := fmt.pretty (indent := indent) (column := column)
+    let suggestion := {
+      -- HACK: The `tacticSeq` syntax category is pretty-printed with each line
+      -- indented by two spaces (for some reason), so we remove this
+      -- indentation.
+      suggestion := .string $ dedent text
+      toCodeActionTitle? := some λ _ => "Replace step* with the proof it found"
+      messageData? := some msgText
+      preInfo? := "  "
+    }
+    Lean.Meta.Tactic.TryThis.addSuggestion ref suggestion (origSpan? := origSpan?)
+      (header := "Try this:\n")
+where
+  dedent (s : String) : String :=
+    s.splitOn "\n"
+    |>.map (λ line => line.dropPrefix? "  " |>.map (·.toString) |>.getD line)
+    |> String.intercalate "\n"
+
 end Utils
 
 end Aeneas


### PR DESCRIPTION
The `TryThis` suggestion for `step*?` had a user message referencing Aesop because we were using their `addTryThisTacticSeqSuggestion` infrastructure.

The builtin `TryThis.addSuggestion` unfortunately doesn't work because `tacticSeq` has an extra couple spaces in front of each line when pretty printed, so it seems like the easiest solution is to just lift the `aesop?` solution and change the suggestion text.

This closes issue #476 