### PR TITLE
feat(mvcgen): specs for +,-,*

### DIFF
--- a/backends/lean/Aeneas/Std/Scalar/Core.lean
+++ b/backends/lean/Aeneas/Std/Scalar/Core.lean
@@ -582,7 +582,7 @@ theorem UScalar.tryMkOpt_eq (ty : UScalarTy) (x : Nat) :
 theorem UScalar.tryMk_eq (ty : UScalarTy) (x : Nat) :
   match tryMk ty x with
   | ok y => y.val = x ∧ inBounds ty x
-  | fail _ => ¬ (inBounds ty x)
+  | fail .integerOverflow => ¬ (inBounds ty x)
   | _ => False := by
   have := UScalar.tryMkOpt_eq ty x
   simp [tryMk, ofOption]
@@ -604,7 +604,7 @@ theorem IScalar.tryMkOpt_eq (ty : IScalarTy) (x : Int) :
 theorem IScalar.tryMk_eq (ty : IScalarTy) (x : Int) :
   match tryMk ty x with
   | ok y => y.val = x ∧ inBounds ty x
-  | fail _ => ¬ (inBounds ty x)
+  | fail .integerOverflow => ¬ (inBounds ty x)
   | _ => False := by
   have := tryMkOpt_eq ty x
   simp [tryMk]

--- a/backends/lean/Aeneas/Std/Scalar/Ops/Add.lean
+++ b/backends/lean/Aeneas/Std/Scalar/Ops/Add.lean
@@ -39,8 +39,8 @@ theorem UScalar.add_equiv {ty} (x y : UScalar ty) :
   | ok z => x.val + y.val < 2^ty.numBits ∧
     z.val = x.val + y.val ∧
     z.bv = x.bv + y.bv
-  | fail _ => ¬ (UScalar.inBounds ty (x.val + y.val))
-  | _ => ⊥ := by
+  | fail .integerOverflow => ¬ (UScalar.inBounds ty (x.val + y.val))
+  | _ => False := by
   have : x + y = add x y := by rfl
   rw [this]
   simp [add]
@@ -58,8 +58,8 @@ theorem IScalar.add_equiv {ty} (x y : IScalar ty) :
     IScalar.inBounds ty (x.val + y.val) ∧
     z.val = x.val + y.val ∧
     z.bv = x.bv + y.bv
-  | fail _ => ¬ (IScalar.inBounds ty (x.val + y.val))
-  | _ => ⊥ := by
+  | fail .integerOverflow => ¬ (IScalar.inBounds ty (x.val + y.val))
+  | _ => False := by
   have : x + y = add x y := by rfl
   rw [this]
   simp [add]
@@ -106,28 +106,61 @@ iscalar theorem «%S».add_bv_spec {x y : «%S»}
 /-!
 Theorems about the addition, with a specification which uses
 only integers. Those are the most common to use, so we mark them with the
-`step` attribute.
+`step` and `spec` attribute.
 -/
