### PR TITLE
[Lean]: Support BITS constant on integer types

### DIFF
--- a/backends/lean/Aeneas/Std/Scalar/Core.lean
+++ b/backends/lean/Aeneas/Std/Scalar/Core.lean
@@ -835,6 +835,18 @@ theorem IScalar.min_le_max (ty : IScalarTy) : IScalar.min ty ≤ IScalar.max ty 
 @[reducible] def core.num.Isize.MIN : Isize := IScalar.ofIntCore Isize.min (by simp [Isize.min, Isize.numBits])
 @[reducible] def core.num.Isize.MAX : Isize := IScalar.ofIntCore Isize.max (by simp [Isize.max, Isize.numBits]; (have : (0 : Int) < 2 ^ (System.Platform.numBits - 1) := by simp); omega)
 
+@[reducible] def core.num.U8.BITS : U32 := UScalar.ofNat (UScalarTy.numBits .U8)
+@[reducible] def core.num.U16.BITS : U32 := UScalar.ofNat (UScalarTy.numBits .U16)
+@[reducible] def core.num.U32.BITS : U32 := UScalar.ofNat (UScalarTy.numBits .U32)
+@[reducible] def core.num.U64.BITS : U32 := UScalar.ofNat (UScalarTy.numBits .U64)
+@[reducible] def core.num.U128.BITS : U32 := UScalar.ofNat (UScalarTy.numBits .U128)
+@[reducible] def core.num.Usize.BITS : U32 := UScalar.ofNat (UScalarTy.numBits .Usize) (by grind[UScalar.cMax, UScalar.rMax, U32.rMax, System.Platform.numBits])
+@[reducible] def core.num.I8.BITS : U32 := UScalar.ofNat (IScalarTy.numBits .I8)
+@[reducible] def core.num.I16.BITS : U32 := UScalar.ofNat (IScalarTy.numBits .I16)
+@[reducible] def core.num.I32.BITS : U32 := UScalar.ofNat (IScalarTy.numBits .I32)
+@[reducible] def core.num.I64.BITS : U32 := UScalar.ofNat (IScalarTy.numBits .I64)
+@[reducible] def core.num.I128.BITS : U32 := UScalar.ofNat (IScalarTy.numBits .I128)
+@[reducible] def core.num.Isize.BITS : U32 := UScalar.ofNat (IScalarTy.numBits .Isize) (by grind[UScalar.cMax, UScalar.rMax, U32.rMax, System.Platform.numBits])
 
 /-! # Comparisons -/
 instance {ty} : LT (UScalar ty) where

--- a/src/extract/ExtractBuiltin.ml
+++ b/src/extract/ExtractBuiltin.ml
@@ -36,6 +36,7 @@ let builtin_globals () : Pure.builtin_global_info list =
     ([
        mk_ints_globals "MIN";
        mk_ints_globals "MAX";
+       mk_ints_globals "BITS";
        [
          (* UNIT_METADATA should be eliminated through a micro-pass and should
             never appear in the code. *)

--- a/tests/lean/Scalars.lean
+++ b/tests/lean/Scalars.lean
@@ -126,4 +126,16 @@ def u32_as_i16 (x : Std.U32) : Result Std.I16 := do
 def i16_as_u32 (x : Std.I16) : Result Std.U32 := do
   ok (IScalar.hcast .U32 x)
 
+/-- [scalars::u32_use_bits]:
+    Source: 'tests/src/scalars.rs', lines 93:0-95:1
+    Visibility: public -/
+def u32_use_bits : Result Std.U32 := do
+  ok core.num.U32.BITS
+
+/-- [scalars::i32_use_bits]:
+    Source: 'tests/src/scalars.rs', lines 97:0-99:1
+    Visibility: public -/
+def i32_use_bits : Result Std.U32 := do
+  ok core.num.I32.BITS
+
 end scalars

--- a/tests/src/scalars.rs
+++ b/tests/src/scalars.rs
@@ -89,3 +89,11 @@ fn u32_as_i16(x: u32) -> i16 {
 fn i16_as_u32(x: i16) -> u32 {
     x as u32
 }
+
+pub fn u32_use_bits() -> u32 {
+    u32::BITS
+}
+
+pub fn i32_use_bits() -> u32 {
+    i32::BITS
+}


### PR DESCRIPTION
## Summary

All Rust integer types provide the associated constant [`BITS`](https://doc.rust-lang.org/std/primitive.u8.html#associatedconstant.BITS), returning the size of the type in bits. Translation does not reduce these constants and instead generates opaque axioms, e.g., using `u8::BITS` generates

```lean
@[rust_const "core::num::{u8}::BITS"] axiom core.num.U8.BITS : Result Std.U32
```

This PR registers `BITS` as a builtin global for all integer types mapping it to 

```lean
UScalar.ofNat (UScalarTy.numBits <Ty>)
```

## Changes

- Register BITS as a builtin global in the extractor (`ExtractBuiltin.ml`) (analogously to  `MIN` and `MAX`)
- Add `core.num.{U8,... , U128, Usize, I8, ..., I128, Isize}.BITS` as reducible definitions in `Scalar/Core.lean`
- Add test functions `u32_use_bits` / `i32_use_bits` in `tests/src/scalars.rs` 