### PR TITLE
fix: Skip builtin methods in trait impl struct literals

### DIFF
--- a/src/extract/Extract.ml
+++ b/src/extract/Extract.ml
@@ -3657,7 +3657,18 @@ let extract_trait_impl (ctx : extraction_ctx) (fmt : F.formatter)
     (* The methods *)
     List.iter
       (fun (name, bound_fn) ->
-        extract_trait_impl_method_items ctx fmt impl name bound_fn)
+        (* Skip methods whose function is a builtin: their def is not emitted,
+           so referencing them in the struct literal would create a dangling
+           self-reference.  The Lean library provides default field values for
+           these methods (e.g. PartialOrd.lt, Ord.max, PartialEq.ne). *)
+        let dominated_by_builtin =
+          let method_decl_id = bound_fn.binder_value.fun_id in
+          match A.FunDeclId.Map.find_opt method_decl_id ctx.trans_funs with
+          | Some trans -> Option.is_some trans.f.builtin_info
+          | None -> false
+        in
+        if not dominated_by_builtin then
+          extract_trait_impl_method_items ctx fmt impl name bound_fn)
       impl.methods;
 
     (* Close the outer boxes for the definition, as well as the brackets *)

--- a/tests/lean/Order.lean
+++ b/tests/lean/Order.lean
@@ -9,6 +9,9 @@ set_option linter.unusedVariables false
 /- You can set the `maxHeartbeats` value with the `-max-heartbeats` CLI option -/
 set_option maxHeartbeats 1000000
 
+/- You can remove the following line by using the CLI option `-all-computable`: -/
+noncomputable section
+
 namespace order
 
 /-- [order::compare]:
@@ -76,6 +79,11 @@ def Wrap.Insts.CoreCmpEq : core.cmp.Eq Wrap := {
     Wrap.Insts.CoreCmpEq.assert_receiver_is_total_eq
 }
 
+/-- [order::{core::cmp::PartialOrd<order::Wrap> for order::Wrap}::lt]:
+    Source: 'tests/src/order.rs', lines 21:24-21:34
+    Visibility: public -/
+axiom Wrap.Insts.CoreCmpPartialOrdWrap.lt : Wrap → Wrap → Result Bool
+
 /-- [order::{core::cmp::PartialOrd<order::Wrap> for order::Wrap}::partial_cmp]:
     Source: 'tests/src/order.rs', lines 21:24-21:34
     Visibility: public -/
@@ -89,6 +97,7 @@ def Wrap.Insts.CoreCmpPartialOrdWrap.partial_cmp
 def Wrap.Insts.CoreCmpPartialOrdWrap : core.cmp.PartialOrd Wrap Wrap := {
   partialEqInst := Wrap.Insts.CoreCmpPartialEqWrap
   partial_cmp := Wrap.Insts.CoreCmpPartialOrdWrap.partial_cmp
+  lt := Wrap.Insts.CoreCmpPartialOrdWrap.lt
 }
 
 /-- [order::{core::cmp::Ord for order::Wrap}::cmp]:
@@ -118,5 +127,11 @@ def wrap_partial_cmp (x : Wrap) (y : Wrap) : Result (Option Ordering) := do
     Visibility: public -/
 def wrap_cmp (x : Wrap) (y : Wrap) : Result Ordering := do
   Wrap.Insts.CoreCmpOrd.cmp x y
+
+/-- [order::wrap_lt]:
+    Source: 'tests/src/order.rs', lines 35:0-37:1
+    Visibility: public -/
+def wrap_lt (x : Wrap) (y : Wrap) : Result Bool := do
+  Wrap.Insts.CoreCmpPartialOrdWrap.lt x y
 
 end order

--- a/tests/src/order.rs
+++ b/tests/src/order.rs
@@ -28,3 +28,10 @@ pub fn wrap_partial_cmp(x: &Wrap, y: &Wrap) -> Option<Ordering> {
 pub fn wrap_cmp(x: &Wrap, y: &Wrap) -> Ordering {
     x.cmp(y)
 }
+
+/// Exercises the `lt` method of the derived PartialOrd.
+/// When Charon includes `lt` in the trait impl's method list, Aeneas must not
+/// emit a dangling self-reference in the struct literal.
+pub fn wrap_lt(x: Wrap, y: Wrap) -> bool {
+    x < y
+}


### PR DESCRIPTION
When a trait impl method is a builtin (e.g. PartialOrd::lt, Ord::max, PartialEq::ne), Aeneas does not emit a `def` for it — the Lean library provides the implementation. However, `extract_trait_impl` was still emitting a field reference to the non-existent def in the struct literal, creating a dangling self-reference that Lean cannot resolve.

Now, when iterating over `impl.methods`, we check whether the method's translated function has `builtin_info` set. If so, the field is omitted from the struct literal, relying on the default field values added in #940.

Also adds a `wrap_lt` test exercising derived PartialOrd `<` on a newtype.