+
+section mvcgen
+open Std.Do
+set_option mvcgen.warning false
+
+/-- Generic theorem - shouldn't be used much -/
+theorem UScalar.add_mvcgen {ty} {x y : UScalar ty} {Q}
+  (hmax : UScalar.max ty < ↑x + ↑y → (Q.2.1 .integerOverflow).down)
+  (h : ∀ z : UScalar ty, (↑z : Nat) = ↑x + ↑y → (Q.1 z).down) :
+  ⦃ ⌜ True ⌝ ⦄ (x + y) ⦃ Q ⦄ := by
+  have h := @UScalar.add_equiv _ x y
+  split at h <;> try simp_all only [max] <;> (mvcgen; grind)
+
+/-- Generic theorem - shouldn't be used much -/
+theorem IScalar.add_mvcgen {ty} {x y : IScalar ty} {Q}
+  (hmin : ↑x + ↑y < IScalar.min ty → (Q.2.1 .integerOverflow).down)
+  (hmax : IScalar.max ty < ↑x + ↑y → (Q.2.1 .integerOverflow).down)
+  (h : ∀ z : IScalar ty, (↑z : Int) = ↑x + ↑y → (Q.1 z).down) :
+  ⦃ ⌜ True ⌝ ⦄ (x + y) ⦃ Q ⦄ := by
+  have h := @IScalar.add_equiv _ x y
+  split at h <;> try simp_all only [min, max] <;> (mvcgen; grind)
+
+uscalar @[spec] theorem «%S».add_mvcgen {Q} {x y : «%S»}
+  (hmax : «%S».max < x.val + y.val → (Q.2.1 .integerOverflow).down)
+  (h : ∀ z : «%S», (↑z : Nat) = ↑x + ↑y → (Q.1 z).down) :
+  ⦃ ⌜ True ⌝ ⦄ (x + y) ⦃ Q ⦄ :=
+  UScalar.add_mvcgen (by scalar_tac) (fun _ _ => h _ (by scalar_tac))
+
+iscalar @[spec] theorem «%S».add_mvcgen {Q} {x y : «%S»}
+  (hmin : ↑x + ↑y < «%S».min → (Q.2.1 .integerOverflow).down)
+  (hmax : «%S».max < ↑x + ↑y → (Q.2.1 .integerOverflow).down)
+  (h : ∀ z : «%S», (↑z : Int) = ↑x + ↑y → (Q.1 z).down) :
+  ⦃ ⌜ True ⌝ ⦄ (x + y) ⦃ Q ⦄ :=
+  IScalar.add_mvcgen (by scalar_tac) (by scalar_tac) (fun _ _ => h _ (by scalar_tac))
+
+end mvcgen
+
+section step
 
 /-- Generic theorem - shouldn't be used much -/
 @[step]
 theorem UScalar.add_spec {ty} {x y : UScalar ty}
   (hmax : ↑x + ↑y ≤ UScalar.max ty) :
-  x + y ⦃ z => (↑z : Nat) = ↑x + ↑y ⦄ := by
-  have h := @add_equiv ty x y
-  split at h <;> simp_all [max]
-  have : 0 < 2^ty.numBits := by simp
-  omega
+  x + y ⦃ z => (↑z : Nat) = ↑x + ↑y ⦄ :=
+  Result.spec_of_mvcgen (add_mvcgen (by omega) (by simp))
 
 /-- Generic theorem - shouldn't be used much -/
 @[step]
 theorem IScalar.add_spec {ty} {x y : IScalar ty}
   (hmin : IScalar.min ty ≤ ↑x + ↑y)
   (hmax : ↑x + ↑y ≤ IScalar.max ty) :
-  x + y ⦃ z => (↑z : Int) = ↑x + ↑y ⦄ := by
-  have h := @add_equiv ty x y
-  split at h <;> simp_all [min, max]
-  omega
+  x + y ⦃ z => (↑z : Int) = ↑x + ↑y ⦄ :=
+  Result.spec_of_mvcgen (add_mvcgen (by omega) (by omega) (by simp))
 
 uscalar @[step] theorem «%S».add_spec {x y : «%S»} (hmax : x.val + y.val ≤ «%S».max) :
   x + y ⦃ z => (↑z : Nat) = ↑x + ↑y ⦄ :=
@@ -137,5 +170,7 @@ iscalar @[step] theorem «%S».add_spec {x y : «%S»}
   (hmin : «%S».min ≤ ↑x + ↑y) (hmax : ↑x + ↑y ≤ «%S».max) :
   x + y ⦃ z => (↑z : Int) = ↑x + ↑y ⦄ :=
   IScalar.add_spec (by scalar_tac) (by scalar_tac)
+
+end step
 
 end Aeneas.Std

--- a/backends/lean/Aeneas/Std/Scalar/Ops/Mul.lean
+++ b/backends/lean/Aeneas/Std/Scalar/Ops/Mul.lean
@@ -42,8 +42,8 @@ Theorems with a specification which use integers and bit-vectors
 theorem UScalar.mul_equiv {ty} (x y : UScalar ty) :
   match mul x y with
   | ok z => x.val * y.val ≤ UScalar.max ty ∧ (↑z : Nat) = ↑x * ↑y ∧ z.bv = x.bv * y.bv
-  | fail _ => UScalar.max ty < x.val * y.val
-  | .div => False := by
+  | fail .integerOverflow => UScalar.max ty < x.val * y.val
+  | _ => False := by
   simp only [mul]
   have := tryMk_eq ty (x.val * y.val)
   split <;> simp_all only [inBounds, true_and, not_lt, gt_iff_lt]
