### PR TITLE
Handle char matching in SwitchInt evaluation

### DIFF
--- a/src/interp/InterpStatements.ml
+++ b/src/interp/InterpStatements.ml
@@ -1041,6 +1041,15 @@ and eval_switch_raw (config : config) (span : Meta.span) (switch : switch) :
             with
             | None -> eval_block config otherwise ctx
             | Some (_, tgt) -> eval_block config tgt ctx)
+        | VLiteral (VChar cv), TChar -> (
+            (* Find the branch *)
+            match
+              List.find_opt (fun (svl, _) -> List.mem (VChar cv) svl) stgts
+            with
+            | None -> eval_block config otherwise ctx
+            | Some (_, tgt) -> eval_block config tgt ctx)
+        | VSymbolic _, TChar ->
+            [%craise] span "Unsupported: matching on a symbolic char value"
         | VSymbolic sv, _ ->
             (* Several branches may be grouped together: every branch is described
                by a pair (list of values, branch expression).


### PR DESCRIPTION
Adds concrete VChar case to eval_switch_raw so that match-on-char works, and raises a proper error for symbolic char matching (unsupported).

Fixes #797.