### PR TITLE
Update charon

### DIFF
--- a/charon-pin
+++ b/charon-pin
@@ -1,2 +1,2 @@
 # This is the commit from https://github.com/AeneasVerif/charon that should be used with this version of aeneas.
-319d43e4f6ee05290921ff9f74cebf5b58e4dd73
+fbd54169205bf97e3c42cbfef95ca5807d697bfb

--- a/flake.lock
+++ b/flake.lock
@@ -9,11 +9,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1776274269,
-        "narHash": "sha256-V/BWAdsBo+aaBIpzOreZaGpgqvFcWFcdnqviKHdsblY=",
+        "lastModified": 1776276343,
+        "narHash": "sha256-nf7FkqqdvhMQz0yyYywIJMfS+nrCdniZbiTxmrkea78=",
         "owner": "aeneasverif",
         "repo": "charon",
-        "rev": "319d43e4f6ee05290921ff9f74cebf5b58e4dd73",
+        "rev": "fbd54169205bf97e3c42cbfef95ca5807d697bfb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Companion to https://github.com/AeneasVerif/charon/pull/1098. This will fix building aeneas with nix under MacOS.