@@ -72,8 +72,8 @@ theorem UScalar.mul_bv_spec {ty} {x y : UScalar ty}
 theorem IScalar.mul_equiv {ty} (x y : IScalar ty) :
   match mul x y with
   | ok z => IScalar.min ty ≤ x.val * y.val ∧ x.val * y.val ≤ IScalar.max ty ∧ z.val = x.val * y.val ∧ z.bv = x.bv * y.bv
-  | fail _ => ¬(IScalar.min ty ≤ x.val * y.val ∧ x.val * y.val ≤ IScalar.max ty)
-  | .div => False := by
+  | fail .integerOverflow => ¬(IScalar.min ty ≤ x.val * y.val ∧ x.val * y.val ≤ IScalar.max ty)
+  | _ => False := by
   simp only [mul, not_and, not_le]
   have := tryMk_eq ty (x.val * y.val)
   split <;> simp_all only [inBounds, min, max, true_and, not_and, not_lt] <;>
@@ -133,22 +133,61 @@ iscalar theorem «%S».mul_bv_spec {x y : «%S»}
 Theorems with a specification which only use integers
 -/
 
+section mvcgen
+open Std.Do
+set_option mvcgen.warning false
+
+/-- Generic theorem - shouldn't be used much -/
+theorem UScalar.mul_mvcgen {ty} {x y : UScalar ty} {Q}
+  (hmax : UScalar.max ty < ↑x * ↑y → (Q.2.1 .integerOverflow).down)
+  (h : ∀ z : UScalar ty, (↑z : Nat) = ↑x * ↑y → (Q.1 z).down) :
+  ⦃ ⌜ True ⌝ ⦄ (x * y) ⦃ Q ⦄ := by
+  have heq := @UScalar.mul_equiv _ x y
+  simp only [show UScalar.mul x y = x * y from rfl] at heq
+  split at heq <;> try simp_all only []
+    <;> (mvcgen; grind)
+
+/-- Generic theorem - shouldn't be used much -/
+theorem IScalar.mul_mvcgen {ty} {x y : IScalar ty} {Q}
+  (hmin : ↑x * ↑y < IScalar.min ty → (Q.2.1 .integerOverflow).down)
+  (hmax : IScalar.max ty < ↑x * ↑y → (Q.2.1 .integerOverflow).down)
+  (h : ∀ z : IScalar ty, (↑z : Int) = ↑x * ↑y → (Q.1 z).down) :
+  ⦃ ⌜ True ⌝ ⦄ (x * y) ⦃ Q ⦄ := by
+  have heq := @IScalar.mul_equiv _ x y
+  simp only [show IScalar.mul x y = x * y from rfl] at heq
+  split at heq
+    <;> try simp_all only [min, max]
+    <;> (mvcgen; grind)
+
+uscalar @[spec] theorem «%S».mul_mvcgen {Q} {x y : «%S»}
+  (hmax : «%S».max < x.val * y.val → (Q.2.1 .integerOverflow).down)
+  (h : ∀ z : «%S», (↑z : Nat) = ↑x * ↑y → (Q.1 z).down) :
+  ⦃ ⌜ True ⌝ ⦄ (x * y) ⦃ Q ⦄ :=
+  UScalar.mul_mvcgen (by scalar_tac) (fun _ _ => h _ (by scalar_tac))
+
+iscalar @[spec] theorem «%S».mul_mvcgen {Q} {x y : «%S»}
+  (hmin : ↑x * ↑y < «%S».min → (Q.2.1 .integerOverflow).down)
+  (hmax : «%S».max < ↑x * ↑y → (Q.2.1 .integerOverflow).down)
+  (h : ∀ z : «%S», (↑z : Int) = ↑x * ↑y → (Q.1 z).down) :
+  ⦃ ⌜ True ⌝ ⦄ (x * y) ⦃ Q ⦄ :=
+  IScalar.mul_mvcgen (by scalar_tac) (by scalar_tac) (fun _ _ => h _ (by scalar_tac))
+
+end mvcgen
+
+section step
+
 /-- Generic theorem - shouldn't be used much -/
 theorem UScalar.mul_spec {ty} {x y : UScalar ty}
   (hmax : ↑x * ↑y ≤ UScalar.max ty) :
