### PR TITLE
fix: Add default field values for PartialOrd and Ord structures

### DIFF
--- a/backends/lean/Aeneas/Std/Core/Cmp.lean
+++ b/backends/lean/Aeneas/Std/Core/Cmp.lean
@@ -32,86 +32,113 @@ attribute
   (body := .enum [⟨"Less", "lt", none⟩, ⟨"Equal", "eq", none⟩, ⟨"Greater", "gt", none⟩])]
   Ordering
 
-@[rust_trait "core::cmp::PartialOrd" (parentClauses := ["partialEqInst"])]
-structure core.cmp.PartialOrd (Self : Type) (Rhs : Type) where
-  partialEqInst : core.cmp.PartialEq Self Rhs
-  partial_cmp : Self → Rhs → Result (Option Ordering)
-  lt : Self → Rhs → Result Bool := fun x y => do
-    let cmp ← partial_cmp x y; ok (cmp = some .lt)
-  le : Self → Rhs → Result Bool := fun x y => do
-    let cmp ← partial_cmp x y; ok (cmp = some .lt ∨ cmp = some .eq)
-  gt : Self → Rhs → Result Bool := fun x y => do
-    let cmp ← partial_cmp x y; ok (cmp = some .gt)
-  ge : Self → Rhs → Result Bool := fun x y => do
-    let cmp ← partial_cmp x y; ok (cmp = some .gt ∨ cmp = some .eq)
-
-/- Default method -/
-@[rust_fun "core::cmp::PartialOrd::lt"]
-def core.cmp.PartialOrd.lt.default {Self Rhs : Type}
+/- Auxiliary functions for the default implementations of `PartialOrd` methods -/
+def core.cmp.PartialOrd.lt_body {Self Rhs : Type}
   (partial_cmp : Self → Rhs → Result (Option Ordering))
   (x : Self) (y : Rhs) : Result Bool := do
   let cmp ← partial_cmp x y
   ok (cmp = some .lt)
 
-/- Default method -/
-@[rust_fun "core::cmp::PartialOrd::le"]
-def core.cmp.PartialOrd.le.default {Self Rhs : Type}
+def core.cmp.PartialOrd.le_body {Self Rhs : Type}
   (partial_cmp : Self → Rhs → Result (Option Ordering))
   (x : Self) (y : Rhs) : Result Bool := do
   let cmp ← partial_cmp x y
   ok (cmp = some .lt ∨ cmp = some .eq)
 
-/- Default method -/
-@[rust_fun "core::cmp::PartialOrd::gt"]
-def core.cmp.PartialOrd.gt.default {Self Rhs : Type}
+def core.cmp.PartialOrd.gt_body {Self Rhs : Type}
   (partial_cmp : Self → Rhs → Result (Option Ordering))
   (x : Self) (y : Rhs) : Result Bool := do
   let cmp ← partial_cmp x y
   ok (cmp = some .gt)
 
-/- Default method -/
-@[rust_fun "core::cmp::PartialOrd::ge"]
-def core.cmp.PartialOrd.ge.default {Self Rhs : Type}
+def core.cmp.PartialOrd.ge_body {Self Rhs : Type}
   (partial_cmp : Self → Rhs → Result (Option Ordering))
   (x : Self) (y : Rhs) : Result Bool := do
   let cmp ← partial_cmp x y
   ok (cmp = some .gt ∨ cmp = some .eq)
