### PR TITLE
fix(mvcgen): Allow divergence for partial correctness

### DIFF
--- a/backends/lean/Aeneas/Std/WP.lean
+++ b/backends/lean/Aeneas/Std/WP.lean
@@ -444,11 +444,13 @@ namespace Aeneas.Std.WP
 open Std Result
 open Std.Do
 
-instance Result.instWP : WP (Result) (.except Error .pure) where
-    wp
-        | .ok v => wp (pure v : Except Error _)
-        | .fail e => wp (throw e : Except Error _)
-        | .div => PredTrans.const ⌜False⌝
+instance Result.instWP : WP Result (.except Error (.except PUnit .pure)) where
+  wp x := {
+    apply Q := match x with | .ok a => Q.1 a | .fail e => Q.2.1 e | .div => Q.2.2.1 ()
+    conjunctive Q₁ Q₂ := by
+      apply SPred.bientails.of_eq
+      cases x <;> simp
+  }
 
 instance : LawfulMonad Result where
     map_const := by intros; rfl
@@ -461,19 +463,14 @@ instance : LawfulMonad Result where
     bind_map := by intros; rfl
     bind_assoc := by intros _ _ _ x _ _; cases x <;> rfl
 
-instance : WPMonad Result (.except Error .pure) where
-  wp_pure := by
-    intros
-    ext Q
-    simp [wp, PredTrans.pure, pure, Except.pure, Id.run]
-  wp_bind x f := by
-    simp only [Result.instWP]
-    ext Q
-    cases x <;> simp [PredTrans.const]
+instance Result.instWPMonad : WPMonad Result (.except Error (.except PUnit .pure)) where
+  wp_pure a := by ext; simp [wp]
+  wp_bind x f := by ext Q; cases x <;> simp [wp]
 
 theorem Result.of_wp {α} {x : Result α} (P : Result α → Prop) :
     (⊢ₛ wp⟦x⟧ post⟨fun a => ⌜P (.ok a)⌝,
-                  fun e => ⌜P (.fail e)⌝⟩) → P x := by
+                  fun e => ⌜P (.fail e)⌝,
+                  fun () => ⌜P .div⌝⟩) → P x := by
   intro hspec
   simp only [instWP] at hspec
   split at hspec <;> simp_all


### PR DESCRIPTION
Hello!

Your `WP` instance for `mvcgen` has the same flaw that we had until recently in hax. By assigning `| .div => PredTrans.const ⌜False⌝`, you are essentially saying that divergence can never be considered correct, even when using partial correctness. 

Here is an example attempt of using partial correctness on `div`:

```
example : ⦃ ⌜ True ⌝ ⦄ (Result.div : Result Unit) ⦃ ⇓? r => ⌜ True ⌝ ⦄ := by
  mvcgen
  simp [wp]
  sorry -- Goal is False
```
[View Full Example in Live Lean](https://live.lean-lang.org/#codez=JYWwDg9gTgLgBAZRgEwHQBUCGBjGxuoAiEAUCRGAKYB2iKRpJw1yArrsAG6VwCiUUaHADuAC0pRKJODIA+cTAGdFEvBGoAxTMAA2rSQC4+A6NLlxmMSgHMJAeW5QAZjojCj/QVDNx5yLsCKwOoAQgCeAFoSEB4m3jK+CgKYYXasMHZOIRCsLIqxXj7yIJgAHqCsIAjAAF6UvKXYlJTILQWmCfJgmNT47fHmua1O/SStUAHU1nAASpRgUAA0cCG8AI5kzGwc3LOUiqw68AAUgI3AcEboYVRwrACUIuKSZvIQANZwx5xGp3dGcwcjnBTi84E5tDpPpR+n89oD4CDzP5OGMJJNpnMFstVhtUU44AAjLZwADe50u1x4rAAvqTAE3AFzgVxunFpx1K/32hwRD2OI2BcEASYRw7lwOkPTnwsUXAC8ZhKMGwojgpREwBgolBqHecE4MhlAD4wbqteDdLq4Ia4KgzZCUeZUMjLUbHVxNtRFDAek1GSFiQDRWIJFIZESWLLCVt3Z7vTwjAAFfQ8ANAoPPGRgJMRpy5FXO6060rRr3UH1GACy6kwyBFqaeUiYHpLPpTMFQzE9AHV44zu59W7zUJRGvN4J4hKhM5IHmmQwlhGAfAkHTq9VaF58pzw9R4R2Ax3E4AB9O5L5fyG0QuA8ddgT4awTCa+MhpNffGLzH0/L8/Wp1W+NJGQdAoB6RRUGwdRPTgQAcYi0HQVEAXGIyGHTBwB0OM4EAYMpYKZKBWB4RC4EAEMp+y5I5XR3Wt4AAVV6GAHhwwBlwgAfjgKB8xgvCCLgIjSIMGVCTCeVOGwWxqDMIJwDgABtBcAF1JOgKAwjgABaNS4AAcQgTBIUCOB4JUIA)

This PR resolves the issue. For the example above, `mvcgen` now produces no verification conditions at all.