### PR TITLE
Fix scalar PartialOrd builtin name: PartialCmp -> PartialOrd

### DIFF
--- a/src/extract/ExtractBuiltin.ml
+++ b/src/extract/ExtractBuiltin.ml
@@ -812,7 +812,7 @@ let mk_builtin_funs () : (pattern * Pure.builtin_fun_info) list =
             "core::cmp::impls::{core::cmp::PartialOrd<" ^ ty ^ "," ^ ty ^ ">}::"
             ^ fun_name)
           (fun ty fun_name ->
-            "core.cmp.impls.PartialCmp"
+            "core.cmp.impls.PartialOrd"
             ^ StringUtils.capitalize_first_letter ty
             ^ "." ^ fun_name)
           [

--- a/tests/lean/Order.lean
+++ b/tests/lean/Order.lean
@@ -27,7 +27,7 @@ def u32_compare (x : Std.U32) (y : Std.U32) : Result Ordering := do
   ok (core.cmp.impls.OrdU32.cmp x y)
 
 /-- [order::u64_partial_cmp]:
-    Source: 'tests/src/order.rs', lines 16:0-18:1
+    Source: 'tests/src/order.rs', lines 13:0-15:1
     Visibility: public -/
 def u64_partial_cmp
   (x : Std.U64) (y : Std.U64) : Result (Option Ordering) := do

--- a/tests/lean/Order.lean
+++ b/tests/lean/Order.lean
@@ -26,4 +26,11 @@ def compare
 def u32_compare (x : Std.U32) (y : Std.U32) : Result Ordering := do
   ok (core.cmp.impls.OrdU32.cmp x y)
 
+/-- [order::u64_partial_cmp]:
+    Source: 'tests/src/order.rs', lines 16:0-18:1
+    Visibility: public -/
+def u64_partial_cmp
+  (x : Std.U64) (y : Std.U64) : Result (Option Ordering) := do
+  ok (core.cmp.impls.PartialOrdU64.partial_cmp x y)
+
 end order

--- a/tests/src/order.rs
+++ b/tests/src/order.rs
@@ -9,3 +9,7 @@ pub fn compare<T: Ord>(x: &T, y: &T) -> Ordering {
 pub fn u32_compare(x: u32, y: u32) -> Ordering {
     x.cmp(&y)
 }
+
+pub fn u64_partial_cmp(x: u64, y: u64) -> Option<Ordering> {
+    x.partial_cmp(&y)
+}


### PR DESCRIPTION
The Lean extraction emitted `core.cmp.impls.PartialCmpU64` (and other scalar types) instead of `core.cmp.impls.PartialOrdU64`, causing a name mismatch with the Lean library which defines these via the `scalar` macro as `core.cmp.impls.PartialOrd'S.*` in `Aeneas/Std/Scalar/EqOrd.lean`.

This broke any crate that derives `PartialOrd` on a newtype wrapping a scalar :

```rust
#[derive(PartialOrd)] 
struct View(u64)
```


 Summary of changes:

- Fixes a typo in the builtin name mapping for scalar `PartialOrd` methods in `ExtractBuiltin.ml`: the Lean name prefix was `PartialCmp` instead of `PartialOrd`
- The compiler emitted names like `core.cmp.impls.PartialCmpU64.partial_cmp`, but the Lean library defines them as `core.cmp.impls.PartialOrdU64.partial_cmp`, causing unresolved name errors
- Adds a regression test (`u64_partial_cmp`) that exercises the scalar `PartialOrd` builtin path

Partially addresses #903 (fixes the scalar `PartialOrd` naming, but the `Types.lean`/`Funs.lean` dependency ordering is a separate issue).