-  x * y ⦃ z => (↑z : Nat) = ↑x * ↑y ⦄ := by
-  apply spec_mono
-  apply mul_bv_spec hmax
-  grind
+  x * y ⦃ z => (↑z : Nat) = ↑x * ↑y ⦄ :=
+  Result.spec_of_mvcgen (mul_mvcgen (by omega) (by simp))
 
 /-- Generic theorem - shouldn't be used much -/
 theorem IScalar.mul_spec {ty} {x y : IScalar ty}
   (hmin : IScalar.min ty ≤ ↑x * ↑y)
   (hmax : ↑x * ↑y ≤ IScalar.max ty) :
-  x * y ⦃ z => (↑z : Int) = ↑x * ↑y ⦄ := by
-  apply spec_mono
-  apply @mul_bv_spec ty x y (by scalar_tac) (by scalar_tac)
-  grind
+  x * y ⦃ z => (↑z : Int) = ↑x * ↑y ⦄ :=
+  Result.spec_of_mvcgen (mul_mvcgen (by omega) (by omega) (by simp))
 
 uscalar @[step] theorem «%S».mul_spec {x y : «%S»} (hmax : x.val * y.val ≤ «%S».max) :
   x * y ⦃ z => (↑z : Nat) = ↑x * ↑y ⦄ :=
@@ -158,5 +197,7 @@ iscalar @[step] theorem «%S».mul_spec {x y : «%S»}
   (hmin : «%S».min ≤ ↑x * ↑y) (hmax : ↑x * ↑y ≤ «%S».max) :
   (x * y) ⦃ z => (↑z : Int) = ↑x * ↑y ⦄ :=
   IScalar.mul_spec (by scalar_tac) (by scalar_tac)
+
+end step
 
 end Aeneas.Std

--- a/backends/lean/Aeneas/Std/Scalar/Ops/Sub.lean
+++ b/backends/lean/Aeneas/Std/Scalar/Ops/Sub.lean
@@ -42,8 +42,8 @@ theorem UScalar.sub_equiv {ty} (x y : UScalar ty) :
     y.val ≤ x.val ∧
     x.val = z.val + y.val ∧
     z.bv = x.bv - y.bv
-  | fail _ => x.val < y.val
-  | _ => ⊥ := by
+  | fail .integerOverflow => x.val < y.val
+  | _ => False := by
   have : x - y = sub x y := by rfl
   simp [this, sub]
   dcases h : x.val < y.val <;> simp [h]
@@ -86,8 +86,8 @@ theorem IScalar.sub_equiv {ty} (x y : IScalar ty) :
     IScalar.inBounds ty (x.val - y.val) ∧
     z.val = x.val - y.val ∧
     z.bv = x.bv - y.bv
-  | fail _ => ¬ (IScalar.inBounds ty (x.val - y.val))
-  | _ => ⊥ := by
+  | fail .integerOverflow => ¬ (IScalar.inBounds ty (x.val - y.val))
+  | _ => False := by
   have : x - y = sub x y := by rfl
   simp [this, sub]
   have h := tryMk_eq ty (↑x - ↑y)
@@ -132,24 +132,62 @@ iscalar theorem «%S».sub_bv_spec {x y : «%S»}
 Theorems with a specification which only uses integers
 -/
 
