### PR TITLE
Fix duplicate phonetic pronunciations and typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Wall in Pompei, digital image from Michael Lahanis.
 
 # Aeneas
 
-Aeneas (pronunced [Eh-nee-as]) is a verification toolchain for Rust programs.  It relies on a translation from Rusts's MIR
+Aeneas (pronunced [Eh-nee-as]) is a verification toolchain for Rust programs.  It relies on a translation from Rust's MIR
 internal language to a pure lamdba calculus.  It is intended to be used in combination with
 [Charon](https://github.com/AeneasVerif/charon), which compiles Rust programs to an intermediate
 representation called LLBC. It currently has backends for [F\*](https://www.fstar-lang.org),

--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ Wall in Pompei, digital image from Michael Lahanis.
 </figcaption>
 </div></p>
 
-# Aeneas [Eh-nee-as]
+# Aeneas
 
-Aeneas (pronunced [Ay-nay-as]) is a verification toolchain for Rust programs.  It relies on a translation from Rusts's MIR
+Aeneas (pronunced [Eh-nee-as]) is a verification toolchain for Rust programs.  It relies on a translation from Rusts's MIR
 internal language to a pure lamdba calculus.  It is intended to be used in combination with
 [Charon](https://github.com/AeneasVerif/charon), which compiles Rust programs to an intermediate
 representation called LLBC. It currently has backends for [F\*](https://www.fstar-lang.org),


### PR DESCRIPTION
The duplicate phonetic pronounciations are a minor thing, but they're the first
thing you see in the README, so they seemed worth fixing.

While fixing that, I noticed a typo, so I fixed that too.