+
+@[rust_trait "core::cmp::PartialOrd" (parentClauses := ["partialEqInst"])]
+structure core.cmp.PartialOrd (Self : Type) (Rhs : Type) where
+  partialEqInst : core.cmp.PartialEq Self Rhs
+  partial_cmp : Self → Rhs → Result (Option Ordering)
+  lt : Self → Rhs → Result Bool := core.cmp.PartialOrd.lt_body partial_cmp
+  le : Self → Rhs → Result Bool := core.cmp.PartialOrd.le_body partial_cmp
+  gt : Self → Rhs → Result Bool := core.cmp.PartialOrd.gt_body partial_cmp
+  ge : Self → Rhs → Result Bool := core.cmp.PartialOrd.ge_body partial_cmp
+
+/- Default method -/
+@[rust_fun "core::cmp::PartialOrd::lt"]
+def core.cmp.PartialOrd.lt.default {Self Rhs : Type}
+  (partial_cmp : Self → Rhs → Result (Option Ordering))
+  (x : Self) (y : Rhs) : Result Bool :=
+  core.cmp.PartialOrd.lt_body partial_cmp x y
+
+/- Default method -/
+@[rust_fun "core::cmp::PartialOrd::le"]
+def core.cmp.PartialOrd.le.default {Self Rhs : Type}
+  (partial_cmp : Self → Rhs → Result (Option Ordering))
+  (x : Self) (y : Rhs) : Result Bool :=
+  core.cmp.PartialOrd.le_body partial_cmp x y
+
+/- Default method -/
+@[rust_fun "core::cmp::PartialOrd::gt"]
+def core.cmp.PartialOrd.gt.default {Self Rhs : Type}
+  (partial_cmp : Self → Rhs → Result (Option Ordering))
+  (x : Self) (y : Rhs) : Result Bool :=
+  core.cmp.PartialOrd.gt_body partial_cmp x y
+
+/- Default method -/
+@[rust_fun "core::cmp::PartialOrd::ge"]
+def core.cmp.PartialOrd.ge.default {Self Rhs : Type}
+  (partial_cmp : Self → Rhs → Result (Option Ordering))
+  (x : Self) (y : Rhs) : Result Bool :=
+  core.cmp.PartialOrd.ge_body partial_cmp x y
+
+/- Auxiliary functions for the default implementations of `Ord` methods -/
+def core.cmp.Ord.max_body {Self : Type} (lt : Self → Self → Result Bool)
+  (x y : Self) : Result Self := do
+  if ← lt x y then ok y else ok x
+
+def core.cmp.Ord.min_body {Self : Type} (lt : Self → Self → Result Bool)
+  (x y : Self) : Result Self := do
+  if ← lt x y then ok x else ok y
+
+def core.cmp.Ord.clamp_body {Self : Type} (le lt gt : Self → Self → Result Bool)
+  (self min max : Self) : Result Self := do
+  massert (← le min max)
+  if ← lt self min then ok min
+  else if ← gt self max then ok max
+  else ok self
 
 @[rust_trait "core::cmp::Ord" (parentClauses := ["eqInst", "partialOrdInst"])]
 structure core.cmp.Ord (Self : Type) where
   eqInst : core.cmp.Eq Self
   partialOrdInst : core.cmp.PartialOrd Self Self
   cmp : Self → Self → Result Ordering
-  max : Self → Self → Result Self := fun x y => do
-    if ← partialOrdInst.lt x y then ok y else ok x
-  min : Self → Self → Result Self := fun x y => do
-    if ← partialOrdInst.lt x y then ok x else ok y
-  clamp : Self → Self → Self → Result Self := fun self min max => do
-    massert (← partialOrdInst.le min max)
-    if ← partialOrdInst.lt self min then ok min
-    else if ← partialOrdInst.gt self max then ok max
-    else ok self
+  max : Self → Self → Result Self :=
+    core.cmp.Ord.max_body partialOrdInst.lt
+  min : Self → Self → Result Self :=
+    core.cmp.Ord.min_body partialOrdInst.lt
+  clamp : Self → Self → Self → Result Self :=
+    core.cmp.Ord.clamp_body partialOrdInst.le partialOrdInst.lt partialOrdInst.gt
 
 /- Default method -/
 @[rust_fun "core::cmp::Ord::max"]
 def core.cmp.Ord.max.default {Self : Type} (lt : Self → Self → Result Bool)
-  (x y : Self) : Result Self := do
-  if ← lt x y then ok y else ok x
+  (x y : Self) : Result Self :=
+  core.cmp.Ord.max_body lt x y
 
 /- Default method -/
 @[rust_fun "core::cmp::Ord::min"]
 def core.cmp.Ord.min.default {Self : Type} (lt : Self → Self → Result Bool)