+section mvcgen
+open Std.Do
+set_option mvcgen.warning false
+
+-- TODO: derive `step` lemma from `spec` lemma?
+
+/- Generic theorem - shouldn't be used much -/
+theorem UScalar.sub_mvcgen {ty} {x y : UScalar ty} {Q}
+  (hlt : x.val < y.val → (Q.2.1 .integerOverflow).down)
+  (h : ∀ z : UScalar ty, (↑z : Nat) = ↑x - ↑y → (Q.1 z).down) :
+  ⦃ ⌜ True ⌝ ⦄ (x - y) ⦃ Q ⦄ := by
+  have heq := @UScalar.sub_equiv _ x y
+  split at heq <;> try simp_all only []
+    <;> (mvcgen; grind)
+
+/- Generic theorem - shouldn't be used much -/
+theorem IScalar.sub_mvcgen {ty} {x y : IScalar ty} {Q}
+  (hmin : ↑x - ↑y < IScalar.min ty → (Q.2.1 .integerOverflow).down)
+  (hmax : IScalar.max ty < ↑x - ↑y → (Q.2.1 .integerOverflow).down)
+  (h : ∀ z : IScalar ty, (↑z : Int) = ↑x - ↑y → (Q.1 z).down) :
+  ⦃ ⌜ True ⌝ ⦄ (x - y) ⦃ Q ⦄ := by
+  have heq := @IScalar.sub_equiv _ x y
+  split at heq <;> try simp_all only [min, max]
+    <;> (mvcgen; grind)
+
+uscalar @[spec] theorem «%S».sub_mvcgen {Q} {x y : «%S»}
+  (hlt : x.val < y.val → (Q.2.1 .integerOverflow).down)
+  (h : ∀ z : «%S», (↑z : Nat) = ↑x - ↑y → (Q.1 z).down) :
+  ⦃ ⌜ True ⌝ ⦄ (x - y) ⦃ Q ⦄ :=
+  UScalar.sub_mvcgen (by scalar_tac) (fun _ _ => h _ (by scalar_tac))
+
+iscalar @[spec] theorem «%S».sub_mvcgen {Q} {x y : «%S»}
+  (hmin : ↑x - ↑y < «%S».min → (Q.2.1 .integerOverflow).down)
+  (hmax : «%S».max < ↑x - ↑y → (Q.2.1 .integerOverflow).down)
+  (h : ∀ z : «%S», (↑z : Int) = ↑x - ↑y → (Q.1 z).down) :
+  ⦃ ⌜ True ⌝ ⦄ (x - y) ⦃ Q ⦄ :=
+  IScalar.sub_mvcgen (by scalar_tac) (by scalar_tac) (fun _ _ => h _ (by scalar_tac))
+
+end mvcgen
+
+section step
+
 /- Generic theorem - shouldn't be used much -/
 @[step]
 theorem UScalar.sub_spec {ty} {x y : UScalar ty}
   (h : y.val ≤ x.val) :
-  x - y ⦃ z => z.val = x.val - y.val ∧ y.val ≤ x.val ⦄ := by
-  have h := @sub_equiv ty x y
-  split at h <;> simp_all
-  omega
+  x - y ⦃ z => z.val = x.val - y.val ∧ y.val ≤ x.val ⦄ :=
+  Result.spec_of_mvcgen (sub_mvcgen (by omega) (fun z hz => ⟨hz, h⟩))
 
 /- Generic theorem - shouldn't be used much -/
 @[step]
 theorem IScalar.sub_spec {ty} {x y : IScalar ty}
   (hmin : IScalar.min ty ≤ ↑x - ↑y)
   (hmax : ↑x - ↑y ≤ IScalar.max ty) :
-  x - y ⦃ z => (↑z : Int) = ↑x - ↑y ⦄ := by
-  have h := @sub_equiv ty x y
-  split at h <;> simp_all [min, max]
-  omega
+  x - y ⦃ z => (↑z : Int) = ↑x - ↑y ⦄ :=
+  Result.spec_of_mvcgen (sub_mvcgen (by omega) (by omega) (by simp))
 
 uscalar @[step] theorem «%S».sub_spec {x y : «%S»} (h : y.val ≤ x.val) :
   x - y ⦃ z => z.val = x.val - y.val ∧ y.val ≤ x.val ⦄ :=
@@ -159,5 +197,7 @@ iscalar @[step] theorem «%S».sub_spec {x y : «%S»}
   (hmin : «%S».min ≤ ↑x - ↑y) (hmax : ↑x - ↑y ≤ «%S».max) :
   x - y ⦃ z => (↑z : Int) = ↑x - ↑y ⦄ :=
   IScalar.sub_spec (by scalar_tac) (by scalar_tac)
+
+end step
 
 end Aeneas.Std

--- a/backends/lean/Aeneas/Std/WP.lean
+++ b/backends/lean/Aeneas/Std/WP.lean
@@ -444,11 +444,13 @@ namespace Aeneas.Std.WP
 open Std Result
 open Std.Do
 
-instance Result.instWP : WP (Result) (.except Error .pure) where
-    wp
-        | .ok v => wp (pure v : Except Error _)
-        | .fail e => wp (throw e : Except Error _)
-        | .div => PredTrans.const ⌜False⌝
+instance Result.instWP : WP Result (.except Error (.except PUnit .pure)) where
+  wp x := {
+    apply Q := match x with | .ok a => Q.1 a | .fail e => Q.2.1 e | .div => Q.2.2.1 ()
+    conjunctive Q₁ Q₂ := by
+      apply SPred.bientails.of_eq
+      cases x <;> simp
+  }
 
 instance : LawfulMonad Result where
     map_const := by intros; rfl
@@ -461,19 +463,14 @@ instance : LawfulMonad Result where
     bind_map := by intros; rfl
     bind_assoc := by intros _ _ _ x _ _; cases x <;> rfl
 
-instance : WPMonad Result (.except Error .pure) where
-  wp_pure := by
-    intros
-    ext Q
-    simp [wp, PredTrans.pure, pure, Except.pure, Id.run]
-  wp_bind x f := by
-    simp only [Result.instWP]
-    ext Q
-    cases x <;> simp [PredTrans.const]
+instance Result.instWPMonad : WPMonad Result (.except Error (.except PUnit .pure)) where
+  wp_pure a := by ext; simp [wp]
+  wp_bind x f := by ext Q; cases x <;> simp [wp]
 
 theorem Result.of_wp {α} {x : Result α} (P : Result α → Prop) :
     (⊢ₛ wp⟦x⟧ post⟨fun a => ⌜P (.ok a)⌝,
-                  fun e => ⌜P (.fail e)⌝⟩) → P x := by
+                  fun e => ⌜P (.fail e)⌝,
+                  fun () => ⌜P .div⌝⟩) → P x := by
   intro hspec
   simp only [instWP] at hspec
   split at hspec <;> simp_all

--- a/backends/lean/Aeneas/Std/WP.lean
+++ b/backends/lean/Aeneas/Std/WP.lean
@@ -478,6 +478,23 @@ theorem Result.of_wp {α} {x : Result α} (P : Result α → Prop) :
 end Aeneas.Std.WP
 
 namespace Aeneas.Std
+open Std.Do
+set_option mvcgen.warning false
+
+@[spec]
+theorem Result.ok_mvcgen {α : Type} {v : α} {Q : PostCond α (.except Error (.except PUnit .pure))}
+    (h : (Q.1 v).down) : ⦃ ⌜ True ⌝ ⦄ Result.ok v ⦃ Q ⦄ := by mvcgen
+
+@[spec]
+theorem Result.fail_mvcgen {α : Type} {e} {Q : PostCond α (.except Error (.except PUnit .pure))}
+    (h : (Q.2.1 e).down) : ⦃ ⌜ True ⌝ ⦄ Result.fail e ⦃ Q ⦄ := by mvcgen
+
+theorem Result.spec_of_mvcgen {p : α → Prop} {f : Result α} (h : ⦃ ⌜ True ⌝ ⦄ f ⦃ ⇓ v => ⌜ p v ⌝ ⦄) :
+  f ⦃ v => p v ⦄ := by cases f <;> simp_all [Triple, wp]
+
+end Aeneas.Std
+
+namespace Aeneas.Std
 
 /-!
 # Loops


### PR DESCRIPTION
Based on my other PR #939, this PR adds mvcgen specs for addition, subtraction, and multiplication.

I'd like to add more `mvcgen` specs, but maybe we should discuss first whether this is the right way to go.

To state the specifications, I use an abstract postcondition `Q`, which allows me to define the specification in the most general way: for total correctness, partial correctness and everything in between. The Lean developer also use this style [here](https://github.com/leanprover/lean4/blob/714601baf118066cbf3f282361339c6d06665b2a/src/Std/Do/Triple/SpecLemmas.lean) (except that I use the unicode notation for triples).

For the preconditions, it's more convenient to state them as assumptions of the lemma (especially when there is more than one), and just use `⌜ True ⌝` as the Triple precondition. To `mvcgen`, this is equivalent. The Triple precondition is only relevant for stateful monads.

A further discussion point is whether we should mark the theorems as `spec` or maybe only `scoped spec` or maybe some custom attribute, so that users have the chance to provide their own `mvcgen` specs if they wish. A related point is that I eventually would like to have one set of specs for integer reasoning and one set of specs for bitvector reasoning. But maybe just using `spec` for the integer specs is okay to get started?