-  (x y : Self) : Result Self := do
-  if ← lt x y then ok x else ok y
+  (x y : Self) : Result Self :=
+  core.cmp.Ord.min_body lt x y
 
 /- Default method -/
 @[rust_fun "core::cmp::Ord::clamp"]
 def core.cmp.Ord.clamp.default {Self : Type} (le lt gt : Self → Self → Result Bool)
-  (self min max : Self) : Result Self := do
-  massert (← le min max)
-  if ← lt self min then ok min
-  else if ← gt self max then ok max
-  else ok self
+  (self min max : Self) : Result Self :=
+  core.cmp.Ord.clamp_body le lt gt self min max
 
 @[simp, rust_fun "core::cmp::min"]
 def core.cmp.min {T : Type} (OrdInst : core.cmp.Ord T) (x y : T) : Result T :=

--- a/backends/lean/Aeneas/Std/Core/Cmp.lean
+++ b/backends/lean/Aeneas/Std/Core/Cmp.lean
@@ -36,10 +36,14 @@ attribute
 structure core.cmp.PartialOrd (Self : Type) (Rhs : Type) where
   partialEqInst : core.cmp.PartialEq Self Rhs
   partial_cmp : Self → Rhs → Result (Option Ordering)
-  lt : Self → Rhs → Result Bool
-  le : Self → Rhs → Result Bool
-  gt : Self → Rhs → Result Bool
-  ge : Self → Rhs → Result Bool
+  lt : Self → Rhs → Result Bool := fun x y => do
+    let cmp ← partial_cmp x y; ok (cmp = some .lt)
+  le : Self → Rhs → Result Bool := fun x y => do
+    let cmp ← partial_cmp x y; ok (cmp = some .lt ∨ cmp = some .eq)
+  gt : Self → Rhs → Result Bool := fun x y => do
+    let cmp ← partial_cmp x y; ok (cmp = some .gt)
+  ge : Self → Rhs → Result Bool := fun x y => do
+    let cmp ← partial_cmp x y; ok (cmp = some .gt ∨ cmp = some .eq)
 
 /- Default method -/
 @[rust_fun "core::cmp::PartialOrd::lt"]
@@ -78,9 +82,15 @@ structure core.cmp.Ord (Self : Type) where
   eqInst : core.cmp.Eq Self
   partialOrdInst : core.cmp.PartialOrd Self Self
   cmp : Self → Self → Result Ordering
-  max : Self → Self → Result Self
-  min : Self → Self → Result Self
-  clamp : Self → Self → Self → Result Self
+  max : Self → Self → Result Self := fun x y => do
+    if ← partialOrdInst.lt x y then ok y else ok x
+  min : Self → Self → Result Self := fun x y => do
+    if ← partialOrdInst.lt x y then ok x else ok y
+  clamp : Self → Self → Self → Result Self := fun self min max => do
+    massert (← partialOrdInst.le min max)
+    if ← partialOrdInst.lt self min then ok min
+    else if ← partialOrdInst.gt self max then ok max
+    else ok self
 
 /- Default method -/
 @[rust_fun "core::cmp::Ord::max"]

--- a/src/extract/ExtractBuiltin.ml
+++ b/src/extract/ExtractBuiltin.ml
@@ -812,7 +812,7 @@ let mk_builtin_funs () : (pattern * Pure.builtin_fun_info) list =
             "core::cmp::impls::{core::cmp::PartialOrd<" ^ ty ^ "," ^ ty ^ ">}::"
             ^ fun_name)
           (fun ty fun_name ->
-            "core.cmp.impls.PartialCmp"
+            "core.cmp.impls.PartialOrd"
             ^ StringUtils.capitalize_first_letter ty
             ^ "." ^ fun_name)
           [

--- a/tests/lean/Order.lean
+++ b/tests/lean/Order.lean
@@ -27,10 +27,96 @@ def u32_compare (x : Std.U32) (y : Std.U32) : Result Ordering := do
   ok (core.cmp.impls.OrdU32.cmp x y)
 
 /-- [order::u64_partial_cmp]:
-    Source: 'tests/src/order.rs', lines 16:0-18:1
+    Source: 'tests/src/order.rs', lines 13:0-15:1
     Visibility: public -/
 def u64_partial_cmp
   (x : Std.U64) (y : Std.U64) : Result (Option Ordering) := do
   ok (core.cmp.impls.PartialOrdU64.partial_cmp x y)
+
+/-- [order::Wrap]
+    Source: 'tests/src/order.rs', lines 22:0-22:21
+    Visibility: public -/
+@[reducible]
+def Wrap := Std.U64
+
+/-- Trait implementation: [order::{core::marker::StructuralPartialEq for order::Wrap}]
+    Source: 'tests/src/order.rs', lines 21:9-21:18 -/
+@[reducible]
+def Wrap.Insts.CoreMarkerStructuralPartialEq : core.marker.StructuralPartialEq
+  Wrap := {
+}
+
+/-- [order::{core::cmp::PartialEq<order::Wrap> for order::Wrap}::eq]:
+    Source: 'tests/src/order.rs', lines 21:9-21:18
+    Visibility: public -/
+def Wrap.Insts.CoreCmpPartialEqWrap.eq
+  (self : Wrap) (other : Wrap) : Result Bool := do
+  ok (self = other)
+
+/-- Trait implementation: [order::{core::cmp::PartialEq<order::Wrap> for order::Wrap}]
+    Source: 'tests/src/order.rs', lines 21:9-21:18 -/
+@[reducible]
+def Wrap.Insts.CoreCmpPartialEqWrap : core.cmp.PartialEq Wrap Wrap := {
+  eq := Wrap.Insts.CoreCmpPartialEqWrap.eq
+}
+
+/-- [order::{core::cmp::Eq for order::Wrap}::assert_receiver_is_total_eq]:
+    Source: 'tests/src/order.rs', lines 21:20-21:22
+    Visibility: public -/
+def Wrap.Insts.CoreCmpEq.assert_receiver_is_total_eq
+  (self : Wrap) : Result Unit := do
+  ok ()
+
+/-- Trait implementation: [order::{core::cmp::Eq for order::Wrap}]
+    Source: 'tests/src/order.rs', lines 21:20-21:22 -/
+@[reducible]
+def Wrap.Insts.CoreCmpEq : core.cmp.Eq Wrap := {
+  partialEqInst := Wrap.Insts.CoreCmpPartialEqWrap
+  assert_receiver_is_total_eq :=
+    Wrap.Insts.CoreCmpEq.assert_receiver_is_total_eq
+}
+
+/-- [order::{core::cmp::PartialOrd<order::Wrap> for order::Wrap}::partial_cmp]:
+    Source: 'tests/src/order.rs', lines 21:24-21:34
+    Visibility: public -/
+def Wrap.Insts.CoreCmpPartialOrdWrap.partial_cmp
+  (self : Wrap) (other : Wrap) : Result (Option Ordering) := do
+  ok (core.cmp.impls.PartialOrdU64.partial_cmp self other)
+
+/-- Trait implementation: [order::{core::cmp::PartialOrd<order::Wrap> for order::Wrap}]
+    Source: 'tests/src/order.rs', lines 21:24-21:34 -/
+@[reducible]
+def Wrap.Insts.CoreCmpPartialOrdWrap : core.cmp.PartialOrd Wrap Wrap := {
+  partialEqInst := Wrap.Insts.CoreCmpPartialEqWrap
+  partial_cmp := Wrap.Insts.CoreCmpPartialOrdWrap.partial_cmp
+}
+
+/-- [order::{core::cmp::Ord for order::Wrap}::cmp]:
+    Source: 'tests/src/order.rs', lines 21:36-21:39
+    Visibility: public -/
+def Wrap.Insts.CoreCmpOrd.cmp
+  (self : Wrap) (other : Wrap) : Result Ordering := do
+  ok (core.cmp.impls.OrdU64.cmp self other)
+
+/-- Trait implementation: [order::{core::cmp::Ord for order::Wrap}]
+    Source: 'tests/src/order.rs', lines 21:36-21:39 -/
+@[reducible]
+def Wrap.Insts.CoreCmpOrd : core.cmp.Ord Wrap := {
+  eqInst := Wrap.Insts.CoreCmpEq
+  partialOrdInst := Wrap.Insts.CoreCmpPartialOrdWrap
+  cmp := Wrap.Insts.CoreCmpOrd.cmp
+}
+
+/-- [order::wrap_partial_cmp]:
+    Source: 'tests/src/order.rs', lines 24:0-26:1
+    Visibility: public -/
+def wrap_partial_cmp (x : Wrap) (y : Wrap) : Result (Option Ordering) := do
+  Wrap.Insts.CoreCmpPartialOrdWrap.partial_cmp x y
+
+/-- [order::wrap_cmp]:
+    Source: 'tests/src/order.rs', lines 28:0-30:1
+    Visibility: public -/
+def wrap_cmp (x : Wrap) (y : Wrap) : Result Ordering := do
+  Wrap.Insts.CoreCmpOrd.cmp x y
 
 end order

--- a/tests/lean/Order.lean
+++ b/tests/lean/Order.lean
@@ -26,4 +26,11 @@ def compare
 def u32_compare (x : Std.U32) (y : Std.U32) : Result Ordering := do
   ok (core.cmp.impls.OrdU32.cmp x y)
 
+/-- [order::u64_partial_cmp]:
+    Source: 'tests/src/order.rs', lines 16:0-18:1
+    Visibility: public -/
+def u64_partial_cmp
+  (x : Std.U64) (y : Std.U64) : Result (Option Ordering) := do
+  ok (core.cmp.impls.PartialOrdU64.partial_cmp x y)
+
 end order

--- a/tests/src/order.rs
+++ b/tests/src/order.rs
@@ -13,3 +13,18 @@ pub fn u32_compare(x: u32, y: u32) -> Ordering {
 pub fn u64_partial_cmp(x: u64, y: u64) -> Option<Ordering> {
     x.partial_cmp(&y)
 }
+
+/// Exercises derived PartialOrd and Ord on a struct with scalar fields.
+/// The derived impls only generate partial_cmp/cmp — the remaining methods
+/// (lt, le, gt, ge, max, min, clamp) use defaults. The Lean structure
+/// definitions must provide default field values for these.
+#[derive(PartialEq, Eq, PartialOrd, Ord)]
+pub struct Wrap(u64);
+
+pub fn wrap_partial_cmp(x: &Wrap, y: &Wrap) -> Option<Ordering> {
+    x.partial_cmp(y)
+}
+
+pub fn wrap_cmp(x: &Wrap, y: &Wrap) -> Ordering {
+    x.cmp(y)
+}

--- a/tests/src/order.rs
+++ b/tests/src/order.rs
@@ -9,3 +9,7 @@ pub fn compare<T: Ord>(x: &T, y: &T) -> Ordering {
 pub fn u32_compare(x: u32, y: u32) -> Ordering {
     x.cmp(&y)
 }
+
+pub fn u64_partial_cmp(x: u64, y: u64) -> Option<Ordering> {
+    x.partial_cmp(&y)
+}


### PR DESCRIPTION
When Rust derives `PartialOrd`/`Ord`, only `partial_cmp`/`cmp` are generated, the rest use trait defaults. Charon's LLBC only includes the generated methods, so Aeneas emits struct literals missing the default fields. Previously this caused "Fields missing" errors in Lean.

The fix follows the same pattern already used by `PartialEq.ne` and `Eq.assert_receiver_is_total_eq`: Lean fills in defaults when the compiler omits them.

Stacked on #935 (fails to build without it).