### PR TITLE
feat: implement @[trait_default] + impl_def for Lean backend

### DIFF
--- a/backends/lean/Aeneas/Extract/Extract.lean
+++ b/backends/lean/Aeneas/Extract/Extract.lean
@@ -604,14 +604,15 @@ def processTraitDecl (declName : Name) (_pat : String) (info : TraitDecl) : Attr
     let userTypes := Std.HashMap.ofList (info.typesInfo.map (fun x => (x.extract, x)))
     let userMethods := Std.HashMap.ofList (info.methodsInfo.map (fun x => (x.extract, x)))
 
-    -- Go through all the fields
     let mut parentClauses := #[]
     let mut consts := #[]
     let mut types := #[]
     let mut methods := #[]
     let fields := structInfo.fieldNames.toList
+    let mut fieldRustNames : Std.HashSet String := ∅
     for field in fields do
       let rustField ← fieldNameToString false field
+      fieldRustNames := fieldRustNames.insert rustField
       if let some info := userParentClauses.get? rustField then
         parentClauses := parentClauses.push info
       else if let some info := userConsts.get? rustField then
@@ -622,6 +623,25 @@ def processTraitDecl (declName : Name) (_pat : String) (info : TraitDecl) : Attr
         methods := methods.push info
       else
         methods := methods.push ⟨ rustField, ← fieldNameToString true field ⟩
+
+    -- Add the user information which was not matched with a field
+    -- Parent clauses
+    for rustField in info.parentClauses do
+      if ¬ fieldRustNames.contains rustField then
+        parentClauses := parentClauses.push rustField
+    -- Constants
+    for info in info.constsInfo do
+      if ¬ fieldRustNames.contains info.extract then
+        consts := consts.push info
+    -- Types
+    for info in info.typesInfo do
+      if ¬ fieldRustNames.contains info.extract then
+        types := types.push info
+    -- Methods
+    for info in info.methodsInfo do
+      if ¬ fieldRustNames.contains info.extract then
+        methods := methods.push info
+
     pure { info with parentClauses := parentClauses.toList,
                      constsInfo := consts.toList,
                      typesInfo := types.toList,

--- a/backends/lean/Aeneas/Std/Core/Cmp.lean
+++ b/backends/lean/Aeneas/Std/Core/Cmp.lean
@@ -1,27 +1,28 @@
 import Aeneas.Extract
 import Aeneas.Std.Primitives
+import Aeneas.Tactic.Elab.TraitDefault
 
 namespace Aeneas.Std
 
 open Result
 
-@[rust_trait "core::cmp::PartialEq"]
+@[rust_trait "core::cmp::PartialEq" (defaultMethods := ["ne"])]
 structure core.cmp.PartialEq (Self : Type) (Rhs : Type) where
   eq : Self → Rhs → Result Bool
   ne : Self → Rhs → Result Bool := fun self other => do ok (not (← eq self other))
 
-@[rust_trait "core::cmp::Eq" (parentClauses := ["partialEqInst"])]
+@[rust_trait "core::cmp::Eq" (parentClauses := ["partialEqInst"]) (defaultMethods := ["assert_receiver_is_total_eq"])]
 structure core.cmp.Eq (Self : Type) where
   partialEqInst : core.cmp.PartialEq Self Self
   assert_receiver_is_total_eq (_ : Self) : Result Unit := .ok ()
 
-@[simp, rust_fun "core::cmp::Eq::assert_receiver_is_total_eq"]
+@[simp, trait_default]
 def core.cmp.Eq.assert_receiver_is_total_eq.default
   {Self : Type} (EqInst : core.cmp.Eq Self) (x : Self) : Result Unit :=
   EqInst.assert_receiver_is_total_eq x
 
 /- Default method -/
-@[rust_fun "core::cmp::PartialEq::ne"]
+@[trait_default]
 def core.cmp.PartialEq.ne.default {Self Rhs : Type} (eq : Self → Rhs → Result Bool)
   (self : Self) (other : Rhs) : Result Bool := do
   ok (¬ (← eq self other))
@@ -57,7 +58,7 @@ def core.cmp.PartialOrd.ge_body {Self Rhs : Type}
   let cmp ← partial_cmp x y
   ok (cmp = some .gt ∨ cmp = some .eq)
 
-@[rust_trait "core::cmp::PartialOrd" (parentClauses := ["partialEqInst"])]
+@[rust_trait "core::cmp::PartialOrd" (parentClauses := ["partialEqInst"]) (defaultMethods := ["lt", "le", "gt", "ge"])]
 structure core.cmp.PartialOrd (Self : Type) (Rhs : Type) where
   partialEqInst : core.cmp.PartialEq Self Rhs
   partial_cmp : Self → Rhs → Result (Option Ordering)
@@ -67,28 +68,28 @@ structure core.cmp.PartialOrd (Self : Type) (Rhs : Type) where
   ge : Self → Rhs → Result Bool := core.cmp.PartialOrd.ge_body partial_cmp
 
 /- Default method -/
-@[rust_fun "core::cmp::PartialOrd::lt"]
+@[trait_default]
 def core.cmp.PartialOrd.lt.default {Self Rhs : Type}
   (partial_cmp : Self → Rhs → Result (Option Ordering))
   (x : Self) (y : Rhs) : Result Bool :=
   core.cmp.PartialOrd.lt_body partial_cmp x y
 
 /- Default method -/
-@[rust_fun "core::cmp::PartialOrd::le"]
+@[trait_default]
 def core.cmp.PartialOrd.le.default {Self Rhs : Type}
   (partial_cmp : Self → Rhs → Result (Option Ordering))
   (x : Self) (y : Rhs) : Result Bool :=
   core.cmp.PartialOrd.le_body partial_cmp x y
 
 /- Default method -/
-@[rust_fun "core::cmp::PartialOrd::gt"]
+@[trait_default]
 def core.cmp.PartialOrd.gt.default {Self Rhs : Type}
   (partial_cmp : Self → Rhs → Result (Option Ordering))
   (x : Self) (y : Rhs) : Result Bool :=
   core.cmp.PartialOrd.gt_body partial_cmp x y
 
 /- Default method -/
-@[rust_fun "core::cmp::PartialOrd::ge"]
+@[trait_default]
 def core.cmp.PartialOrd.ge.default {Self Rhs : Type}
   (partial_cmp : Self → Rhs → Result (Option Ordering))
   (x : Self) (y : Rhs) : Result Bool :=
@@ -110,7 +111,7 @@ def core.cmp.Ord.clamp_body {Self : Type} (le lt gt : Self → Self → Result B
   else if ← gt self max then ok max
   else ok self
 
-@[rust_trait "core::cmp::Ord" (parentClauses := ["eqInst", "partialOrdInst"])]
+@[rust_trait "core::cmp::Ord" (parentClauses := ["eqInst", "partialOrdInst"]) (defaultMethods := ["max", "min", "clamp"])]
 structure core.cmp.Ord (Self : Type) where
   eqInst : core.cmp.Eq Self
   partialOrdInst : core.cmp.PartialOrd Self Self
@@ -123,19 +124,19 @@ structure core.cmp.Ord (Self : Type) where
     core.cmp.Ord.clamp_body partialOrdInst.le partialOrdInst.lt partialOrdInst.gt
 
 /- Default method -/
-@[rust_fun "core::cmp::Ord::max"]
+@[trait_default]
 def core.cmp.Ord.max.default {Self : Type} (lt : Self → Self → Result Bool)
   (x y : Self) : Result Self :=
   core.cmp.Ord.max_body lt x y
 
 /- Default method -/
-@[rust_fun "core::cmp::Ord::min"]
+@[trait_default]
 def core.cmp.Ord.min.default {Self : Type} (lt : Self → Self → Result Bool)
   (x y : Self) : Result Self :=
   core.cmp.Ord.min_body lt x y
 
 /- Default method -/
-@[rust_fun "core::cmp::Ord::clamp"]
+@[trait_default]
 def core.cmp.Ord.clamp.default {Self : Type} (le lt gt : Self → Self → Result Bool)
   (self min max : Self) : Result Self :=
   core.cmp.Ord.clamp_body le lt gt self min max

--- a/backends/lean/Aeneas/Std/Core/Core.lean
+++ b/backends/lean/Aeneas/Std/Core/Core.lean
@@ -28,7 +28,7 @@ structure clone.Clone (Self : Type) where
   clone_from : Self → Self → Result Self := fun _ => clone
 
 @[trait_default]
-def clone.Clone.from_from.default {Self : Type} (clone : Self → Result Self)
+def clone.Clone.clone_from.default {Self : Type} (clone : Self → Result Self)
   (_self source : Self) : Result Self :=
   clone source
 

--- a/backends/lean/Aeneas/Std/Core/Core.lean
+++ b/backends/lean/Aeneas/Std/Core/Core.lean
@@ -2,6 +2,7 @@ import Lean
 import Aeneas.Std.Primitives
 import Aeneas.Tactic.Step.Init
 import Aeneas.Std.Alloc
+import Aeneas.Tactic.Elab.TraitDefault
 
 namespace Aeneas
 
@@ -26,6 +27,7 @@ structure clone.Clone (Self : Type) where
   clone : Self → Result Self
   clone_from : Self → Self → Result Self := fun _ => clone
 
+@[trait_default]
 def clone.Clone.from_from.default {Self : Type} (clone : Self → Result Self)
   (_self source : Self) : Result Self :=
   clone source

--- a/backends/lean/Aeneas/Std/Core/Iter.lean
+++ b/backends/lean/Aeneas/Std/Core/Iter.lean
@@ -55,6 +55,14 @@ def core.iter.traits.iterator.Iterator.step_by.default
   if step_by.val = 0 then .fail .panic
   else .ok ⟨ self, step_by ⟩
 
+/- `methods := ["collect"]` registers `collect` in the trait's metadata even
+   though it is *not* a field of the structure. Making `collect` an actual
+   field would force a circular dependency between `Iterator` and
+   `FromIterator` (since `collect.default` calls `from_iter` via the
+   `IntoIterator` blanket impl), so the field is omitted and the library
+   default `core.iter.traits.iterator.Iterator.collect.default` (defined
+   below, attributed `@[trait_default]`) is supplied directly to opaque
+   `collect` impls during extraction. -/
 @[rust_trait "core::iter::traits::iterator::Iterator"
   (methods := ["collect"])
   (defaultMethods := ["step_by", "enumerate", "take", "collect"])]

--- a/backends/lean/Aeneas/Std/Core/Iter.lean
+++ b/backends/lean/Aeneas/Std/Core/Iter.lean
@@ -7,6 +7,7 @@ import Aeneas.Std.Scalar.CloneCopy
 import Aeneas.Std.Scalar.EqOrd
 import Aeneas.Std.Scalar.CheckedOps
 import Aeneas.Std.Core.Core
+import Aeneas.Tactic.Elab.TraitDefault
 
 namespace Aeneas.Std
 
@@ -47,22 +48,25 @@ structure core.iter.adapters.take.Take (I : Type u) where
 structure core.iter.adapters.rev.Rev (T : Type u) where
   iter : T
 
-@[rust_trait "core::iter::traits::iterator::Iterator"]
-structure core.iter.traits.iterator.Iterator (Self : Type) (Self_Item : Type)
-  where
-  next : Self → Result ((Option Self_Item) × Self)
-  step_by : Self → Usize → Result (core.iter.adapters.step_by.StepBy Self)
-  enumerate : Self → Result (core.iter.adapters.enumerate.Enumerate Self)
-  take : Self → Usize → Result (core.iter.adapters.take.Take Self)
-  -- rev : Self → Result (core.iter.adapters.rev.Rev Self) -- requires DoubleEndedIterator, leading to circularity
-  -- TODO: collect
-
-@[rust_fun "core::iter::traits::iterator::Iterator::step_by"]
+@[trait_default]
 def core.iter.traits.iterator.Iterator.step_by.default
   {Self : Type} (self: Self) (step_by : Std.Usize) :
   Result (core.iter.adapters.step_by.StepBy Self) :=
   if step_by.val = 0 then .fail .panic
   else .ok ⟨ self, step_by ⟩
+
+@[rust_trait "core::iter::traits::iterator::Iterator"
+  (methods := ["collect"])
+  (defaultMethods := ["step_by", "enumerate", "take", "collect"])]
+structure core.iter.traits.iterator.Iterator (Self : Type) (Self_Item : Type)
+  where
+  next : Self → Result ((Option Self_Item) × Self)
+  step_by : Self → Usize → Result (core.iter.adapters.step_by.StepBy Self) :=
+    core.iter.traits.iterator.Iterator.step_by.default
+  enumerate : Self → Result (core.iter.adapters.enumerate.Enumerate Self) :=
+    fun self => .ok { iter := self, count := 0#usize }
+  take : Self → Usize → Result (core.iter.adapters.take.Take Self) :=
+    fun self n => .ok { iter := self, n := n }
 
 /-- Skip up to `n` elements from an iterator -/
 def core.iter.adapters.step_by.skipN
@@ -169,7 +173,7 @@ def core.iter.traits.collect.IntoIterator.Blanket {I : Type} {Item : Type}
   into_iter := core.iter.traits.collect.IntoIterator.Blanket.into_iter IteratorInst
 }
 
-@[rust_fun "core::iter::traits::iterator::Iterator::collect"]
+@[trait_default]
 def core.iter.traits.iterator.Iterator.collect.default
   {Self : Type} {B : Type} {Item : Type} (IteratorInst :
   core.iter.traits.iterator.Iterator Self Item)

--- a/src/Translate.ml
+++ b/src/Translate.ml
@@ -1005,6 +1005,49 @@ let trait_impl_is_builtin (ctx : gen_ctx) (id : Pure.trait_impl_id) : bool =
   in
   Option.is_some builtin_info
 
+(** Lean only: check whether a [pure_fun_translation] is an opaque trait impl
+    method whose Lean library counterpart already provides a default body.
+
+    When this holds we must not emit any code for the method:
+    - emitting an axiom would shadow the library default;
+    - emitting a definition is impossible since the LLBC body is missing;
+    - referencing it from the trait impl struct literal would create a dangling
+      self-reference.
+
+    The trait declaration is looked up first in the translated trait decls and,
+    if absent (external trait), in the builtin trait decls map. *)
+let trait_impl_method_has_lean_library_default (ctx : gen_ctx)
+    (pure_fun : pure_fun_translation) : bool =
+  Config.backend () = Lean
+  && pure_fun.f.body = None
+  &&
+  match pure_fun.f.Pure.src with
+  | TraitImplItem (_, trait_decl_ref, item_name, _) -> (
+      let builtin_info =
+        match
+          TraitDeclId.Map.find_opt trait_decl_ref.id ctx.trans_trait_decls
+        with
+        | Some trait_decl -> trait_decl.builtin_info
+        | None ->
+            (* External trait: not in the pure declarations. Look up the
+               builtin trait decls map directly from the crate trait decls. *)
+            let trait_decl =
+              TraitDeclId.Map.find trait_decl_ref.id ctx.crate.trait_decls
+            in
+            let builtin_trait_decls =
+              ExtractBuiltin.builtin_trait_decls_map ()
+            in
+            match_name_find_opt ctx.trans_ctx trait_decl.item_meta.name
+              builtin_trait_decls
+      in
+      match builtin_info with
+      | None -> false
+      | Some info -> (
+          match List.find_opt (fun (m, _) -> m = item_name) info.methods with
+          | Some (_, fun_info) -> fun_info.has_default
+          | None -> false))
+  | _ -> false
+
 (** Export a trait declaration. *)
 let export_trait_decl (fmt : Format.formatter) (_config : gen_config)
     (ctx : gen_ctx) (trait_decl_id : Pure.trait_decl_id) (extract_decl : bool)
@@ -1074,55 +1117,9 @@ let extract_definitions (fmt : Format.formatter) (config : gen_config)
             | TraitDeclItem (_, _, false) -> ()
             (* Global initializers are translated along with the global definition *)
             | _ when pure_fun.f.is_global_decl_body -> ()
-            | TraitImplItem (_, trait_decl_ref, item_name, _)
-              when Config.backend () = Lean ->
-                (* Check if it's an opaque default method *)
-                let trait_decl =
-                  TraitDeclId.Map.find_opt trait_decl_ref.id
-                    ctx.trans_trait_decls
-                in
-                let is_opaque = pure_fun.f.body = None in
-                let has_library_default =
-                  match trait_decl with
-                  | Some trait_decl -> (
-                      match trait_decl.builtin_info with
-                      | None -> false
-                      | Some info -> (
-                          match
-                            List.find_opt
-                              (fun (m, _) -> m = item_name)
-                              info.methods
-                          with
-                          | Some (_, fun_info) -> fun_info.has_default
-                          | None -> false))
-                  | None -> (
-                      (* The trait declaration is not in the pure declarations:
-                         it must be an external trait. Check the builtin trait
-                         declarations. *)
-                      let trait_decl =
-                        TraitDeclId.Map.find trait_decl_ref.id
-                          ctx.crate.trait_decls
-                      in
-                      let builtin_trait_decls =
-                        ExtractBuiltin.builtin_trait_decls_map ()
-                      in
-                      let builtin_info =
-                        match_name_find_opt ctx.trans_ctx
-                          trait_decl.item_meta.name builtin_trait_decls
-                      in
-                      match builtin_info with
-                      | None -> false
-                      | Some info -> (
-                          match
-                            List.find_opt
-                              (fun (m, _) -> m = item_name)
-                              info.methods
-                          with
-                          | Some (_, fun_info) -> fun_info.has_default
-                          | None -> false))
-                in
-                if is_opaque && has_library_default then ()
-                else export_functions_group [ pure_fun ]
+            (* Skip opaque trait methods that have a Lean library default *)
+            | _ when trait_impl_method_has_lean_library_default ctx pure_fun ->
+                ()
             | _ ->
                 (* Translate *)
                 export_functions_group [ pure_fun ])
@@ -1135,61 +1132,13 @@ let extract_definitions (fmt : Format.formatter) (config : gen_config)
             (fun id -> FunDeclId.Map.find_opt id ctx.trans_funs)
             ids
         in
-        (* Special case for Lean: filter out opaque default methods *)
+        (* Filter out opaque trait methods that have a Lean library default *)
         let pure_funs =
-          if Config.backend () = Lean then
-            List.filter
-              (fun pure_fun ->
-                if pure_fun.f.is_global_decl_body then true
-                else
-                  match pure_fun.f.Pure.src with
-                  | TraitImplItem (_, trait_decl_ref, item_name, _) ->
-                      let trait_decl =
-                        TraitDeclId.Map.find_opt trait_decl_ref.id
-                          ctx.trans_trait_decls
-                      in
-                      let is_opaque = pure_fun.f.body = None in
-                      let has_library_default =
-                        match trait_decl with
-                        | Some trait_decl -> (
-                            match trait_decl.builtin_info with
-                            | None -> false
-                            | Some info -> (
-                                match
-                                  List.find_opt
-                                    (fun (m, _) -> m = item_name)
-                                    info.methods
-                                with
-                                | Some (_, fun_info) -> fun_info.has_default
-                                | None -> false))
-                        | None -> (
-                            (* External trait *)
-                            let trait_decl =
-                              TraitDeclId.Map.find trait_decl_ref.id
-                                ctx.crate.trait_decls
-                            in
-                            let builtin_trait_decls =
-                              ExtractBuiltin.builtin_trait_decls_map ()
-                            in
-                            let builtin_info =
-                              match_name_find_opt ctx.trans_ctx
-                                trait_decl.item_meta.name builtin_trait_decls
-                            in
-                            match builtin_info with
-                            | None -> false
-                            | Some info -> (
-                                match
-                                  List.find_opt
-                                    (fun (m, _) -> m = item_name)
-                                    info.methods
-                                with
-                                | Some (_, fun_info) -> fun_info.has_default
-                                | None -> false))
-                      in
-                      not (is_opaque && has_library_default)
-                  | _ -> true)
-              pure_funs
-          else pure_funs
+          List.filter
+            (fun pure_fun ->
+              pure_fun.f.is_global_decl_body
+              || not (trait_impl_method_has_lean_library_default ctx pure_fun))
+            pure_funs
         in
         if pure_funs = [] then ()
         else if List.exists (fun pf -> pf.f.is_global_decl_body) pure_funs then

--- a/src/Translate.ml
+++ b/src/Translate.ml
@@ -1074,6 +1074,55 @@ let extract_definitions (fmt : Format.formatter) (config : gen_config)
             | TraitDeclItem (_, _, false) -> ()
             (* Global initializers are translated along with the global definition *)
             | _ when pure_fun.f.is_global_decl_body -> ()
+            | TraitImplItem (_, trait_decl_ref, item_name, _)
+              when Config.backend () = Lean ->
+                (* Check if it's an opaque default method *)
+                let trait_decl =
+                  TraitDeclId.Map.find_opt trait_decl_ref.id
+                    ctx.trans_trait_decls
+                in
+                let is_opaque = pure_fun.f.body = None in
+                let has_library_default =
+                  match trait_decl with
+                  | Some trait_decl -> (
+                      match trait_decl.builtin_info with
+                      | None -> false
+                      | Some info -> (
+                          match
+                            List.find_opt
+                              (fun (m, _) -> m = item_name)
+                              info.methods
+                          with
+                          | Some (_, fun_info) -> fun_info.has_default
+                          | None -> false))
+                  | None -> (
+                      (* The trait declaration is not in the pure declarations:
+                         it must be an external trait. Check the builtin trait
+                         declarations. *)
+                      let trait_decl =
+                        TraitDeclId.Map.find trait_decl_ref.id
+                          ctx.crate.trait_decls
+                      in
+                      let builtin_trait_decls =
+                        ExtractBuiltin.builtin_trait_decls_map ()
+                      in
+                      let builtin_info =
+                        match_name_find_opt ctx.trans_ctx
+                          trait_decl.item_meta.name builtin_trait_decls
+                      in
+                      match builtin_info with
+                      | None -> false
+                      | Some info -> (
+                          match
+                            List.find_opt
+                              (fun (m, _) -> m = item_name)
+                              info.methods
+                          with
+                          | Some (_, fun_info) -> fun_info.has_default
+                          | None -> false))
+                in
+                if is_opaque && has_library_default then ()
+                else export_functions_group [ pure_fun ]
             | _ ->
                 (* Translate *)
                 export_functions_group [ pure_fun ])
@@ -1086,7 +1135,64 @@ let extract_definitions (fmt : Format.formatter) (config : gen_config)
             (fun id -> FunDeclId.Map.find_opt id ctx.trans_funs)
             ids
         in
-        if List.exists (fun pf -> pf.f.is_global_decl_body) pure_funs then
+        (* Special case for Lean: filter out opaque default methods *)
+        let pure_funs =
+          if Config.backend () = Lean then
+            List.filter
+              (fun pure_fun ->
+                if pure_fun.f.is_global_decl_body then true
+                else
+                  match pure_fun.f.Pure.src with
+                  | TraitImplItem (_, trait_decl_ref, item_name, _) ->
+                      let trait_decl =
+                        TraitDeclId.Map.find_opt trait_decl_ref.id
+                          ctx.trans_trait_decls
+                      in
+                      let is_opaque = pure_fun.f.body = None in
+                      let has_library_default =
+                        match trait_decl with
+                        | Some trait_decl -> (
+                            match trait_decl.builtin_info with
+                            | None -> false
+                            | Some info -> (
+                                match
+                                  List.find_opt
+                                    (fun (m, _) -> m = item_name)
+                                    info.methods
+                                with
+                                | Some (_, fun_info) -> fun_info.has_default
+                                | None -> false))
+                        | None -> (
+                            (* External trait *)
+                            let trait_decl =
+                              TraitDeclId.Map.find trait_decl_ref.id
+                                ctx.crate.trait_decls
+                            in
+                            let builtin_trait_decls =
+                              ExtractBuiltin.builtin_trait_decls_map ()
+                            in
+                            let builtin_info =
+                              match_name_find_opt ctx.trans_ctx
+                                trait_decl.item_meta.name builtin_trait_decls
+                            in
+                            match builtin_info with
+                            | None -> false
+                            | Some info -> (
+                                match
+                                  List.find_opt
+                                    (fun (m, _) -> m = item_name)
+                                    info.methods
+                                with
+                                | Some (_, fun_info) -> fun_info.has_default
+                                | None -> false))
+                      in
+                      not (is_opaque && has_library_default)
+                  | _ -> true)
+              pure_funs
+          else pure_funs
+        in
+        if pure_funs = [] then ()
+        else if List.exists (fun pf -> pf.f.is_global_decl_body) pure_funs then
           [%craise_opt_span] None "Mutually recursive globals are not supported"
         else (* Translate *)
           export_functions_group pure_funs

--- a/src/extract/Extract.ml
+++ b/src/extract/Extract.ml
@@ -3499,8 +3499,11 @@ let extract_trait_impl (ctx : extraction_ctx) (fmt : F.formatter)
   (* `let (....) : Trait ... =` *)
   (* Open the box for the name + generics *)
   F.pp_open_hovbox fmt ctx.indent_incr;
-  (* Lean only: we have a special elaboration if the impl is recursive *)
-  (if is_rec then (
+  (* Lean only: we have a special elaboration for trait implementations *)
+  (if backend () = Lean then (
+     F.pp_print_string fmt "impl_def";
+     F.pp_print_space fmt ())
+   else if is_rec then (
      F.pp_print_string fmt "impl_def";
      F.pp_print_space fmt ())
    else
@@ -3517,23 +3520,26 @@ let extract_trait_impl (ctx : extraction_ctx) (fmt : F.formatter)
   (* First, reserve the trait decl field names (constants, types, methods, parent
      clauses) so that generic parameter names are made fresh w.r.t. them.
      See the comment in {!extract_trait_decl}. *)
+  let pure_trait_decl =
+    let decl_id = impl.impl_trait.trait_decl_id in
+    TraitDeclId.Map.find decl_id ctx.trans_trait_decls
+  in
   let ctx =
     let decl_id = impl.impl_trait.trait_decl_id in
-    let trait_decl = TraitDeclId.Map.find decl_id ctx.trans_trait_decls in
     let field_names =
       List.map
         (fun (name, _) -> ctx_get_trait_const span decl_id name ctx)
-        trait_decl.consts
+        pure_trait_decl.consts
       @ List.map
           (fun name -> ctx_get_trait_type span decl_id name ctx)
-          trait_decl.types
+          pure_trait_decl.types
       @ List.map
           (fun (name, _) -> ctx_get_trait_method span decl_id name ctx)
-          trait_decl.methods
+          pure_trait_decl.methods
       @ List.map
           (fun (clause : trait_param) ->
             ctx_get_trait_parent_clause span decl_id clause.clause_id ctx)
-          trait_decl.parent_clauses
+          pure_trait_decl.parent_clauses
     in
     ctx_reserve_names field_names ctx
   in
@@ -3657,7 +3663,40 @@ let extract_trait_impl (ctx : extraction_ctx) (fmt : F.formatter)
     (* The methods *)
     List.iter
       (fun (name, bound_fn) ->
-        extract_trait_impl_method_items ctx fmt impl name bound_fn)
+        let method_decl_id = bound_fn.binder_value.fun_id in
+        let trans_fun =
+          A.FunDeclId.Map.find_opt method_decl_id ctx.trans_funs
+        in
+        (* Skip methods whose function is a builtin: their def is not emitted,
+           so referencing them in the struct literal would create a dangling
+           self-reference. *)
+        let is_builtin =
+          match trans_fun with
+          | Some trans -> Option.is_some trans.f.builtin_info
+          | None -> false
+        in
+        (* We also skip methods that have a library default if they are opaque
+           (i.e., they have no body).
+           The Lean library provides default field values for these methods
+           (e.g. PartialOrd.lt, Ord.max, PartialEq.ne). *)
+        let has_library_default =
+          match pure_trait_decl.builtin_info with
+          | None -> false
+          | Some info -> (
+              match List.find_opt (fun (m, _) -> m = name) info.methods with
+              | Some (_, fun_info) -> fun_info.has_default
+              | None -> false)
+        in
+        let is_opaque =
+          match trans_fun with
+          | Some trans -> trans.f.body = None
+          | None -> true
+        in
+        let skip =
+          is_builtin || (backend () = Lean && has_library_default && is_opaque)
+        in
+        if not skip then
+          extract_trait_impl_method_items ctx fmt impl name bound_fn)
       impl.methods;
 
     (* Close the outer boxes for the definition, as well as the brackets *)

--- a/src/extract/ExtractBuiltinLean.ml
+++ b/src/extract/ExtractBuiltinLean.ml
@@ -17,7 +17,7 @@ let lean_builtin_types =
       ~kind:(KStruct [ ("size", Some "size"); ("align", Some "align") ]);
     (* file: "Aeneas/Std/Array/ArraySlice.lean", line: 115 *)
     mk_type "core::array::TryFromSliceError" "core.array.TryFromSliceError";
-    (* file: "Aeneas/Std/Core/Cmp.lean", line: 31 *)
+    (* file: "Aeneas/Std/Core/Cmp.lean", line: 32 *)
     mk_type "core::cmp::Ordering" "Ordering"
       ~kind:
         (KEnum
@@ -33,20 +33,20 @@ let lean_builtin_types =
     mk_type "core::fmt::Formatter" "core.fmt.Formatter";
     (* file: "Aeneas/Std/Core/Fmt.lean", line: 38 *)
     mk_type "core::fmt::rt::Argument" "core.fmt.rt.Argument";
-    (* file: "Aeneas/Std/Core/Iter.lean", line: 36 *)
+    (* file: "Aeneas/Std/Core/Iter.lean", line: 37 *)
     mk_type "core::iter::adapters::enumerate::Enumerate"
       "core.iter.adapters.enumerate.Enumerate"
       ~kind:(KStruct [ ("iter", Some "iter"); ("count", Some "count") ]);
-    (* file: "Aeneas/Std/Core/Iter.lean", line: 276 *)
+    (* file: "Aeneas/Std/Core/Iter.lean", line: 280 *)
     mk_type "core::iter::adapters::map::Map" "core.iter.adapters.map.Map"
       ~kind:(KStruct [ ("iter", Some "iter"); ("f", Some "f") ]);
-    (* file: "Aeneas/Std/Core/Iter.lean", line: 46 *)
+    (* file: "Aeneas/Std/Core/Iter.lean", line: 47 *)
     mk_type "core::iter::adapters::rev::Rev" "core.iter.adapters.rev.Rev"
       ~kind:(KStruct [ ("iter", Some "iter") ]);
-    (* file: "Aeneas/Std/Core/Iter.lean", line: 30 *)
+    (* file: "Aeneas/Std/Core/Iter.lean", line: 31 *)
     mk_type "core::iter::adapters::step_by::StepBy"
       "core.iter.adapters.step_by.StepBy";
-    (* file: "Aeneas/Std/Core/Iter.lean", line: 41 *)
+    (* file: "Aeneas/Std/Core/Iter.lean", line: 42 *)
     mk_type "core::iter::adapters::take::Take" "core.iter.adapters.take.Take"
       ~kind:(KStruct [ ("iter", Some "iter"); ("n", Some "n") ]);
     (* file: "Aeneas/Std/Core/Ops.lean", line: 83 *)
@@ -56,19 +56,19 @@ let lean_builtin_types =
     (* file: "Aeneas/Std/Range.lean", line: 14 *)
     mk_type "core::ops::range::Range" "core.ops.range.Range"
       ~kind:(KStruct [ ("start", Some "start"); ("end", Some "«end»") ]);
-    (* file: "Aeneas/Std/Core/Core.lean", line: 122 *)
+    (* file: "Aeneas/Std/Core/Core.lean", line: 124 *)
     mk_type "core::ops::range::RangeFrom" "core.ops.range.RangeFrom"
       ~kind:(KStruct [ ("start", Some "start") ]);
     (* file: "Aeneas/Std/Range.lean", line: 20 *)
     mk_type "core::ops::range::RangeTo" "core.ops.range.RangeTo"
       ~kind:(KStruct [ ("end", Some "«end»") ]);
-    (* file: "Aeneas/Std/Core/Core.lean", line: 12 *)
+    (* file: "Aeneas/Std/Core/Core.lean", line: 13 *)
     mk_type "core::option::Option" "Option" ~prefix_variant_names:false
       ~kind:(KEnum [ ("None", Some "none"); ("Some", Some "some") ]);
     (* file: "Aeneas/Std/Core/Panic.lean", line: 6 *)
     mk_type "core::panic::panic_info::PanicInfo"
       "core.panic.panic_info.PanicInfo";
-    (* file: "Aeneas/Std/Core/Core.lean", line: 126 *)
+    (* file: "Aeneas/Std/Core/Core.lean", line: 128 *)
     mk_type "core::panicking::AssertKind" "core.panicking.AssertKind"
       ~kind:
         (KEnum [ ("Eq", Some "Eq"); ("Ne", Some "Ne"); ("Match", Some "Match") ]);
@@ -175,16 +175,16 @@ let lean_builtin_funs =
     (* file: "Aeneas/Std/Alloc.lean", line: 25 *)
     mk_fun "alloc::alloc::{core::clone::Clone<alloc::alloc::Global>}::clone"
       "alloc.alloc.CloneGlobal.clone";
-    (* file: "Aeneas/Std/Core/Core.lean", line: 48 *)
+    (* file: "Aeneas/Std/Core/Core.lean", line: 50 *)
     mk_fun "alloc::boxed::{core::clone::Clone<Box<@T>>}::clone"
       "core.alloc.boxed.CloneBox.clone"
       ~keep_params:(Some [ true; false ])
       ~keep_trait_clauses:(Some [ true; false ]);
-    (* file: "Aeneas/Std/Core/Cmp.lean", line: 161 *)
+    (* file: "Aeneas/Std/Core/Cmp.lean", line: 199 *)
     mk_fun "alloc::boxed::{core::cmp::PartialEq<Box<@T>, Box<@T>>}::eq"
       "alloc.boxed.PartialEqBox.eq"
       ~keep_params:(Some [ true; false ]);
-    (* file: "Aeneas/Std/Core/Core.lean", line: 14 *)
+    (* file: "Aeneas/Std/Core/Core.lean", line: 15 *)
     mk_fun "alloc::boxed::{core::convert::AsMut<Box<@T>, @T>}::as_mut"
       "alloc.boxed.AsMutBox.as_mut"
       ~keep_params:(Some [ true; false ])
@@ -379,52 +379,33 @@ let lean_builtin_funs =
     mk_fun
       "core::array::{core::ops::index::IndexMut<[@T; @N], @I, @O>}::index_mut"
       "core.array.Array.index_mut";
-    (* file: "Aeneas/Std/Core/Core.lean", line: 132 *)
+    (* file: "Aeneas/Std/Core/Core.lean", line: 134 *)
     mk_fun "core::clone::impls::{core::clone::Clone<&'0 @T>}::clone"
       "core.clone.impls.CloneShared.clone";
-    (* file: "Aeneas/Std/Core/Cmp.lean", line: 18 *)
-    mk_fun "core::cmp::Eq::assert_receiver_is_total_eq"
-      "core.cmp.Eq.assert_receiver_is_total_eq.default";
-    (* file: "Aeneas/Std/Core/Cmp.lean", line: 98 *)
-    mk_fun "core::cmp::Ord::clamp" "core.cmp.Ord.clamp.default";
-    (* file: "Aeneas/Std/Core/Cmp.lean", line: 86 *)
-    mk_fun "core::cmp::Ord::max" "core.cmp.Ord.max.default";
-    (* file: "Aeneas/Std/Core/Cmp.lean", line: 92 *)
-    mk_fun "core::cmp::Ord::min" "core.cmp.Ord.min.default";
-    (* file: "Aeneas/Std/Core/Cmp.lean", line: 24 *)
-    mk_fun "core::cmp::PartialEq::ne" "core.cmp.PartialEq.ne.default";
-    (* file: "Aeneas/Std/Core/Cmp.lean", line: 69 *)
-    mk_fun "core::cmp::PartialOrd::ge" "core.cmp.PartialOrd.ge.default";
-    (* file: "Aeneas/Std/Core/Cmp.lean", line: 61 *)
-    mk_fun "core::cmp::PartialOrd::gt" "core.cmp.PartialOrd.gt.default";
-    (* file: "Aeneas/Std/Core/Cmp.lean", line: 53 *)
-    mk_fun "core::cmp::PartialOrd::le" "core.cmp.PartialOrd.le.default";
-    (* file: "Aeneas/Std/Core/Cmp.lean", line: 45 *)
-    mk_fun "core::cmp::PartialOrd::lt" "core.cmp.PartialOrd.lt.default";
-    (* file: "Aeneas/Std/Core/Cmp.lean", line: 132 *)
+    (* file: "Aeneas/Std/Core/Cmp.lean", line: 170 *)
     mk_fun "core::cmp::impls::{core::cmp::Ord<()>}::cmp"
       "core.cmp.impls.OrdUnit.cmp";
-    (* file: "Aeneas/Std/Core/Cmp.lean", line: 144 *)
+    (* file: "Aeneas/Std/Core/Cmp.lean", line: 182 *)
     mk_fun "core::cmp::impls::{core::cmp::PartialEq<&'a @A, &'b @B>}::eq"
       "core.cmp.impls.PartialEqShared.eq";
-    (* file: "Aeneas/Std/Core/Cmp.lean", line: 149 *)
+    (* file: "Aeneas/Std/Core/Cmp.lean", line: 187 *)
     mk_fun "core::cmp::impls::{core::cmp::PartialEq<&'a @A, &'b @B>}::ne"
       "core.cmp.impls.PartialEqShared.ne";
-    (* file: "Aeneas/Std/Core/Cmp.lean", line: 116 *)
+    (* file: "Aeneas/Std/Core/Cmp.lean", line: 154 *)
     mk_fun "core::cmp::impls::{core::cmp::PartialEq<(), ()>}::eq"
       "core.cmp.impls.PartialEqUnit.eq";
-    (* file: "Aeneas/Std/Core/Cmp.lean", line: 119 *)
+    (* file: "Aeneas/Std/Core/Cmp.lean", line: 157 *)
     mk_fun "core::cmp::impls::{core::cmp::PartialEq<(), ()>}::ne"
       "core.cmp.impls.PartialEqUnit.ne";
-    (* file: "Aeneas/Std/Core/Cmp.lean", line: 136 *)
+    (* file: "Aeneas/Std/Core/Cmp.lean", line: 174 *)
     mk_fun "core::cmp::impls::{core::cmp::PartialEq<bool, bool>}::eq"
       "core.cmp.impls.PartialEqBool.eq";
-    (* file: "Aeneas/Std/Core/Cmp.lean", line: 128 *)
+    (* file: "Aeneas/Std/Core/Cmp.lean", line: 166 *)
     mk_fun "core::cmp::impls::{core::cmp::PartialOrd<(), ()>}::partial_cmp"
       "core.cmp.impls.PartialOrdUnit.partial_cmp";
-    (* file: "Aeneas/Std/Core/Cmp.lean", line: 111 *)
+    (* file: "Aeneas/Std/Core/Cmp.lean", line: 149 *)
     mk_fun "core::cmp::max" "core.cmp.max";
-    (* file: "Aeneas/Std/Core/Cmp.lean", line: 106 *)
+    (* file: "Aeneas/Std/Core/Cmp.lean", line: 144 *)
     mk_fun "core::cmp::min" "core.cmp.min";
     (* file: "Aeneas/Std/Core/Convert.lean", line: 26 *)
     mk_fun "core::convert::{core::convert::From<@T, @T>}::from"
@@ -552,71 +533,65 @@ let lean_builtin_funs =
     (* file: "Aeneas/Std/Core/Discriminant.lean", line: 26 *)
     mk_fun "core::intrinsics::discriminant_value"
       "core.intrinsics.discriminant_value";
-    (* file: "Aeneas/Std/Core/Iter.lean", line: 105 *)
+    (* file: "Aeneas/Std/Core/Iter.lean", line: 109 *)
     mk_fun
       "core::iter::adapters::step_by::{core::iter::traits::iterator::Iterator<core::iter::adapters::step_by::StepBy<@I>, \
        @Clause0_Item>}::enumerate"
       "core.iter.adapters.step_by.IteratorStepBy.enumerate";
-    (* file: "Aeneas/Std/Core/Iter.lean", line: 79 *)
+    (* file: "Aeneas/Std/Core/Iter.lean", line: 83 *)
     mk_fun
       "core::iter::adapters::step_by::{core::iter::traits::iterator::Iterator<core::iter::adapters::step_by::StepBy<@I>, \
        @Clause0_Item>}::next"
       "core.iter.adapters.step_by.IteratorStepBy.next";
-    (* file: "Aeneas/Std/Core/Iter.lean", line: 94 *)
+    (* file: "Aeneas/Std/Core/Iter.lean", line: 98 *)
     mk_fun
       "core::iter::adapters::step_by::{core::iter::traits::iterator::Iterator<core::iter::adapters::step_by::StepBy<@I>, \
        @Clause0_Item>}::step_by"
       "core.iter.adapters.step_by.IteratorStepBy.step_by";
-    (* file: "Aeneas/Std/Core/Iter.lean", line: 114 *)
+    (* file: "Aeneas/Std/Core/Iter.lean", line: 118 *)
     mk_fun
       "core::iter::adapters::step_by::{core::iter::traits::iterator::Iterator<core::iter::adapters::step_by::StepBy<@I>, \
        @Clause0_Item>}::take"
       "core.iter.adapters.step_by.IteratorStepBy.take";
-    (* file: "Aeneas/Std/Core/Iter.lean", line: 212 *)
+    (* file: "Aeneas/Std/Core/Iter.lean", line: 216 *)
     mk_fun
       "core::iter::range::{core::iter::range::Step<usize>}::backward_checked"
       "core.iter.range.StepUsize.backward_checked";
-    (* file: "Aeneas/Std/Core/Iter.lean", line: 206 *)
+    (* file: "Aeneas/Std/Core/Iter.lean", line: 210 *)
     mk_fun
       "core::iter::range::{core::iter::range::Step<usize>}::forward_checked"
       "core.iter.range.StepUsize.forward_checked";
-    (* file: "Aeneas/Std/Core/Iter.lean", line: 197 *)
+    (* file: "Aeneas/Std/Core/Iter.lean", line: 201 *)
     mk_fun "core::iter::range::{core::iter::range::Step<usize>}::steps_between"
       "core.iter.range.StepUsize.steps_between";
-    (* file: "Aeneas/Std/Core/Iter.lean", line: 251 *)
+    (* file: "Aeneas/Std/Core/Iter.lean", line: 255 *)
     mk_fun
       "core::iter::range::{core::iter::traits::iterator::Iterator<core::ops::range::Range<@A>, \
        @A>}::enumerate"
       "core.iter.range.IteratorRange.enumerate";
-    (* file: "Aeneas/Std/Core/Iter.lean", line: 227 *)
+    (* file: "Aeneas/Std/Core/Iter.lean", line: 231 *)
     mk_fun
       "core::iter::range::{core::iter::traits::iterator::Iterator<core::ops::range::Range<@A>, \
        @A>}::next"
       "core.iter.range.IteratorRange.next";
-    (* file: "Aeneas/Std/Core/Iter.lean", line: 242 *)
+    (* file: "Aeneas/Std/Core/Iter.lean", line: 246 *)
     mk_fun
       "core::iter::range::{core::iter::traits::iterator::Iterator<core::ops::range::Range<@A>, \
        @A>}::step_by"
       "core.iter.range.IteratorRange.step_by";
-    (* file: "Aeneas/Std/Core/Iter.lean", line: 258 *)
+    (* file: "Aeneas/Std/Core/Iter.lean", line: 262 *)
     mk_fun
       "core::iter::range::{core::iter::traits::iterator::Iterator<core::ops::range::Range<@A>, \
        @A>}::take"
       "core.iter.range.IteratorRange.take";
-    (* file: "Aeneas/Std/Core/Iter.lean", line: 155 *)
+    (* file: "Aeneas/Std/Core/Iter.lean", line: 159 *)
     mk_fun
       "core::iter::traits::collect::{core::iter::traits::collect::IntoIterator<@I, \
        @Item, @I>}::into_iter"
       "core.iter.traits.collect.IntoIterator.Blanket.into_iter";
-    (* file: "Aeneas/Std/Core/Iter.lean", line: 172 *)
-    mk_fun "core::iter::traits::iterator::Iterator::collect"
-      "core.iter.traits.iterator.Iterator.collect.default";
-    (* file: "Aeneas/Std/Core/Iter.lean", line: 60 *)
-    mk_fun "core::iter::traits::iterator::Iterator::step_by"
-      "core.iter.traits.iterator.Iterator.step_by.default";
-    (* file: "Aeneas/Std/Core/Core.lean", line: 73 *)
+    (* file: "Aeneas/Std/Core/Core.lean", line: 75 *)
     mk_fun "core::mem::replace" "core.mem.replace" ~can_fail:false ~lift:false;
-    (* file: "Aeneas/Std/Core/Core.lean", line: 77 *)
+    (* file: "Aeneas/Std/Core/Core.lean", line: 79 *)
     mk_fun "core::mem::swap" "core.mem.swap" ~can_fail:false ~lift:false;
     (* file: "Aeneas/Std/Scalar/Pow.lean", line: 7 *)
     mk_fun "core::num::{usize}::is_power_of_two"
@@ -624,19 +599,19 @@ let lean_builtin_funs =
     (* file: "Aeneas/Std/Core/CoreOption.lean", line: 8 *)
     mk_fun "core::option::{core::option::Option<@T>}::expect"
       "core.option.Option.expect";
-    (* file: "Aeneas/Std/Core/Core.lean", line: 115 *)
+    (* file: "Aeneas/Std/Core/Core.lean", line: 117 *)
     mk_fun "core::option::{core::option::Option<@T>}::is_none"
       "core.option.Option.is_none" ~can_fail:false ~lift:false;
-    (* file: "Aeneas/Std/Core/Core.lean", line: 119 *)
+    (* file: "Aeneas/Std/Core/Core.lean", line: 121 *)
     mk_fun "core::option::{core::option::Option<@T>}::is_some"
       "core.option.Option.is_some" ~can_fail:false ~lift:false;
-    (* file: "Aeneas/Std/Core/Core.lean", line: 112 *)
+    (* file: "Aeneas/Std/Core/Core.lean", line: 114 *)
     mk_fun "core::option::{core::option::Option<@T>}::take"
       "core.option.Option.take" ~can_fail:false ~lift:false;
-    (* file: "Aeneas/Std/Core/Core.lean", line: 91 *)
+    (* file: "Aeneas/Std/Core/Core.lean", line: 93 *)
     mk_fun "core::option::{core::option::Option<@T>}::unwrap"
       "core.option.Option.unwrap";
-    (* file: "Aeneas/Std/Core/Core.lean", line: 100 *)
+    (* file: "Aeneas/Std/Core/Core.lean", line: 102 *)
     mk_fun "core::option::{core::option::Option<@T>}::unwrap_or"
       "core.option.Option.unwrap_or" ~can_fail:false;
     (* file: "Aeneas/Std/Core/Fmt.lean", line: 95 *)
@@ -865,24 +840,27 @@ let lean_builtin_trait_decls =
     mk_trait_decl "core::alloc::global::GlobalAlloc"
       "core.alloc.global.GlobalAlloc"
       ~methods:[ ("alloc", "alloc"); ("dealloc", "dealloc") ];
-    (* file: "Aeneas/Std/Core/Core.lean", line: 24 *)
+    (* file: "Aeneas/Std/Core/Core.lean", line: 25 *)
     mk_trait_decl "core::clone::Clone" "core.clone.Clone"
       ~methods:[ ("clone", "clone"); ("clone_from", "clone_from") ]
       ~default_methods:[ "clone_from" ];
-    (* file: "Aeneas/Std/Core/Cmp.lean", line: 13 *)
+    (* file: "Aeneas/Std/Core/Cmp.lean", line: 14 *)
     mk_trait_decl "core::cmp::Eq" "core.cmp.Eq"
       ~parent_clauses:[ "partialEqInst" ]
       ~methods:
-        [ ("assert_receiver_is_total_eq", "assert_receiver_is_total_eq") ];
-    (* file: "Aeneas/Std/Core/Cmp.lean", line: 76 *)
+        [ ("assert_receiver_is_total_eq", "assert_receiver_is_total_eq") ]
+      ~default_methods:[ "assert_receiver_is_total_eq" ];
+    (* file: "Aeneas/Std/Core/Cmp.lean", line: 114 *)
     mk_trait_decl "core::cmp::Ord" "core.cmp.Ord"
       ~parent_clauses:[ "eqInst"; "partialOrdInst" ]
       ~methods:
-        [ ("cmp", "cmp"); ("max", "max"); ("min", "min"); ("clamp", "clamp") ];
-    (* file: "Aeneas/Std/Core/Cmp.lean", line: 8 *)
+        [ ("cmp", "cmp"); ("max", "max"); ("min", "min"); ("clamp", "clamp") ]
+      ~default_methods:[ "max"; "min"; "clamp" ];
+    (* file: "Aeneas/Std/Core/Cmp.lean", line: 9 *)
     mk_trait_decl "core::cmp::PartialEq" "core.cmp.PartialEq"
-      ~methods:[ ("eq", "eq"); ("ne", "ne") ];
-    (* file: "Aeneas/Std/Core/Cmp.lean", line: 35 *)
+      ~methods:[ ("eq", "eq"); ("ne", "ne") ]
+      ~default_methods:[ "ne" ];
+    (* file: "Aeneas/Std/Core/Cmp.lean", line: 61 *)
     mk_trait_decl "core::cmp::PartialOrd" "core.cmp.PartialOrd"
       ~parent_clauses:[ "partialEqInst" ]
       ~methods:
@@ -892,11 +870,12 @@ let lean_builtin_trait_decls =
           ("le", "le");
           ("gt", "gt");
           ("ge", "ge");
-        ];
+        ]
+      ~default_methods:[ "lt"; "le"; "gt"; "ge" ];
     (* file: "Aeneas/Std/Core/Convert.lean", line: 66 *)
     mk_trait_decl "core::convert::AsMut" "core.convert.AsMut"
       ~methods:[ ("as_mut", "as_mut") ];
-    (* file: "Aeneas/Std/Core/Core.lean", line: 20 *)
+    (* file: "Aeneas/Std/Core/Core.lean", line: 21 *)
     mk_trait_decl "core::convert::From" "core.convert.From"
       ~methods:[ ("from", "from_") ];
     (* file: "Aeneas/Std/Core/Convert.lean", line: 11 *)
@@ -929,11 +908,11 @@ let lean_builtin_trait_decls =
     (* file: "Aeneas/Std/Core/Hash.lean", line: 6 *)
     mk_trait_decl "core::hash::Hasher" "core.hash.Hasher"
       ~methods:[ ("finish", "finish"); ("write", "write") ];
-    (* file: "Aeneas/Std/Core/Iter.lean", line: 24 *)
+    (* file: "Aeneas/Std/Core/Iter.lean", line: 25 *)
     mk_trait_decl "core::iter::adapters::zip::TrustedRandomAccessNoCoerce"
       "core.iter.adapters.zip.TrustedRandomAccessNoCoerce"
       ~consts:[ ("MAY_HAVE_SIDE_EFFECT", "MAY_HAVE_SIDE_EFFECT") ];
-    (* file: "Aeneas/Std/Core/Iter.lean", line: 13 *)
+    (* file: "Aeneas/Std/Core/Iter.lean", line: 14 *)
     mk_trait_decl "core::iter::range::Step" "core.iter.range.Step"
       ~parent_clauses:[ "cloneInst"; "partialOrdInst" ]
       ~methods:
@@ -942,35 +921,35 @@ let lean_builtin_trait_decls =
           ("forward_checked", "forward_checked");
           ("backward_checked", "backward_checked");
         ];
-    (* file: "Aeneas/Std/Core/Iter.lean", line: 138 *)
+    (* file: "Aeneas/Std/Core/Iter.lean", line: 142 *)
     mk_trait_decl "core::iter::traits::accum::Product"
       "core.iter.traits.accum.Product"
       ~methods:[ ("product", "product") ];
-    (* file: "Aeneas/Std/Core/Iter.lean", line: 134 *)
+    (* file: "Aeneas/Std/Core/Iter.lean", line: 138 *)
     mk_trait_decl "core::iter::traits::accum::Sum" "core.iter.traits.accum.Sum"
       ~methods:[ ("sum", "sum") ];
-    (* file: "Aeneas/Std/Core/Iter.lean", line: 181 *)
+    (* file: "Aeneas/Std/Core/Iter.lean", line: 185 *)
     mk_trait_decl "core::iter::traits::collect::Extend"
       "core.iter.traits.collect.Extend"
       ~methods:[ ("extend", "extend") ];
-    (* file: "Aeneas/Std/Core/Iter.lean", line: 149 *)
+    (* file: "Aeneas/Std/Core/Iter.lean", line: 153 *)
     mk_trait_decl "core::iter::traits::collect::FromIterator"
       "core.iter.traits.collect.FromIterator"
       ~methods:[ ("from_iter", "from_iter") ];
-    (* file: "Aeneas/Std/Core/Iter.lean", line: 142 *)
+    (* file: "Aeneas/Std/Core/Iter.lean", line: 146 *)
     mk_trait_decl "core::iter::traits::collect::IntoIterator"
       "core.iter.traits.collect.IntoIterator" ~parent_clauses:[ "iteratorInst" ]
       ~methods:[ ("into_iter", "into_iter") ];
-    (* file: "Aeneas/Std/Core/Iter.lean", line: 186 *)
+    (* file: "Aeneas/Std/Core/Iter.lean", line: 190 *)
     mk_trait_decl "core::iter::traits::double_ended::DoubleEndedIterator"
       "core.iter.traits.double_ended.DoubleEndedIterator"
       ~parent_clauses:[ "iteratorInst" ]
       ~methods:[ ("next_back", "next_back") ];
-    (* file: "Aeneas/Std/Core/Iter.lean", line: 192 *)
+    (* file: "Aeneas/Std/Core/Iter.lean", line: 196 *)
     mk_trait_decl "core::iter::traits::exact_size::ExactSizeIterator"
       "core.iter.traits.exact_size.ExactSizeIterator"
       ~parent_clauses:[ "iteratorInst" ];
-    (* file: "Aeneas/Std/Core/Iter.lean", line: 50 *)
+    (* file: "Aeneas/Std/Core/Iter.lean", line: 58 *)
     mk_trait_decl "core::iter::traits::iterator::Iterator"
       "core.iter.traits.iterator.Iterator"
       ~methods:
@@ -979,8 +958,10 @@ let lean_builtin_trait_decls =
           ("step_by", "step_by");
           ("enumerate", "enumerate");
           ("take", "take");
-        ];
-    (* file: "Aeneas/Std/Core/Core.lean", line: 59 *)
+          ("collect", "collect");
+        ]
+      ~default_methods:[ "step_by"; "enumerate"; "take"; "collect" ];
+    (* file: "Aeneas/Std/Core/Core.lean", line: 61 *)
     mk_trait_decl "core::marker::Copy" "core.marker.Copy"
       ~parent_clauses:[ "cloneInst" ];
     (* file: "Aeneas/Std/Core/Discriminant.lean", line: 8 *)
@@ -1058,13 +1039,13 @@ let lean_builtin_trait_decls =
 
 let lean_builtin_trait_impls =
   [
-    (* file: "Aeneas/Std/Core/Core.lean", line: 53 *)
+    (* file: "Aeneas/Std/Core/Core.lean", line: 55 *)
     mk_trait_impl "core::clone::Clone<Box<@T>>" "core.core.clone.CloneBox"
       ~keep_params:(Some [ true; false ])
       ~keep_trait_clauses:(Some [ true; false ]);
     (* file: "Aeneas/Std/Array/Array.lean", line: 249 *)
     mk_trait_impl "core::clone::Clone<[@T; @N]>" "core.clone.CloneArray";
-    (* file: "Aeneas/Std/Core/Core.lean", line: 33 *)
+    (* file: "Aeneas/Std/Core/Core.lean", line: 35 *)
     mk_trait_impl "core::clone::Clone<alloc::alloc::Global>"
       "core.core.clone.CloneGlobal";
     (* file: "Aeneas/Std/Vec.lean", line: 452 *)
@@ -1072,14 +1053,14 @@ let lean_builtin_trait_impls =
       "core.clone.CloneallocvecVec"
       ~keep_params:(Some [ true; false ])
       ~keep_trait_clauses:(Some [ true; false ]);
-    (* file: "Aeneas/Std/Core/Core.lean", line: 42 *)
+    (* file: "Aeneas/Std/Core/Core.lean", line: 44 *)
     mk_trait_impl "core::clone::Clone<bool>" "core.clone.CloneBool";
-    (* file: "Aeneas/Std/Core/Cmp.lean", line: 154 *)
+    (* file: "Aeneas/Std/Core/Cmp.lean", line: 192 *)
     mk_trait_impl "core::cmp::PartialEq<&'a @A, &'b @B>"
       "core.cmp.PartialEqShared";
-    (* file: "Aeneas/Std/Core/Cmp.lean", line: 122 *)
+    (* file: "Aeneas/Std/Core/Cmp.lean", line: 160 *)
     mk_trait_impl "core::cmp::PartialEq<(), ()>" "core.cmp.PartialEqUnit";
-    (* file: "Aeneas/Std/Core/Cmp.lean", line: 166 *)
+    (* file: "Aeneas/Std/Core/Cmp.lean", line: 204 *)
     mk_trait_impl "core::cmp::PartialEq<Box<@T>, Box<@T>>"
       "core.cmp.PartialEqBox"
       ~keep_params:(Some [ true; false ]);
@@ -1088,7 +1069,7 @@ let lean_builtin_trait_impls =
       "core::cmp::PartialEq<alloc::vec::Vec<@T>, alloc::vec::Vec<@U>>"
       "core.cmp.PartialEqVec"
       ~keep_params:(Some [ true; true; false; false ]);
-    (* file: "Aeneas/Std/Core/Cmp.lean", line: 139 *)
+    (* file: "Aeneas/Std/Core/Cmp.lean", line: 177 *)
     mk_trait_impl "core::cmp::PartialEq<bool, bool>" "core.cmp.PartialEqBool";
     (* file: "Aeneas/Std/Core/Convert.lean", line: 70 *)
     mk_trait_impl "core::convert::AsMut<Box<@T>, @T>" "core.convert.AsMutBox";
@@ -1155,13 +1136,13 @@ let lean_builtin_trait_impls =
     mk_trait_impl "core::fmt::Debug<u8>" "core.fmt.DebugU8";
     (* file: "Aeneas/Std/Scalar/Fmt.lean", line: 73 *)
     mk_trait_impl "core::fmt::Debug<usize>" "core.fmt.DebugUsize";
-    (* file: "Aeneas/Std/Core/Iter.lean", line: 218 *)
+    (* file: "Aeneas/Std/Core/Iter.lean", line: 222 *)
     mk_trait_impl "core::iter::range::Step<usize>" "core.iter.range.StepUsize";
     (* file: "Aeneas/Std/VecIter.lean", line: 91 *)
     mk_trait_impl
       "core::iter::traits::collect::FromIterator<alloc::vec::Vec<@T>, @T>"
       "core.iter.traits.collect.FromIteratorVec";
-    (* file: "Aeneas/Std/Core/Iter.lean", line: 163 *)
+    (* file: "Aeneas/Std/Core/Iter.lean", line: 167 *)
     mk_trait_impl "core::iter::traits::collect::IntoIterator<@I, @Item, @I>"
       "core.iter.traits.collect.IntoIterator.Blanket";
     (* file: "Aeneas/Std/VecIter.lean", line: 58 *)
@@ -1176,12 +1157,12 @@ let lean_builtin_trait_impls =
        @A>, @T>"
       "core.iter.traits.iterator.IteratorVecIntoIter"
       ~keep_params:(Some [ true; false ]);
-    (* file: "Aeneas/Std/Core/Iter.lean", line: 123 *)
+    (* file: "Aeneas/Std/Core/Iter.lean", line: 127 *)
     mk_trait_impl
       "core::iter::traits::iterator::Iterator<core::iter::adapters::step_by::StepBy<@I>, \
        @Clause0_Item>"
       "core.iter.traits.iterator.IteratorStepBy";
-    (* file: "Aeneas/Std/Core/Iter.lean", line: 265 *)
+    (* file: "Aeneas/Std/Core/Iter.lean", line: 269 *)
     mk_trait_impl
       "core::iter::traits::iterator::Iterator<core::ops::range::Range<@A>, @A>"
       "core.iter.traits.iterator.IteratorRange";
@@ -1195,7 +1176,7 @@ let lean_builtin_trait_impls =
       "core::iter::traits::iterator::Iterator<core::slice::iter::Iter<'a, @T>, \
        &'a @T>"
       "core.iter.traits.iterator.IteratorSliceIter";
-    (* file: "Aeneas/Std/Core/Core.lean", line: 63 *)
+    (* file: "Aeneas/Std/Core/Core.lean", line: 65 *)
     mk_trait_impl "core::marker::Copy<bool>" "core.core.marker.CopyBool";
     (* file: "Aeneas/Std/Core/Ops.lean", line: 29 *)
     mk_trait_impl "core::ops::deref::Deref<Box<@T>, @T>"

--- a/tests/lean/Avl/Funs.lean
+++ b/tests/lean/Avl/Funs.lean
@@ -26,7 +26,7 @@ def I32.Insts.AvlOrd.cmp
 /-- Trait implementation: [avl::{avl::Ord for i32}]
     Source: 'src/avl.rs', lines 6:0-16:1 -/
 @[reducible]
-def I32.Insts.AvlOrd : Ord Std.I32 := {
+impl_def I32.Insts.AvlOrd : Ord Std.I32 := {
   cmp := I32.Insts.AvlOrd.cmp
 }
 

--- a/tests/lean/BlanketImpl.lean
+++ b/tests/lean/BlanketImpl.lean
@@ -33,7 +33,7 @@ def Trait2.Blanket.foo {T : Type} (Trait1Inst : Trait1 T) : Result Unit := do
 /-- Trait implementation: [blanket_impl::{blanket_impl::Trait2 for T}]
     Source: 'tests/src/blanket_impl.rs', lines 9:0-9:31 -/
 @[reducible]
-def Trait2.Blanket {T : Type} (Trait1Inst : Trait1 T) : Trait2 T := {
+impl_def Trait2.Blanket {T : Type} (Trait1Inst : Trait1 T) : Trait2 T := {
   foo := Trait2.Blanket.foo Trait1Inst
 }
 

--- a/tests/lean/Closures.lean
+++ b/tests/lean/Closures.lean
@@ -48,7 +48,7 @@ def call_fn_no_state.closure.Insts.CoreOpsFunctionFnOnceTupleU32U32.call_once
 /-- Trait implementation: [closures::call_fn_no_state::{core::ops::function::FnOnce<(u32), u32> for closures::call_fn_no_state::closure}]
     Source: 'tests/src/closures.rs', lines 4:15-4:40 -/
 @[reducible]
-def call_fn_no_state.closure.Insts.CoreOpsFunctionFnOnceTupleU32U32 :
+impl_def call_fn_no_state.closure.Insts.CoreOpsFunctionFnOnceTupleU32U32 :
   core.ops.function.FnOnce call_fn_no_state.closure Std.U32 Std.U32 := {
   call_once :=
     call_fn_no_state.closure.Insts.CoreOpsFunctionFnOnceTupleU32U32.call_once
@@ -57,7 +57,7 @@ def call_fn_no_state.closure.Insts.CoreOpsFunctionFnOnceTupleU32U32 :
 /-- Trait implementation: [closures::call_fn_no_state::{core::ops::function::FnMut<(u32), u32> for closures::call_fn_no_state::closure}]
     Source: 'tests/src/closures.rs', lines 4:15-4:40 -/
 @[reducible]
-def call_fn_no_state.closure.Insts.CoreOpsFunctionFnMutTupleU32U32 :
+impl_def call_fn_no_state.closure.Insts.CoreOpsFunctionFnMutTupleU32U32 :
   core.ops.function.FnMut call_fn_no_state.closure Std.U32 Std.U32 := {
   FnOnceInst := call_fn_no_state.closure.Insts.CoreOpsFunctionFnOnceTupleU32U32
   call_mut :=
@@ -67,7 +67,7 @@ def call_fn_no_state.closure.Insts.CoreOpsFunctionFnMutTupleU32U32 :
 /-- Trait implementation: [closures::call_fn_no_state::{core::ops::function::Fn<(u32), u32> for closures::call_fn_no_state::closure}]
     Source: 'tests/src/closures.rs', lines 4:15-4:40 -/
 @[reducible]
-def call_fn_no_state.closure.Insts.CoreOpsFunctionFnTupleU32U32 :
+impl_def call_fn_no_state.closure.Insts.CoreOpsFunctionFnTupleU32U32 :
   core.ops.function.Fn call_fn_no_state.closure Std.U32 Std.U32 := {
   FnMutInst := call_fn_no_state.closure.Insts.CoreOpsFunctionFnMutTupleU32U32
   call := call_fn_no_state.closure.Insts.CoreOpsFunctionFnTupleU32U32.call
@@ -110,7 +110,7 @@ def call_fn_shared.closure.Insts.CoreOpsFunctionFnOnceTupleUsizeU8.call_once
 /-- Trait implementation: [closures::call_fn_shared::{core::ops::function::FnOnce<(usize), u8> for closures::call_fn_shared::closure<0>}]
     Source: 'tests/src/closures.rs', lines 9:15-9:40 -/
 @[reducible]
-def call_fn_shared.closure.Insts.CoreOpsFunctionFnOnceTupleUsizeU8 :
+impl_def call_fn_shared.closure.Insts.CoreOpsFunctionFnOnceTupleUsizeU8 :
   core.ops.function.FnOnce call_fn_shared.closure Std.Usize Std.U8 := {
   call_once :=
     call_fn_shared.closure.Insts.CoreOpsFunctionFnOnceTupleUsizeU8.call_once
@@ -119,7 +119,7 @@ def call_fn_shared.closure.Insts.CoreOpsFunctionFnOnceTupleUsizeU8 :
 /-- Trait implementation: [closures::call_fn_shared::{core::ops::function::FnMut<(usize), u8> for closures::call_fn_shared::closure<0>}]
     Source: 'tests/src/closures.rs', lines 9:15-9:40 -/
 @[reducible]
-def call_fn_shared.closure.Insts.CoreOpsFunctionFnMutTupleUsizeU8 :
+impl_def call_fn_shared.closure.Insts.CoreOpsFunctionFnMutTupleUsizeU8 :
   core.ops.function.FnMut call_fn_shared.closure Std.Usize Std.U8 := {
   FnOnceInst := call_fn_shared.closure.Insts.CoreOpsFunctionFnOnceTupleUsizeU8
   call_mut :=
@@ -129,7 +129,7 @@ def call_fn_shared.closure.Insts.CoreOpsFunctionFnMutTupleUsizeU8 :
 /-- Trait implementation: [closures::call_fn_shared::{core::ops::function::Fn<(usize), u8> for closures::call_fn_shared::closure<0>}]
     Source: 'tests/src/closures.rs', lines 9:15-9:40 -/
 @[reducible]
-def call_fn_shared.closure.Insts.CoreOpsFunctionFnTupleUsizeU8 :
+impl_def call_fn_shared.closure.Insts.CoreOpsFunctionFnTupleUsizeU8 :
   core.ops.function.Fn call_fn_shared.closure Std.Usize Std.U8 := {
   FnMutInst := call_fn_shared.closure.Insts.CoreOpsFunctionFnMutTupleUsizeU8
   call := call_fn_shared.closure.Insts.CoreOpsFunctionFnTupleUsizeU8.call
@@ -175,7 +175,7 @@ def call_closure1.closure.Insts.CoreOpsFunctionFnOnceTupleU32.call_once
 /-- Trait implementation: [closures::call_closure1::{core::ops::function::FnOnce<(), u32> for closures::call_closure1::closure}]
     Source: 'tests/src/closures.rs', lines 35:17-35:21 -/
 @[reducible]
-def call_closure1.closure.Insts.CoreOpsFunctionFnOnceTupleU32 :
+impl_def call_closure1.closure.Insts.CoreOpsFunctionFnOnceTupleU32 :
   core.ops.function.FnOnce call_closure1.closure Unit Std.U32 := {
   call_once :=
     call_closure1.closure.Insts.CoreOpsFunctionFnOnceTupleU32.call_once
@@ -184,7 +184,7 @@ def call_closure1.closure.Insts.CoreOpsFunctionFnOnceTupleU32 :
 /-- Trait implementation: [closures::call_closure1::{core::ops::function::FnMut<(), u32> for closures::call_closure1::closure}]
     Source: 'tests/src/closures.rs', lines 35:17-35:21 -/
 @[reducible]
-def call_closure1.closure.Insts.CoreOpsFunctionFnMutTupleU32 :
+impl_def call_closure1.closure.Insts.CoreOpsFunctionFnMutTupleU32 :
   core.ops.function.FnMut call_closure1.closure Unit Std.U32 := {
   FnOnceInst := call_closure1.closure.Insts.CoreOpsFunctionFnOnceTupleU32
   call_mut := call_closure1.closure.Insts.CoreOpsFunctionFnMutTupleU32.call_mut
@@ -193,7 +193,7 @@ def call_closure1.closure.Insts.CoreOpsFunctionFnMutTupleU32 :
 /-- Trait implementation: [closures::call_closure1::{core::ops::function::Fn<(), u32> for closures::call_closure1::closure}]
     Source: 'tests/src/closures.rs', lines 35:17-35:21 -/
 @[reducible]
-def call_closure1.closure.Insts.CoreOpsFunctionFnTupleU32 :
+impl_def call_closure1.closure.Insts.CoreOpsFunctionFnTupleU32 :
   core.ops.function.Fn call_closure1.closure Unit Std.U32 := {
   FnMutInst := call_closure1.closure.Insts.CoreOpsFunctionFnMutTupleU32
   call := call_closure1.closure.Insts.CoreOpsFunctionFnTupleU32.call
@@ -236,7 +236,7 @@ def call_closure2.closure_1.Insts.CoreOpsFunctionFnOnceTupleU32.call_once
 /-- Trait implementation: [closures::call_closure2::{core::ops::function::FnOnce<(), u32> for closures::call_closure2::closure#1}]
     Source: 'tests/src/closures.rs', lines 40:17-40:21 -/
 @[reducible]
-def call_closure2.closure_1.Insts.CoreOpsFunctionFnOnceTupleU32 :
+impl_def call_closure2.closure_1.Insts.CoreOpsFunctionFnOnceTupleU32 :
   core.ops.function.FnOnce call_closure2.closure_1 Unit Std.U32 := {
   call_once :=
     call_closure2.closure_1.Insts.CoreOpsFunctionFnOnceTupleU32.call_once
@@ -245,7 +245,7 @@ def call_closure2.closure_1.Insts.CoreOpsFunctionFnOnceTupleU32 :
 /-- Trait implementation: [closures::call_closure2::{core::ops::function::FnMut<(), u32> for closures::call_closure2::closure#1}]
     Source: 'tests/src/closures.rs', lines 40:17-40:21 -/
 @[reducible]
-def call_closure2.closure_1.Insts.CoreOpsFunctionFnMutTupleU32 :
+impl_def call_closure2.closure_1.Insts.CoreOpsFunctionFnMutTupleU32 :
   core.ops.function.FnMut call_closure2.closure_1 Unit Std.U32 := {
   FnOnceInst := call_closure2.closure_1.Insts.CoreOpsFunctionFnOnceTupleU32
   call_mut :=
@@ -255,7 +255,7 @@ def call_closure2.closure_1.Insts.CoreOpsFunctionFnMutTupleU32 :
 /-- Trait implementation: [closures::call_closure2::{core::ops::function::Fn<(), u32> for closures::call_closure2::closure#1}]
     Source: 'tests/src/closures.rs', lines 40:17-40:21 -/
 @[reducible]
-def call_closure2.closure_1.Insts.CoreOpsFunctionFnTupleU32 :
+impl_def call_closure2.closure_1.Insts.CoreOpsFunctionFnTupleU32 :
   core.ops.function.Fn call_closure2.closure_1 Unit Std.U32 := {
   FnMutInst := call_closure2.closure_1.Insts.CoreOpsFunctionFnMutTupleU32
   call := call_closure2.closure_1.Insts.CoreOpsFunctionFnTupleU32.call
@@ -292,7 +292,7 @@ def call_closure2.closure.Insts.CoreOpsFunctionFnOnceTupleU32.call_once
 /-- Trait implementation: [closures::call_closure2::{core::ops::function::FnOnce<(), u32> for closures::call_closure2::closure}]
     Source: 'tests/src/closures.rs', lines 39:17-39:21 -/
 @[reducible]
-def call_closure2.closure.Insts.CoreOpsFunctionFnOnceTupleU32 :
+impl_def call_closure2.closure.Insts.CoreOpsFunctionFnOnceTupleU32 :
   core.ops.function.FnOnce call_closure2.closure Unit Std.U32 := {
   call_once :=
     call_closure2.closure.Insts.CoreOpsFunctionFnOnceTupleU32.call_once
@@ -301,7 +301,7 @@ def call_closure2.closure.Insts.CoreOpsFunctionFnOnceTupleU32 :
 /-- Trait implementation: [closures::call_closure2::{core::ops::function::FnMut<(), u32> for closures::call_closure2::closure}]
     Source: 'tests/src/closures.rs', lines 39:17-39:21 -/
 @[reducible]
-def call_closure2.closure.Insts.CoreOpsFunctionFnMutTupleU32 :
+impl_def call_closure2.closure.Insts.CoreOpsFunctionFnMutTupleU32 :
   core.ops.function.FnMut call_closure2.closure Unit Std.U32 := {
   FnOnceInst := call_closure2.closure.Insts.CoreOpsFunctionFnOnceTupleU32
   call_mut := call_closure2.closure.Insts.CoreOpsFunctionFnMutTupleU32.call_mut
@@ -310,7 +310,7 @@ def call_closure2.closure.Insts.CoreOpsFunctionFnMutTupleU32 :
 /-- Trait implementation: [closures::call_closure2::{core::ops::function::Fn<(), u32> for closures::call_closure2::closure}]
     Source: 'tests/src/closures.rs', lines 39:17-39:21 -/
 @[reducible]
-def call_closure2.closure.Insts.CoreOpsFunctionFnTupleU32 :
+impl_def call_closure2.closure.Insts.CoreOpsFunctionFnTupleU32 :
   core.ops.function.Fn call_closure2.closure Unit Std.U32 := {
   FnMutInst := call_closure2.closure.Insts.CoreOpsFunctionFnMutTupleU32
   call := call_closure2.closure.Insts.CoreOpsFunctionFnTupleU32.call

--- a/tests/lean/ConstShadow.lean
+++ b/tests/lean/ConstShadow.lean
@@ -36,7 +36,7 @@ def Foo.Insts.Const_shadowHasConst4.N : Std.Usize := 42#usize
 /-- Trait implementation: [const_shadow::{const_shadow::HasConst<4usize> for const_shadow::Foo}]
     Source: 'tests/src/const-shadow.rs', lines 20:0-26:1 -/
 @[reducible]
-def Foo.Insts.Const_shadowHasConst4 : HasConst Foo 4#usize := {
+impl_def Foo.Insts.Const_shadowHasConst4 : HasConst Foo 4#usize := {
   N := ok Foo.Insts.Const_shadowHasConst4.N
   get := Foo.Insts.Const_shadowHasConst4.get
 }

--- a/tests/lean/ConstantsLean.lean
+++ b/tests/lean/ConstantsLean.lean
@@ -63,8 +63,8 @@ def Wrapper.Insts.Constants_leanTrait.NM (N1 : Std.Usize) (M1 : Std.Usize)
 /-- Trait implementation: [constants_lean::{constants_lean::Trait for constants_lean::Wrapper<N, M>}]
     Source: 'tests/src/constants-lean.rs', lines 26:0-28:1 -/
 @[reducible]
-def Wrapper.Insts.Constants_leanTrait (N1 : Std.Usize) (M1 : Std.Usize) : Trait
-  (Wrapper N1 M1) := {
+impl_def Wrapper.Insts.Constants_leanTrait (N1 : Std.Usize) (M1 : Std.Usize) :
+  Trait (Wrapper N1 M1) := {
   NM := Wrapper.Insts.Constants_leanTrait.NM N1 M1
 }
 

--- a/tests/lean/Curve25519/Curve25519.lean
+++ b/tests/lean/Curve25519/Curve25519.lean
@@ -27,8 +27,8 @@ def Scalar52.Insts.CoreOpsIndexIndexUsizeU64.index
 /-- Trait implementation: [curve25519::{core::ops::index::Index<usize, u64> for curve25519::Scalar52}]
     Source: 'tests/src/curve25519.rs', lines 9:0-14:1 -/
 @[reducible]
-def Scalar52.Insts.CoreOpsIndexIndexUsizeU64 : core.ops.index.Index Scalar52
-  Std.Usize Std.U64 := {
+impl_def Scalar52.Insts.CoreOpsIndexIndexUsizeU64 : core.ops.index.Index
+  Scalar52 Std.Usize Std.U64 := {
   index := Scalar52.Insts.CoreOpsIndexIndexUsizeU64.index
 }
 

--- a/tests/lean/DefaultedMethod.lean
+++ b/tests/lean/DefaultedMethod.lean
@@ -43,7 +43,7 @@ def NoOverride.Insts.Defaulted_methodTrait.provided_method
 /-- Trait implementation: [defaulted_method::{defaulted_method::Trait for defaulted_method::NoOverride}]
     Source: 'tests/src/defaulted_method.rs', lines 10:0-17:1 -/
 @[reducible]
-def NoOverride.Insts.Defaulted_methodTrait : Trait NoOverride := {
+impl_def NoOverride.Insts.Defaulted_methodTrait : Trait NoOverride := {
   provided_method := NoOverride.Insts.Defaulted_methodTrait.provided_method
   required_method := NoOverride.Insts.Defaulted_methodTrait.required_method
 }
@@ -68,7 +68,7 @@ def YesOverride.Insts.Defaulted_methodTrait.provided_method
 /-- Trait implementation: [defaulted_method::{defaulted_method::Trait for defaulted_method::YesOverride}]
     Source: 'tests/src/defaulted_method.rs', lines 20:0-24:1 -/
 @[reducible]
-def YesOverride.Insts.Defaulted_methodTrait : Trait YesOverride := {
+impl_def YesOverride.Insts.Defaulted_methodTrait : Trait YesOverride := {
   provided_method := YesOverride.Insts.Defaulted_methodTrait.provided_method
   required_method := YesOverride.Insts.Defaulted_methodTrait.required_method
 }

--- a/tests/lean/Demo/Demo.lean
+++ b/tests/lean/Demo/Demo.lean
@@ -154,7 +154,7 @@ def Usize.Insts.DemoCounter.incr
 /-- Trait implementation: [demo::{demo::Counter for usize}]
     Source: 'tests/src/demo.rs', lines 104:0-110:1 -/
 @[reducible]
-def Usize.Insts.DemoCounter : Counter Std.Usize := {
+impl_def Usize.Insts.DemoCounter : Counter Std.Usize := {
   incr := Usize.Insts.DemoCounter.incr
 }
 

--- a/tests/lean/Derive.lean
+++ b/tests/lean/Derive.lean
@@ -14,22 +14,6 @@ noncomputable section
 
 namespace derive
 
-/-- [core::cmp::impls::{core::cmp::PartialEq<bool> for bool}::ne]:
-    Source: '/rustc/library/core/src/cmp.rs', lines 1872:16-1872:50
-    Name pattern: [core::cmp::impls::{core::cmp::PartialEq<bool, bool>}::ne]
-    Visibility: public -/
-@[rust_fun "core::cmp::impls::{core::cmp::PartialEq<bool, bool>}::ne"]
-axiom Bool.Insts.CoreCmpPartialEqBool.ne : Bool → Bool → Result Bool
-
-/-- [alloc::boxed::{core::cmp::PartialEq<alloc::boxed::Box<T>> for alloc::boxed::Box<T>}::ne]:
-    Source: '/rustc/library/alloc/src/boxed.rs', lines 2056:4-2056:38
-    Name pattern: [alloc::boxed::{core::cmp::PartialEq<Box<@T>, Box<@T>>}::ne]
-    Visibility: public -/
-@[rust_fun "alloc::boxed::{core::cmp::PartialEq<Box<@T>, Box<@T>>}::ne"]
-axiom Box.Insts.CoreCmpPartialEqBox.ne
-  {T : Type} (A : Type) (corecmpPartialEqInst : core.cmp.PartialEq T T) :
-  T → T → Result Bool
-
 /-- [derive::CopyEnumOneVariant]
     Source: 'tests/src/derive.rs', lines 4:0-6:1 -/
 @[discriminant isize]
@@ -46,7 +30,7 @@ def CopyEnumOneVariant.Insts.CoreCloneClone.clone
 /-- Trait implementation: [derive::{core::clone::Clone for derive::CopyEnumOneVariant}]
     Source: 'tests/src/derive.rs', lines 3:9-3:14 -/
 @[reducible]
-def CopyEnumOneVariant.Insts.CoreCloneClone : core.clone.Clone
+impl_def CopyEnumOneVariant.Insts.CoreCloneClone : core.clone.Clone
   CopyEnumOneVariant := {
   clone := CopyEnumOneVariant.Insts.CoreCloneClone.clone
 }
@@ -54,7 +38,7 @@ def CopyEnumOneVariant.Insts.CoreCloneClone : core.clone.Clone
 /-- Trait implementation: [derive::{core::marker::Copy for derive::CopyEnumOneVariant}]
     Source: 'tests/src/derive.rs', lines 3:16-3:20 -/
 @[reducible]
-def CopyEnumOneVariant.Insts.CoreMarkerCopy : core.marker.Copy
+impl_def CopyEnumOneVariant.Insts.CoreMarkerCopy : core.marker.Copy
   CopyEnumOneVariant := {
   cloneInst := CopyEnumOneVariant.Insts.CoreCloneClone
 }
@@ -62,15 +46,9 @@ def CopyEnumOneVariant.Insts.CoreMarkerCopy : core.marker.Copy
 /-- Trait implementation: [derive::{core::marker::StructuralPartialEq for derive::CopyEnumOneVariant}]
     Source: 'tests/src/derive.rs', lines 3:22-3:31 -/
 @[reducible]
-def CopyEnumOneVariant.Insts.CoreMarkerStructuralPartialEq :
+impl_def CopyEnumOneVariant.Insts.CoreMarkerStructuralPartialEq :
   core.marker.StructuralPartialEq CopyEnumOneVariant := {
 }
-
-/-- [derive::{core::cmp::PartialEq<derive::CopyEnumOneVariant> for derive::CopyEnumOneVariant}::ne]:
-    Source: 'tests/src/derive.rs', lines 3:22-3:31
-    Visibility: public -/
-axiom CopyEnumOneVariant.Insts.CoreCmpPartialEqCopyEnumOneVariant.ne
-  : CopyEnumOneVariant → CopyEnumOneVariant → Result Bool
 
 /-- [derive::{core::cmp::PartialEq<derive::CopyEnumOneVariant> for derive::CopyEnumOneVariant}::eq]:
     Source: 'tests/src/derive.rs', lines 3:22-3:31
@@ -84,10 +62,9 @@ def CopyEnumOneVariant.Insts.CoreCmpPartialEqCopyEnumOneVariant.eq
 /-- Trait implementation: [derive::{core::cmp::PartialEq<derive::CopyEnumOneVariant> for derive::CopyEnumOneVariant}]
     Source: 'tests/src/derive.rs', lines 3:22-3:31 -/
 @[reducible]
-def CopyEnumOneVariant.Insts.CoreCmpPartialEqCopyEnumOneVariant :
+impl_def CopyEnumOneVariant.Insts.CoreCmpPartialEqCopyEnumOneVariant :
   core.cmp.PartialEq CopyEnumOneVariant CopyEnumOneVariant := {
   eq := CopyEnumOneVariant.Insts.CoreCmpPartialEqCopyEnumOneVariant.eq
-  ne := CopyEnumOneVariant.Insts.CoreCmpPartialEqCopyEnumOneVariant.ne
 }
 
 /-- [derive::{core::cmp::Eq for derive::CopyEnumOneVariant}::assert_receiver_is_total_eq]:
@@ -100,7 +77,8 @@ def CopyEnumOneVariant.Insts.CoreCmpEq.assert_receiver_is_total_eq
 /-- Trait implementation: [derive::{core::cmp::Eq for derive::CopyEnumOneVariant}]
     Source: 'tests/src/derive.rs', lines 3:33-3:35 -/
 @[reducible]
-def CopyEnumOneVariant.Insts.CoreCmpEq : core.cmp.Eq CopyEnumOneVariant := {
+impl_def CopyEnumOneVariant.Insts.CoreCmpEq : core.cmp.Eq CopyEnumOneVariant
+  := {
   partialEqInst := CopyEnumOneVariant.Insts.CoreCmpPartialEqCopyEnumOneVariant
   assert_receiver_is_total_eq :=
     CopyEnumOneVariant.Insts.CoreCmpEq.assert_receiver_is_total_eq
@@ -120,8 +98,8 @@ def CopyEnumOneVariant.Insts.CoreFmtDebug.fmt
 /-- Trait implementation: [derive::{core::fmt::Debug for derive::CopyEnumOneVariant}]
     Source: 'tests/src/derive.rs', lines 3:37-3:42 -/
 @[reducible]
-def CopyEnumOneVariant.Insts.CoreFmtDebug : core.fmt.Debug CopyEnumOneVariant
-  := {
+impl_def CopyEnumOneVariant.Insts.CoreFmtDebug : core.fmt.Debug
+  CopyEnumOneVariant := {
   fmt := CopyEnumOneVariant.Insts.CoreFmtDebug.fmt
 }
 
@@ -144,29 +122,23 @@ def ScalarEnum.Insts.CoreCloneClone.clone
 /-- Trait implementation: [derive::{core::clone::Clone for derive::ScalarEnum}]
     Source: 'tests/src/derive.rs', lines 8:9-8:14 -/
 @[reducible]
-def ScalarEnum.Insts.CoreCloneClone : core.clone.Clone ScalarEnum := {
+impl_def ScalarEnum.Insts.CoreCloneClone : core.clone.Clone ScalarEnum := {
   clone := ScalarEnum.Insts.CoreCloneClone.clone
 }
 
 /-- Trait implementation: [derive::{core::marker::Copy for derive::ScalarEnum}]
     Source: 'tests/src/derive.rs', lines 8:16-8:20 -/
 @[reducible]
-def ScalarEnum.Insts.CoreMarkerCopy : core.marker.Copy ScalarEnum := {
+impl_def ScalarEnum.Insts.CoreMarkerCopy : core.marker.Copy ScalarEnum := {
   cloneInst := ScalarEnum.Insts.CoreCloneClone
 }
 
 /-- Trait implementation: [derive::{core::marker::StructuralPartialEq for derive::ScalarEnum}]
     Source: 'tests/src/derive.rs', lines 8:22-8:31 -/
 @[reducible]
-def ScalarEnum.Insts.CoreMarkerStructuralPartialEq :
+impl_def ScalarEnum.Insts.CoreMarkerStructuralPartialEq :
   core.marker.StructuralPartialEq ScalarEnum := {
 }
-
-/-- [derive::{core::cmp::PartialEq<derive::ScalarEnum> for derive::ScalarEnum}::ne]:
-    Source: 'tests/src/derive.rs', lines 8:22-8:31
-    Visibility: public -/
-axiom ScalarEnum.Insts.CoreCmpPartialEqScalarEnum.ne
-  : ScalarEnum → ScalarEnum → Result Bool
 
 /-- [derive::{core::cmp::PartialEq<derive::ScalarEnum> for derive::ScalarEnum}::eq]:
     Source: 'tests/src/derive.rs', lines 8:22-8:31
@@ -180,10 +152,9 @@ def ScalarEnum.Insts.CoreCmpPartialEqScalarEnum.eq
 /-- Trait implementation: [derive::{core::cmp::PartialEq<derive::ScalarEnum> for derive::ScalarEnum}]
     Source: 'tests/src/derive.rs', lines 8:22-8:31 -/
 @[reducible]
-def ScalarEnum.Insts.CoreCmpPartialEqScalarEnum : core.cmp.PartialEq ScalarEnum
-  ScalarEnum := {
+impl_def ScalarEnum.Insts.CoreCmpPartialEqScalarEnum : core.cmp.PartialEq
+  ScalarEnum ScalarEnum := {
   eq := ScalarEnum.Insts.CoreCmpPartialEqScalarEnum.eq
-  ne := ScalarEnum.Insts.CoreCmpPartialEqScalarEnum.ne
 }
 
 /-- [derive::{core::cmp::Eq for derive::ScalarEnum}::assert_receiver_is_total_eq]:
@@ -196,7 +167,7 @@ def ScalarEnum.Insts.CoreCmpEq.assert_receiver_is_total_eq
 /-- Trait implementation: [derive::{core::cmp::Eq for derive::ScalarEnum}]
     Source: 'tests/src/derive.rs', lines 8:33-8:35 -/
 @[reducible]
-def ScalarEnum.Insts.CoreCmpEq : core.cmp.Eq ScalarEnum := {
+impl_def ScalarEnum.Insts.CoreCmpEq : core.cmp.Eq ScalarEnum := {
   partialEqInst := ScalarEnum.Insts.CoreCmpPartialEqScalarEnum
   assert_receiver_is_total_eq :=
     ScalarEnum.Insts.CoreCmpEq.assert_receiver_is_total_eq
@@ -218,7 +189,7 @@ def ScalarEnum.Insts.CoreFmtDebug.fmt
 /-- Trait implementation: [derive::{core::fmt::Debug for derive::ScalarEnum}]
     Source: 'tests/src/derive.rs', lines 8:37-8:42 -/
 @[reducible]
-def ScalarEnum.Insts.CoreFmtDebug : core.fmt.Debug ScalarEnum := {
+impl_def ScalarEnum.Insts.CoreFmtDebug : core.fmt.Debug ScalarEnum := {
   fmt := ScalarEnum.Insts.CoreFmtDebug.fmt
 }
 
@@ -253,7 +224,7 @@ def CopyEnum.Insts.CoreCloneClone.clone
 /-- Trait implementation: [derive::{core::clone::Clone for derive::CopyEnum<T>}]
     Source: 'tests/src/derive.rs', lines 16:9-16:14 -/
 @[reducible]
-def CopyEnum.Insts.CoreCloneClone {T : Type} (corecloneCloneInst :
+impl_def CopyEnum.Insts.CoreCloneClone {T : Type} (corecloneCloneInst :
   core.clone.Clone T) : core.clone.Clone (CopyEnum T) := {
   clone := CopyEnum.Insts.CoreCloneClone.clone corecloneCloneInst
 }
@@ -261,7 +232,7 @@ def CopyEnum.Insts.CoreCloneClone {T : Type} (corecloneCloneInst :
 /-- Trait implementation: [derive::{core::marker::Copy for derive::CopyEnum<T>}]
     Source: 'tests/src/derive.rs', lines 16:16-16:20 -/
 @[reducible]
-def CopyEnum.Insts.CoreMarkerCopy {T : Type} (coremarkerCopyInst :
+impl_def CopyEnum.Insts.CoreMarkerCopy {T : Type} (coremarkerCopyInst :
   core.marker.Copy T) : core.marker.Copy (CopyEnum T) := {
   cloneInst := CopyEnum.Insts.CoreCloneClone coremarkerCopyInst.cloneInst
 }
@@ -269,16 +240,9 @@ def CopyEnum.Insts.CoreMarkerCopy {T : Type} (coremarkerCopyInst :
 /-- Trait implementation: [derive::{core::marker::StructuralPartialEq for derive::CopyEnum<T>}]
     Source: 'tests/src/derive.rs', lines 16:22-16:31 -/
 @[reducible]
-def CopyEnum.Insts.CoreMarkerStructuralPartialEq (T : Type) :
+impl_def CopyEnum.Insts.CoreMarkerStructuralPartialEq (T : Type) :
   core.marker.StructuralPartialEq (CopyEnum T) := {
 }
-
-/-- [derive::{core::cmp::PartialEq<derive::CopyEnum<T>> for derive::CopyEnum<T>}::ne]:
-    Source: 'tests/src/derive.rs', lines 16:22-16:31
-    Visibility: public -/
-axiom CopyEnum.Insts.CoreCmpPartialEqCopyEnum.ne
-  {T : Type} (corecmpPartialEqInst : core.cmp.PartialEq T T) :
-  CopyEnum T → CopyEnum T → Result Bool
 
 /-- [derive::{core::cmp::PartialEq<derive::CopyEnum<T>> for derive::CopyEnum<T>}::eq]:
     Source: 'tests/src/derive.rs', lines 16:22-16:31
@@ -321,10 +285,10 @@ def CopyEnum.Insts.CoreCmpPartialEqCopyEnum.eq
 /-- Trait implementation: [derive::{core::cmp::PartialEq<derive::CopyEnum<T>> for derive::CopyEnum<T>}]
     Source: 'tests/src/derive.rs', lines 16:22-16:31 -/
 @[reducible]
-def CopyEnum.Insts.CoreCmpPartialEqCopyEnum {T : Type} (corecmpPartialEqInst :
-  core.cmp.PartialEq T T) : core.cmp.PartialEq (CopyEnum T) (CopyEnum T) := {
+impl_def CopyEnum.Insts.CoreCmpPartialEqCopyEnum {T : Type}
+  (corecmpPartialEqInst : core.cmp.PartialEq T T) : core.cmp.PartialEq
+  (CopyEnum T) (CopyEnum T) := {
   eq := CopyEnum.Insts.CoreCmpPartialEqCopyEnum.eq corecmpPartialEqInst
-  ne := CopyEnum.Insts.CoreCmpPartialEqCopyEnum.ne corecmpPartialEqInst
 }
 
 /-- [derive::{core::cmp::Eq for derive::CopyEnum<T>}::assert_receiver_is_total_eq]:
@@ -339,7 +303,7 @@ def CopyEnum.Insts.CoreCmpEq.assert_receiver_is_total_eq
 /-- Trait implementation: [derive::{core::cmp::Eq for derive::CopyEnum<T>}]
     Source: 'tests/src/derive.rs', lines 16:33-16:35 -/
 @[reducible]
-def CopyEnum.Insts.CoreCmpEq {T : Type} (corecmpEqInst : core.cmp.Eq T) :
+impl_def CopyEnum.Insts.CoreCmpEq {T : Type} (corecmpEqInst : core.cmp.Eq T) :
   core.cmp.Eq (CopyEnum T) := {
   partialEqInst := CopyEnum.Insts.CoreCmpPartialEqCopyEnum
     corecmpEqInst.partialEqInst
@@ -371,8 +335,8 @@ def CopyEnum.Insts.CoreFmtDebug.fmt
 /-- Trait implementation: [derive::{core::fmt::Debug for derive::CopyEnum<T>}]
     Source: 'tests/src/derive.rs', lines 16:37-16:42 -/
 @[reducible]
-def CopyEnum.Insts.CoreFmtDebug {T : Type} (corefmtDebugInst : core.fmt.Debug
-  T) : core.fmt.Debug (CopyEnum T) := {
+impl_def CopyEnum.Insts.CoreFmtDebug {T : Type} (corefmtDebugInst :
+  core.fmt.Debug T) : core.fmt.Debug (CopyEnum T) := {
   fmt := CopyEnum.Insts.CoreFmtDebug.fmt corefmtDebugInst
 }
 
@@ -411,24 +375,17 @@ def Enum.Insts.CoreCloneClone.clone
 /-- Trait implementation: [derive::{core::clone::Clone for derive::Enum<T>}]
     Source: 'tests/src/derive.rs', lines 24:9-24:14 -/
 @[reducible]
-def Enum.Insts.CoreCloneClone {T : Type} (corecloneCloneInst : core.clone.Clone
-  T) : core.clone.Clone (Enum T) := {
+impl_def Enum.Insts.CoreCloneClone {T : Type} (corecloneCloneInst :
+  core.clone.Clone T) : core.clone.Clone (Enum T) := {
   clone := Enum.Insts.CoreCloneClone.clone corecloneCloneInst
 }
 
 /-- Trait implementation: [derive::{core::marker::StructuralPartialEq for derive::Enum<T>}]
     Source: 'tests/src/derive.rs', lines 24:16-24:25 -/
 @[reducible]
-def Enum.Insts.CoreMarkerStructuralPartialEq (T : Type) :
+impl_def Enum.Insts.CoreMarkerStructuralPartialEq (T : Type) :
   core.marker.StructuralPartialEq (Enum T) := {
 }
-
-/-- [derive::{core::cmp::PartialEq<derive::Enum<T>> for derive::Enum<T>}::ne]:
-    Source: 'tests/src/derive.rs', lines 24:16-24:25
-    Visibility: public -/
-axiom Enum.Insts.CoreCmpPartialEqEnum.ne
-  {T : Type} (corecmpPartialEqInst : core.cmp.PartialEq T T) :
-  Enum T → Enum T → Result Bool
 
 /-- [derive::{core::cmp::PartialEq<derive::Enum<T>> for derive::Enum<T>}::eq]:
     Source: 'tests/src/derive.rs', lines 24:16-24:25
@@ -483,10 +440,9 @@ def Enum.Insts.CoreCmpPartialEqEnum.eq
 /-- Trait implementation: [derive::{core::cmp::PartialEq<derive::Enum<T>> for derive::Enum<T>}]
     Source: 'tests/src/derive.rs', lines 24:16-24:25 -/
 @[reducible]
-def Enum.Insts.CoreCmpPartialEqEnum {T : Type} (corecmpPartialEqInst :
+impl_def Enum.Insts.CoreCmpPartialEqEnum {T : Type} (corecmpPartialEqInst :
   core.cmp.PartialEq T T) : core.cmp.PartialEq (Enum T) (Enum T) := {
   eq := Enum.Insts.CoreCmpPartialEqEnum.eq corecmpPartialEqInst
-  ne := Enum.Insts.CoreCmpPartialEqEnum.ne corecmpPartialEqInst
 }
 
 /-- [derive::{core::cmp::Eq for derive::Enum<T>}::assert_receiver_is_total_eq]:
@@ -501,7 +457,7 @@ def Enum.Insts.CoreCmpEq.assert_receiver_is_total_eq
 /-- Trait implementation: [derive::{core::cmp::Eq for derive::Enum<T>}]
     Source: 'tests/src/derive.rs', lines 24:27-24:29 -/
 @[reducible]
-def Enum.Insts.CoreCmpEq {T : Type} (corecmpEqInst : core.cmp.Eq T) :
+impl_def Enum.Insts.CoreCmpEq {T : Type} (corecmpEqInst : core.cmp.Eq T) :
   core.cmp.Eq (Enum T) := {
   partialEqInst := Enum.Insts.CoreCmpPartialEqEnum corecmpEqInst.partialEqInst
   assert_receiver_is_total_eq :=
@@ -537,8 +493,8 @@ def Enum.Insts.CoreFmtDebug.fmt
 /-- Trait implementation: [derive::{core::fmt::Debug for derive::Enum<T>}]
     Source: 'tests/src/derive.rs', lines 24:31-24:36 -/
 @[reducible]
-def Enum.Insts.CoreFmtDebug {T : Type} (corefmtDebugInst : core.fmt.Debug T) :
-  core.fmt.Debug (Enum T) := {
+impl_def Enum.Insts.CoreFmtDebug {T : Type} (corefmtDebugInst : core.fmt.Debug
+  T) : core.fmt.Debug (Enum T) := {
   fmt := Enum.Insts.CoreFmtDebug.fmt corefmtDebugInst
 }
 
@@ -567,24 +523,17 @@ partial_fixpoint
 /-- Trait implementation: [derive::{core::clone::Clone for derive::List<T>}]
     Source: 'tests/src/derive.rs', lines 34:9-34:14 -/
 @[reducible]
-def List.Insts.CoreCloneClone {T : Type} (corecloneCloneInst : core.clone.Clone
-  T) : core.clone.Clone (List T) := {
+impl_def List.Insts.CoreCloneClone {T : Type} (corecloneCloneInst :
+  core.clone.Clone T) : core.clone.Clone (List T) := {
   clone := List.Insts.CoreCloneClone.clone corecloneCloneInst
 }
 
 /-- Trait implementation: [derive::{core::marker::StructuralPartialEq for derive::List<T>}]
     Source: 'tests/src/derive.rs', lines 34:16-34:25 -/
 @[reducible]
-def List.Insts.CoreMarkerStructuralPartialEq (T : Type) :
+impl_def List.Insts.CoreMarkerStructuralPartialEq (T : Type) :
   core.marker.StructuralPartialEq (List T) := {
 }
-
-/-- [derive::{core::cmp::PartialEq<derive::List<T>> for derive::List<T>}::ne]:
-    Source: 'tests/src/derive.rs', lines 34:16-34:25
-    Visibility: public -/
-axiom List.Insts.CoreCmpPartialEqList.ne
-  {T : Type} (corecmpPartialEqInst : core.cmp.PartialEq T T) :
-  List T → List T → Result Bool
 
 /-- [derive::{core::cmp::PartialEq<derive::List<T>> for derive::List<T>}::eq]:
     Source: 'tests/src/derive.rs', lines 34:16-34:25
@@ -618,10 +567,9 @@ partial_fixpoint
 /-- Trait implementation: [derive::{core::cmp::PartialEq<derive::List<T>> for derive::List<T>}]
     Source: 'tests/src/derive.rs', lines 34:16-34:25 -/
 @[reducible]
-def List.Insts.CoreCmpPartialEqList {T : Type} (corecmpPartialEqInst :
+impl_def List.Insts.CoreCmpPartialEqList {T : Type} (corecmpPartialEqInst :
   core.cmp.PartialEq T T) : core.cmp.PartialEq (List T) (List T) := {
   eq := List.Insts.CoreCmpPartialEqList.eq corecmpPartialEqInst
-  ne := List.Insts.CoreCmpPartialEqList.ne corecmpPartialEqInst
 }
 
 /-- [derive::{core::cmp::Eq for derive::List<T>}::assert_receiver_is_total_eq]:
@@ -636,7 +584,7 @@ def List.Insts.CoreCmpEq.assert_receiver_is_total_eq
 /-- Trait implementation: [derive::{core::cmp::Eq for derive::List<T>}]
     Source: 'tests/src/derive.rs', lines 34:27-34:29 -/
 @[reducible]
-def List.Insts.CoreCmpEq {T : Type} (corecmpEqInst : core.cmp.Eq T) :
+impl_def List.Insts.CoreCmpEq {T : Type} (corecmpEqInst : core.cmp.Eq T) :
   core.cmp.Eq (List T) := {
   partialEqInst := List.Insts.CoreCmpPartialEqList corecmpEqInst.partialEqInst
   assert_receiver_is_total_eq :=
@@ -667,7 +615,7 @@ def CopyStruct.Insts.CoreCloneClone.clone
 /-- Trait implementation: [derive::{core::clone::Clone for derive::CopyStruct<T>}]
     Source: 'tests/src/derive.rs', lines 41:9-41:14 -/
 @[reducible]
-def CopyStruct.Insts.CoreCloneClone {T : Type} (corecloneCloneInst :
+impl_def CopyStruct.Insts.CoreCloneClone {T : Type} (corecloneCloneInst :
   core.clone.Clone T) : core.clone.Clone (CopyStruct T) := {
   clone := CopyStruct.Insts.CoreCloneClone.clone corecloneCloneInst
 }
@@ -675,7 +623,7 @@ def CopyStruct.Insts.CoreCloneClone {T : Type} (corecloneCloneInst :
 /-- Trait implementation: [derive::{core::marker::Copy for derive::CopyStruct<T>}]
     Source: 'tests/src/derive.rs', lines 41:16-41:20 -/
 @[reducible]
-def CopyStruct.Insts.CoreMarkerCopy {T : Type} (coremarkerCopyInst :
+impl_def CopyStruct.Insts.CoreMarkerCopy {T : Type} (coremarkerCopyInst :
   core.marker.Copy T) : core.marker.Copy (CopyStruct T) := {
   cloneInst := CopyStruct.Insts.CoreCloneClone coremarkerCopyInst.cloneInst
 }
@@ -683,16 +631,9 @@ def CopyStruct.Insts.CoreMarkerCopy {T : Type} (coremarkerCopyInst :
 /-- Trait implementation: [derive::{core::marker::StructuralPartialEq for derive::CopyStruct<T>}]
     Source: 'tests/src/derive.rs', lines 41:22-41:31 -/
 @[reducible]
-def CopyStruct.Insts.CoreMarkerStructuralPartialEq (T : Type) :
+impl_def CopyStruct.Insts.CoreMarkerStructuralPartialEq (T : Type) :
   core.marker.StructuralPartialEq (CopyStruct T) := {
 }
-
-/-- [derive::{core::cmp::PartialEq<derive::CopyStruct<T>> for derive::CopyStruct<T>}::ne]:
-    Source: 'tests/src/derive.rs', lines 41:22-41:31
-    Visibility: public -/
-axiom CopyStruct.Insts.CoreCmpPartialEqCopyStruct.ne
-  {T : Type} (corecmpPartialEqInst : core.cmp.PartialEq T T) :
-  CopyStruct T → CopyStruct T → Result Bool
 
 /-- [derive::{core::cmp::PartialEq<derive::CopyStruct<T>> for derive::CopyStruct<T>}::eq]:
     Source: 'tests/src/derive.rs', lines 41:22-41:31
@@ -716,11 +657,10 @@ def CopyStruct.Insts.CoreCmpPartialEqCopyStruct.eq
 /-- Trait implementation: [derive::{core::cmp::PartialEq<derive::CopyStruct<T>> for derive::CopyStruct<T>}]
     Source: 'tests/src/derive.rs', lines 41:22-41:31 -/
 @[reducible]
-def CopyStruct.Insts.CoreCmpPartialEqCopyStruct {T : Type}
+impl_def CopyStruct.Insts.CoreCmpPartialEqCopyStruct {T : Type}
   (corecmpPartialEqInst : core.cmp.PartialEq T T) : core.cmp.PartialEq
   (CopyStruct T) (CopyStruct T) := {
   eq := CopyStruct.Insts.CoreCmpPartialEqCopyStruct.eq corecmpPartialEqInst
-  ne := CopyStruct.Insts.CoreCmpPartialEqCopyStruct.ne corecmpPartialEqInst
 }
 
 /-- [derive::{core::cmp::Eq for derive::CopyStruct<T>}::assert_receiver_is_total_eq]:
@@ -735,8 +675,8 @@ def CopyStruct.Insts.CoreCmpEq.assert_receiver_is_total_eq
 /-- Trait implementation: [derive::{core::cmp::Eq for derive::CopyStruct<T>}]
     Source: 'tests/src/derive.rs', lines 41:33-41:35 -/
 @[reducible]
-def CopyStruct.Insts.CoreCmpEq {T : Type} (corecmpEqInst : core.cmp.Eq T) :
-  core.cmp.Eq (CopyStruct T) := {
+impl_def CopyStruct.Insts.CoreCmpEq {T : Type} (corecmpEqInst : core.cmp.Eq T)
+  : core.cmp.Eq (CopyStruct T) := {
   partialEqInst := CopyStruct.Insts.CoreCmpPartialEqCopyStruct
     corecmpEqInst.partialEqInst
   assert_receiver_is_total_eq :=
@@ -761,8 +701,8 @@ def CopyStruct.Insts.CoreFmtDebug.fmt
 /-- Trait implementation: [derive::{core::fmt::Debug for derive::CopyStruct<T>}]
     Source: 'tests/src/derive.rs', lines 41:37-41:42 -/
 @[reducible]
-def CopyStruct.Insts.CoreFmtDebug {T : Type} (corefmtDebugInst : core.fmt.Debug
-  T) : core.fmt.Debug (CopyStruct T) := {
+impl_def CopyStruct.Insts.CoreFmtDebug {T : Type} (corefmtDebugInst :
+  core.fmt.Debug T) : core.fmt.Debug (CopyStruct T) := {
   fmt := CopyStruct.Insts.CoreFmtDebug.fmt corefmtDebugInst
 }
 
@@ -784,7 +724,7 @@ def Struct.Insts.CoreCloneClone.clone
 /-- Trait implementation: [derive::{core::clone::Clone for derive::Struct<T>}]
     Source: 'tests/src/derive.rs', lines 49:9-49:14 -/
 @[reducible]
-def Struct.Insts.CoreCloneClone {T : Type} (corecloneCloneInst :
+impl_def Struct.Insts.CoreCloneClone {T : Type} (corecloneCloneInst :
   core.clone.Clone T) : core.clone.Clone (Struct T) := {
   clone := Struct.Insts.CoreCloneClone.clone corecloneCloneInst
 }
@@ -792,16 +732,9 @@ def Struct.Insts.CoreCloneClone {T : Type} (corecloneCloneInst :
 /-- Trait implementation: [derive::{core::marker::StructuralPartialEq for derive::Struct<T>}]
     Source: 'tests/src/derive.rs', lines 49:16-49:25 -/
 @[reducible]
-def Struct.Insts.CoreMarkerStructuralPartialEq (T : Type) :
+impl_def Struct.Insts.CoreMarkerStructuralPartialEq (T : Type) :
   core.marker.StructuralPartialEq (Struct T) := {
 }
-
-/-- [derive::{core::cmp::PartialEq<derive::Struct<T>> for derive::Struct<T>}::ne]:
-    Source: 'tests/src/derive.rs', lines 49:16-49:25
-    Visibility: public -/
-axiom Struct.Insts.CoreCmpPartialEqStruct.ne
-  {T : Type} (corecmpPartialEqInst : core.cmp.PartialEq T T) :
-  Struct T → Struct T → Result Bool
 
 /-- [derive::{core::cmp::PartialEq<derive::Struct<T>> for derive::Struct<T>}::eq]:
     Source: 'tests/src/derive.rs', lines 49:16-49:25
@@ -816,10 +749,9 @@ def Struct.Insts.CoreCmpPartialEqStruct.eq
 /-- Trait implementation: [derive::{core::cmp::PartialEq<derive::Struct<T>> for derive::Struct<T>}]
     Source: 'tests/src/derive.rs', lines 49:16-49:25 -/
 @[reducible]
-def Struct.Insts.CoreCmpPartialEqStruct {T : Type} (corecmpPartialEqInst :
+impl_def Struct.Insts.CoreCmpPartialEqStruct {T : Type} (corecmpPartialEqInst :
   core.cmp.PartialEq T T) : core.cmp.PartialEq (Struct T) (Struct T) := {
   eq := Struct.Insts.CoreCmpPartialEqStruct.eq corecmpPartialEqInst
-  ne := Struct.Insts.CoreCmpPartialEqStruct.ne corecmpPartialEqInst
 }
 
 /-- [derive::{core::cmp::Eq for derive::Struct<T>}::assert_receiver_is_total_eq]:
@@ -834,7 +766,7 @@ def Struct.Insts.CoreCmpEq.assert_receiver_is_total_eq
 /-- Trait implementation: [derive::{core::cmp::Eq for derive::Struct<T>}]
     Source: 'tests/src/derive.rs', lines 49:27-49:29 -/
 @[reducible]
-def Struct.Insts.CoreCmpEq {T : Type} (corecmpEqInst : core.cmp.Eq T) :
+impl_def Struct.Insts.CoreCmpEq {T : Type} (corecmpEqInst : core.cmp.Eq T) :
   core.cmp.Eq (Struct T) := {
   partialEqInst := Struct.Insts.CoreCmpPartialEqStruct
     corecmpEqInst.partialEqInst
@@ -858,8 +790,8 @@ def Struct.Insts.CoreFmtDebug.fmt
 /-- Trait implementation: [derive::{core::fmt::Debug for derive::Struct<T>}]
     Source: 'tests/src/derive.rs', lines 49:31-49:36 -/
 @[reducible]
-def Struct.Insts.CoreFmtDebug {T : Type} (corefmtDebugInst : core.fmt.Debug T)
-  : core.fmt.Debug (Struct T) := {
+impl_def Struct.Insts.CoreFmtDebug {T : Type} (corefmtDebugInst :
+  core.fmt.Debug T) : core.fmt.Debug (Struct T) := {
   fmt := Struct.Insts.CoreFmtDebug.fmt corefmtDebugInst
 }
 
@@ -890,22 +822,17 @@ def Struct6Fields.Insts.CoreCloneClone.clone
 /-- Trait implementation: [derive::{core::clone::Clone for derive::Struct6Fields}]
     Source: 'tests/src/derive.rs', lines 54:9-54:14 -/
 @[reducible]
-def Struct6Fields.Insts.CoreCloneClone : core.clone.Clone Struct6Fields := {
+impl_def Struct6Fields.Insts.CoreCloneClone : core.clone.Clone Struct6Fields
+  := {
   clone := Struct6Fields.Insts.CoreCloneClone.clone
 }
 
 /-- Trait implementation: [derive::{core::marker::StructuralPartialEq for derive::Struct6Fields}]
     Source: 'tests/src/derive.rs', lines 54:16-54:25 -/
 @[reducible]
-def Struct6Fields.Insts.CoreMarkerStructuralPartialEq :
+impl_def Struct6Fields.Insts.CoreMarkerStructuralPartialEq :
   core.marker.StructuralPartialEq Struct6Fields := {
 }
-
-/-- [derive::{core::cmp::PartialEq<derive::Struct6Fields> for derive::Struct6Fields}::ne]:
-    Source: 'tests/src/derive.rs', lines 54:16-54:25
-    Visibility: public -/
-axiom Struct6Fields.Insts.CoreCmpPartialEqStruct6Fields.ne
-  : Struct6Fields → Struct6Fields → Result Bool
 
 /-- [derive::{core::cmp::PartialEq<derive::Struct6Fields> for derive::Struct6Fields}::eq]:
     Source: 'tests/src/derive.rs', lines 54:16-54:25
@@ -930,10 +857,9 @@ def Struct6Fields.Insts.CoreCmpPartialEqStruct6Fields.eq
 /-- Trait implementation: [derive::{core::cmp::PartialEq<derive::Struct6Fields> for derive::Struct6Fields}]
     Source: 'tests/src/derive.rs', lines 54:16-54:25 -/
 @[reducible]
-def Struct6Fields.Insts.CoreCmpPartialEqStruct6Fields : core.cmp.PartialEq
+impl_def Struct6Fields.Insts.CoreCmpPartialEqStruct6Fields : core.cmp.PartialEq
   Struct6Fields Struct6Fields := {
   eq := Struct6Fields.Insts.CoreCmpPartialEqStruct6Fields.eq
-  ne := Struct6Fields.Insts.CoreCmpPartialEqStruct6Fields.ne
 }
 
 /-- [derive::{core::cmp::Eq for derive::Struct6Fields}::assert_receiver_is_total_eq]:
@@ -946,7 +872,7 @@ def Struct6Fields.Insts.CoreCmpEq.assert_receiver_is_total_eq
 /-- Trait implementation: [derive::{core::cmp::Eq for derive::Struct6Fields}]
     Source: 'tests/src/derive.rs', lines 54:27-54:29 -/
 @[reducible]
-def Struct6Fields.Insts.CoreCmpEq : core.cmp.Eq Struct6Fields := {
+impl_def Struct6Fields.Insts.CoreCmpEq : core.cmp.Eq Struct6Fields := {
   partialEqInst := Struct6Fields.Insts.CoreCmpPartialEqStruct6Fields
   assert_receiver_is_total_eq :=
     Struct6Fields.Insts.CoreCmpEq.assert_receiver_is_total_eq
@@ -978,7 +904,7 @@ def Struct6Fields.Insts.CoreFmtDebug.fmt
 /-- Trait implementation: [derive::{core::fmt::Debug for derive::Struct6Fields}]
     Source: 'tests/src/derive.rs', lines 54:31-54:36 -/
 @[reducible]
-def Struct6Fields.Insts.CoreFmtDebug : core.fmt.Debug Struct6Fields := {
+impl_def Struct6Fields.Insts.CoreFmtDebug : core.fmt.Debug Struct6Fields := {
   fmt := Struct6Fields.Insts.CoreFmtDebug.fmt
 }
 

--- a/tests/lean/Discriminant.lean
+++ b/tests/lean/Discriminant.lean
@@ -27,7 +27,7 @@ inductive AlertLevel where
 /-- Trait implementation: [discriminant::{core::marker::StructuralPartialEq for discriminant::AlertLevel}]
     Source: 'tests/src/discriminant.rs', lines 6:9-6:18 -/
 @[reducible]
-def AlertLevel.Insts.CoreMarkerStructuralPartialEq :
+impl_def AlertLevel.Insts.CoreMarkerStructuralPartialEq :
   core.marker.StructuralPartialEq AlertLevel := {
 }
 
@@ -43,8 +43,8 @@ def AlertLevel.Insts.CoreCmpPartialEqAlertLevel.eq
 /-- Trait implementation: [discriminant::{core::cmp::PartialEq<discriminant::AlertLevel> for discriminant::AlertLevel}]
     Source: 'tests/src/discriminant.rs', lines 6:9-6:18 -/
 @[reducible]
-def AlertLevel.Insts.CoreCmpPartialEqAlertLevel : core.cmp.PartialEq AlertLevel
-  AlertLevel := {
+impl_def AlertLevel.Insts.CoreCmpPartialEqAlertLevel : core.cmp.PartialEq
+  AlertLevel AlertLevel := {
   eq := AlertLevel.Insts.CoreCmpPartialEqAlertLevel.eq
 }
 
@@ -59,7 +59,7 @@ inductive AlertLevelU8 where
 /-- Trait implementation: [discriminant::{core::marker::StructuralPartialEq for discriminant::AlertLevelU8}]
     Source: 'tests/src/discriminant.rs', lines 12:9-12:18 -/
 @[reducible]
-def AlertLevelU8.Insts.CoreMarkerStructuralPartialEq :
+impl_def AlertLevelU8.Insts.CoreMarkerStructuralPartialEq :
   core.marker.StructuralPartialEq AlertLevelU8 := {
 }
 
@@ -75,7 +75,7 @@ def AlertLevelU8.Insts.CoreCmpPartialEqAlertLevelU8.eq
 /-- Trait implementation: [discriminant::{core::cmp::PartialEq<discriminant::AlertLevelU8> for discriminant::AlertLevelU8}]
     Source: 'tests/src/discriminant.rs', lines 12:9-12:18 -/
 @[reducible]
-def AlertLevelU8.Insts.CoreCmpPartialEqAlertLevelU8 : core.cmp.PartialEq
+impl_def AlertLevelU8.Insts.CoreCmpPartialEqAlertLevelU8 : core.cmp.PartialEq
   AlertLevelU8 AlertLevelU8 := {
   eq := AlertLevelU8.Insts.CoreCmpPartialEqAlertLevelU8.eq
 }

--- a/tests/lean/Dyn.lean
+++ b/tests/lean/Dyn.lean
@@ -24,7 +24,7 @@ def U32.Insts.DynTrait.get (self : Std.U32) : Result Std.U32 := do
 /-- Trait implementation: [dyn::{dyn::Trait for u32}]
     Source: 'tests/src/dyn.rs', lines 7:0-11:1 -/
 @[reducible]
-def U32.Insts.DynTrait : Trait Std.U32 := {
+impl_def U32.Insts.DynTrait : Trait Std.U32 := {
   get := U32.Insts.DynTrait.get
 }
 
@@ -36,7 +36,7 @@ def Bool.Insts.DynTrait.get (self : Bool) : Result Std.U32 := do
 /-- Trait implementation: [dyn::{dyn::Trait for bool}]
     Source: 'tests/src/dyn.rs', lines 13:0-17:1 -/
 @[reducible]
-def Bool.Insts.DynTrait : Trait Bool := {
+impl_def Bool.Insts.DynTrait : Trait Bool := {
   get := Bool.Insts.DynTrait.get
 }
 
@@ -119,7 +119,7 @@ def dyn_closure.closure.Insts.CoreOpsFunctionFnOnceTupleU32U32.call_once
 /-- Trait implementation: [dyn::dyn_closure::{core::ops::function::FnOnce<(u32), u32> for dyn::dyn_closure::closure<T0>}]
     Source: 'tests/src/dyn.rs', lines 51:12-51:33 -/
 @[reducible]
-def dyn_closure.closure.Insts.CoreOpsFunctionFnOnceTupleU32U32 {T0 : Type}
+impl_def dyn_closure.closure.Insts.CoreOpsFunctionFnOnceTupleU32U32 {T0 : Type}
   (TrivialInst : Trivial T0) : core.ops.function.FnOnce (dyn_closure.closure
   T0) Std.U32 Std.U32 := {
   call_once :=
@@ -130,7 +130,7 @@ def dyn_closure.closure.Insts.CoreOpsFunctionFnOnceTupleU32U32 {T0 : Type}
 /-- Trait implementation: [dyn::dyn_closure::{core::ops::function::FnMut<(u32), u32> for dyn::dyn_closure::closure<T0>}]
     Source: 'tests/src/dyn.rs', lines 51:12-51:33 -/
 @[reducible]
-def dyn_closure.closure.Insts.CoreOpsFunctionFnMutTupleU32U32 {T0 : Type}
+impl_def dyn_closure.closure.Insts.CoreOpsFunctionFnMutTupleU32U32 {T0 : Type}
   (TrivialInst : Trivial T0) : core.ops.function.FnMut (dyn_closure.closure T0)
   Std.U32 Std.U32 := {
   FnOnceInst := dyn_closure.closure.Insts.CoreOpsFunctionFnOnceTupleU32U32
@@ -143,7 +143,7 @@ def dyn_closure.closure.Insts.CoreOpsFunctionFnMutTupleU32U32 {T0 : Type}
 /-- Trait implementation: [dyn::dyn_closure::{core::ops::function::Fn<(u32), u32> for dyn::dyn_closure::closure<T0>}]
     Source: 'tests/src/dyn.rs', lines 51:12-51:33 -/
 @[reducible]
-def dyn_closure.closure.Insts.CoreOpsFunctionFnTupleU32U32 {T0 : Type}
+impl_def dyn_closure.closure.Insts.CoreOpsFunctionFnTupleU32U32 {T0 : Type}
   (TrivialInst : Trivial T0) : core.ops.function.Fn (dyn_closure.closure T0)
   Std.U32 Std.U32 := {
   FnMutInst := dyn_closure.closure.Insts.CoreOpsFunctionFnMutTupleU32U32

--- a/tests/lean/FromTo.lean
+++ b/tests/lean/FromTo.lean
@@ -29,7 +29,7 @@ def U32.Insts.From_toFromU32.from (x : Std.U32) : Result Std.U32 := do
 /-- Trait implementation: [from_to::{from_to::From<u32> for u32}]
     Source: 'tests/src/from_to.rs', lines 13:0-17:1 -/
 @[reducible]
-def U32.Insts.From_toFromU32 : From Std.U32 Std.U32 := {
+impl_def U32.Insts.From_toFromU32 : From Std.U32 Std.U32 := {
   «from» := U32.Insts.From_toFromU32.from
 }
 
@@ -42,7 +42,7 @@ def U32.Insts.From_toTo.to
 /-- Trait implementation: [from_to::{from_to::To for u32}]
     Source: 'tests/src/from_to.rs', lines 19:0-23:1 -/
 @[reducible]
-def U32.Insts.From_toTo : To Std.U32 := {
+impl_def U32.Insts.From_toTo : To Std.U32 := {
   «to» := fun {T : Type} (FromPU32Inst : From T Std.U32) =>
     U32.Insts.From_toTo.to FromPU32Inst
 }

--- a/tests/lean/Hashmap/Funs.lean
+++ b/tests/lean/Hashmap/Funs.lean
@@ -35,7 +35,7 @@ def Fraction.Insts.CoreCloneClone.clone_from
 /-- Trait implementation: [hashmap::{core::clone::Clone for hashmap::Fraction}]
     Source: 'tests/src/hashmap.rs', lines 43:9-43:14 -/
 @[reducible]
-def Fraction.Insts.CoreCloneClone : core.clone.Clone Fraction := {
+impl_def Fraction.Insts.CoreCloneClone : core.clone.Clone Fraction := {
   clone := Fraction.Insts.CoreCloneClone.clone
   clone_from := Fraction.Insts.CoreCloneClone.clone_from
 }
@@ -43,7 +43,7 @@ def Fraction.Insts.CoreCloneClone : core.clone.Clone Fraction := {
 /-- Trait implementation: [hashmap::{core::marker::Copy for hashmap::Fraction}]
     Source: 'tests/src/hashmap.rs', lines 43:16-43:20 -/
 @[reducible]
-def Fraction.Insts.CoreMarkerCopy : core.marker.Copy Fraction := {
+impl_def Fraction.Insts.CoreMarkerCopy : core.marker.Copy Fraction := {
   cloneInst := Fraction.Insts.CoreCloneClone
 }
 

--- a/tests/lean/Issue804ClosureReturnRef.lean
+++ b/tests/lean/Issue804ClosureReturnRef.lean
@@ -49,7 +49,7 @@ def each_ref.closure.Insts.CoreOpsFunctionFnOnceTupleUsizeSharedU8.call_once
 /-- Trait implementation: [issue_804_closure_return_ref::each_ref::{core::ops::function::FnOnce<(usize), &'_ (u8)> for issue_804_closure_return_ref::each_ref::closure<0>}]
     Source: 'tests/src/issue-804-closure-return-ref.rs', lines 6:24-6:33 -/
 @[reducible]
-def each_ref.closure.Insts.CoreOpsFunctionFnOnceTupleUsizeSharedU8 :
+impl_def each_ref.closure.Insts.CoreOpsFunctionFnOnceTupleUsizeSharedU8 :
   core.ops.function.FnOnce each_ref.closure Std.Usize Std.U8 := {
   call_once :=
     each_ref.closure.Insts.CoreOpsFunctionFnOnceTupleUsizeSharedU8.call_once
@@ -58,7 +58,7 @@ def each_ref.closure.Insts.CoreOpsFunctionFnOnceTupleUsizeSharedU8 :
 /-- Trait implementation: [issue_804_closure_return_ref::each_ref::{core::ops::function::FnMut<(usize), &'_ (u8)> for issue_804_closure_return_ref::each_ref::closure<0>}]
     Source: 'tests/src/issue-804-closure-return-ref.rs', lines 6:24-6:33 -/
 @[reducible]
-def each_ref.closure.Insts.CoreOpsFunctionFnMutTupleUsizeSharedU8 :
+impl_def each_ref.closure.Insts.CoreOpsFunctionFnMutTupleUsizeSharedU8 :
   core.ops.function.FnMut each_ref.closure Std.Usize Std.U8 := {
   FnOnceInst := each_ref.closure.Insts.CoreOpsFunctionFnOnceTupleUsizeSharedU8
   call_mut :=

--- a/tests/lean/LoopsIssues.lean
+++ b/tests/lean/LoopsIssues.lean
@@ -44,7 +44,7 @@ axiom I32.Insts.CoreIterRangeStep.steps_between
     Source: '/rustc/library/core/src/iter/range.rs', lines 299:12-299:37
     Name pattern: [core::iter::range::Step<i32>] -/
 @[reducible, rust_trait_impl "core::iter::range::Step<i32>"]
-def I32.Insts.CoreIterRangeStep : core.iter.range.Step Std.I32 := {
+impl_def I32.Insts.CoreIterRangeStep : core.iter.range.Step Std.I32 := {
   cloneInst := core.clone.CloneI32
   partialOrdInst := core.cmp.PartialOrdI32
   steps_between := I32.Insts.CoreIterRangeStep.steps_between

--- a/tests/lean/Order.lean
+++ b/tests/lean/Order.lean
@@ -42,8 +42,8 @@ def Wrap := Std.U64
 /-- Trait implementation: [order::{core::marker::StructuralPartialEq for order::Wrap}]
     Source: 'tests/src/order.rs', lines 21:9-21:18 -/
 @[reducible]
-def Wrap.Insts.CoreMarkerStructuralPartialEq : core.marker.StructuralPartialEq
-  Wrap := {
+impl_def Wrap.Insts.CoreMarkerStructuralPartialEq :
+  core.marker.StructuralPartialEq Wrap := {
 }
 
 /-- [order::{core::cmp::PartialEq<order::Wrap> for order::Wrap}::eq]:
@@ -56,7 +56,7 @@ def Wrap.Insts.CoreCmpPartialEqWrap.eq
 /-- Trait implementation: [order::{core::cmp::PartialEq<order::Wrap> for order::Wrap}]
     Source: 'tests/src/order.rs', lines 21:9-21:18 -/
 @[reducible]
-def Wrap.Insts.CoreCmpPartialEqWrap : core.cmp.PartialEq Wrap Wrap := {
+impl_def Wrap.Insts.CoreCmpPartialEqWrap : core.cmp.PartialEq Wrap Wrap := {
   eq := Wrap.Insts.CoreCmpPartialEqWrap.eq
 }
 
@@ -70,7 +70,7 @@ def Wrap.Insts.CoreCmpEq.assert_receiver_is_total_eq
 /-- Trait implementation: [order::{core::cmp::Eq for order::Wrap}]
     Source: 'tests/src/order.rs', lines 21:20-21:22 -/
 @[reducible]
-def Wrap.Insts.CoreCmpEq : core.cmp.Eq Wrap := {
+impl_def Wrap.Insts.CoreCmpEq : core.cmp.Eq Wrap := {
   partialEqInst := Wrap.Insts.CoreCmpPartialEqWrap
   assert_receiver_is_total_eq :=
     Wrap.Insts.CoreCmpEq.assert_receiver_is_total_eq
@@ -86,7 +86,7 @@ def Wrap.Insts.CoreCmpPartialOrdWrap.partial_cmp
 /-- Trait implementation: [order::{core::cmp::PartialOrd<order::Wrap> for order::Wrap}]
     Source: 'tests/src/order.rs', lines 21:24-21:34 -/
 @[reducible]
-def Wrap.Insts.CoreCmpPartialOrdWrap : core.cmp.PartialOrd Wrap Wrap := {
+impl_def Wrap.Insts.CoreCmpPartialOrdWrap : core.cmp.PartialOrd Wrap Wrap := {
   partialEqInst := Wrap.Insts.CoreCmpPartialEqWrap
   partial_cmp := Wrap.Insts.CoreCmpPartialOrdWrap.partial_cmp
 }
@@ -101,7 +101,7 @@ def Wrap.Insts.CoreCmpOrd.cmp
 /-- Trait implementation: [order::{core::cmp::Ord for order::Wrap}]
     Source: 'tests/src/order.rs', lines 21:36-21:39 -/
 @[reducible]
-def Wrap.Insts.CoreCmpOrd : core.cmp.Ord Wrap := {
+impl_def Wrap.Insts.CoreCmpOrd : core.cmp.Ord Wrap := {
   eqInst := Wrap.Insts.CoreCmpEq
   partialOrdInst := Wrap.Insts.CoreCmpPartialOrdWrap
   cmp := Wrap.Insts.CoreCmpOrd.cmp

--- a/tests/lean/RenameAttribute.lean
+++ b/tests/lean/RenameAttribute.lean
@@ -39,7 +39,7 @@ def BoolImpl.retTest (self : Bool) : Result Bool := do
 /-- Trait implementation: [rename_attribute::{rename_attribute::BoolTrait for bool}]
     Source: 'tests/src/rename_attribute.rs', lines 23:0-27:1 -/
 @[reducible]
-def BoolImpl : BoolTest Bool := {
+impl_def BoolImpl : BoolTest Bool := {
   getTest := BoolImpl.getTest
   retTest := BoolImpl.retTest
 }

--- a/tests/lean/Traits.lean
+++ b/tests/lean/Traits.lean
@@ -39,7 +39,7 @@ def Bool.Insts.TraitsBoolTrait.ret_true (self : Bool) : Result Bool := do
 /-- Trait implementation: [traits::{traits::BoolTrait for bool}]
     Source: 'tests/src/traits.rs', lines 13:0-17:1 -/
 @[reducible]
-def Bool.Insts.TraitsBoolTrait : BoolTrait Bool := {
+impl_def Bool.Insts.TraitsBoolTrait : BoolTrait Bool := {
   get_bool := Bool.Insts.TraitsBoolTrait.get_bool
   ret_true := Bool.Insts.TraitsBoolTrait.ret_true
 }
@@ -72,8 +72,8 @@ def core.option.Option.Insts.TraitsBoolTrait.ret_true
 /-- Trait implementation: [traits::{traits::BoolTrait for core::option::Option<T>}]
     Source: 'tests/src/traits.rs', lines 24:0-31:1 -/
 @[reducible]
-def core.option.Option.Insts.TraitsBoolTrait (T : Type) : BoolTrait (Option T)
-  := {
+impl_def core.option.Option.Insts.TraitsBoolTrait (T : Type) : BoolTrait
+  (Option T) := {
   get_bool := core.option.Option.Insts.TraitsBoolTrait.get_bool
   ret_true := core.option.Option.Insts.TraitsBoolTrait.ret_true
 }
@@ -109,7 +109,7 @@ def U64.Insts.TraitsToU64.to_u64 (self : Std.U64) : Result Std.U64 := do
 /-- Trait implementation: [traits::{traits::ToU64 for u64}]
     Source: 'tests/src/traits.rs', lines 45:0-49:1 -/
 @[reducible]
-def U64.Insts.TraitsToU64 : ToU64 Std.U64 := {
+impl_def U64.Insts.TraitsToU64 : ToU64 Std.U64 := {
   to_u64 := U64.Insts.TraitsToU64.to_u64
 }
 
@@ -126,8 +126,8 @@ def Pair.Insts.TraitsToU64.to_u64
 /-- Trait implementation: [traits::{traits::ToU64 for (A, A)}]
     Source: 'tests/src/traits.rs', lines 51:0-55:1 -/
 @[reducible]
-def Pair.Insts.TraitsToU64 {A : Type} (ToU64Inst : ToU64 A) : ToU64 (A × A)
-  := {
+impl_def Pair.Insts.TraitsToU64 {A : Type} (ToU64Inst : ToU64 A) : ToU64 (A ×
+  A) := {
   to_u64 := Pair.Insts.TraitsToU64.to_u64 ToU64Inst
 }
 
@@ -168,8 +168,8 @@ def Wrapper.Insts.TraitsToU64.to_u64
 /-- Trait implementation: [traits::{traits::ToU64 for traits::Wrapper<T>}]
     Source: 'tests/src/traits.rs', lines 76:0-80:1 -/
 @[reducible]
-def Wrapper.Insts.TraitsToU64 {T : Type} (ToU64Inst : ToU64 T) : ToU64 (Wrapper
-  T) := {
+impl_def Wrapper.Insts.TraitsToU64 {T : Type} (ToU64Inst : ToU64 T) : ToU64
+  (Wrapper T) := {
   to_u64 := Wrapper.Insts.TraitsToU64.to_u64 ToU64Inst
 }
 
@@ -200,7 +200,7 @@ def U64.Insts.TraitsToTypeBool.to_type (self : Std.U64) : Result Bool := do
 /-- Trait implementation: [traits::{traits::ToType<bool> for u64}]
     Source: 'tests/src/traits.rs', lines 94:0-98:1 -/
 @[reducible]
-def U64.Insts.TraitsToTypeBool : ToType Std.U64 Bool := {
+impl_def U64.Insts.TraitsToTypeBool : ToType Std.U64 Bool := {
   to_type := U64.Insts.TraitsToTypeBool.to_type
 }
 
@@ -274,7 +274,7 @@ structure TestType.test.TestTrait (Self : Type) where
 /-- Trait implementation: [traits::{traits::TestType<T>}::test::{traits::{traits::TestType<T>}::test::TestTrait for traits::{traits::TestType<T>}::test::TestType1}]
     Source: 'tests/src/traits.rs', lines 140:8-144:9 -/
 @[reducible]
-def TestType.test.TestType1.Insts.TraitsTestTypeTestTestTrait :
+impl_def TestType.test.TestType1.Insts.TraitsTestTypeTestTestTrait :
   TestType.test.TestTrait TestType.test.TestType1 := {
   test := TestType.test.TestType1.Insts.TraitsTestTypeTestTestTrait.test
 }
@@ -297,8 +297,8 @@ def BoolWrapper.Insts.TraitsToType.to_type
 /-- Trait implementation: [traits::{traits::ToType<T> for traits::BoolWrapper}]
     Source: 'tests/src/traits.rs', lines 154:0-161:1 -/
 @[reducible]
-def BoolWrapper.Insts.TraitsToType {T : Type} (ToTypeBoolTInst : ToType Bool T)
-  : ToType BoolWrapper T := {
+impl_def BoolWrapper.Insts.TraitsToType {T : Type} (ToTypeBoolTInst : ToType
+  Bool T) : ToType BoolWrapper T := {
   to_type := BoolWrapper.Insts.TraitsToType.to_type ToTypeBoolTInst
 }
 
@@ -335,7 +335,7 @@ def Bool.Insts.TraitsWithConstTyU8U6432.LEN1 : Std.Usize := 12#usize
 /-- Trait implementation: [traits::{traits::WithConstTy<u8, u64, 32usize> for bool}]
     Source: 'tests/src/traits.rs', lines 176:0-183:1 -/
 @[reducible]
-def Bool.Insts.TraitsWithConstTyU8U6432 : WithConstTy Bool Std.U8 Std.U64
+impl_def Bool.Insts.TraitsWithConstTyU8U6432 : WithConstTy Bool Std.U8 Std.U64
   32#usize := {
   LEN1 := ok Bool.Insts.TraitsWithConstTyU8U6432.LEN1
   LEN2 := ok (WithConstTy.LEN2.default Bool 32#usize)
@@ -447,13 +447,13 @@ structure ChildTrait1 (Self : Type) where
 /-- Trait implementation: [traits::{traits::ParentTrait1 for usize}]
     Source: 'tests/src/traits.rs', lines 226:0-226:30 -/
 @[reducible]
-def Usize.Insts.TraitsParentTrait1 : ParentTrait1 Std.Usize := {
+impl_def Usize.Insts.TraitsParentTrait1 : ParentTrait1 Std.Usize := {
 }
 
 /-- Trait implementation: [traits::{traits::ChildTrait1 for usize}]
     Source: 'tests/src/traits.rs', lines 227:0-227:29 -/
 @[reducible]
-def Usize.Insts.TraitsChildTrait1 : ChildTrait1 Std.Usize := {
+impl_def Usize.Insts.TraitsChildTrait1 : ChildTrait1 Std.Usize := {
   ParentTrait1Inst := Usize.Insts.TraitsParentTrait1
 }
 
@@ -503,14 +503,14 @@ structure ChildTrait2 (Self : Type) (Self_Clause0_U : Type)
 /-- Trait implementation: [traits::{traits::WithTarget<u32> for u32}]
     Source: 'tests/src/traits.rs', lines 266:0-268:1 -/
 @[reducible]
-def U32.Insts.TraitsWithTargetU32 : WithTarget Std.U32 Std.U32 := {
+impl_def U32.Insts.TraitsWithTargetU32 : WithTarget Std.U32 Std.U32 := {
 }
 
 /-- Trait implementation: [traits::{traits::ParentTrait2<u32, u32> for u32}]
     Source: 'tests/src/traits.rs', lines 270:0-272:1 -/
 @[reducible]
-def U32.Insts.TraitsParentTrait2U32U32 : ParentTrait2 Std.U32 Std.U32 Std.U32
-  := {
+impl_def U32.Insts.TraitsParentTrait2U32U32 : ParentTrait2 Std.U32 Std.U32
+  Std.U32 := {
   WithTargetInst := U32.Insts.TraitsWithTargetU32
 }
 
@@ -524,8 +524,8 @@ def U32.Insts.TraitsChildTrait2U32U32.convert
 /-- Trait implementation: [traits::{traits::ChildTrait2<u32, u32> for u32}]
     Source: 'tests/src/traits.rs', lines 274:0-278:1 -/
 @[reducible]
-def U32.Insts.TraitsChildTrait2U32U32 : ChildTrait2 Std.U32 Std.U32 Std.U32
-  := {
+impl_def U32.Insts.TraitsChildTrait2U32U32 : ChildTrait2 Std.U32 Std.U32
+  Std.U32 := {
   ParentTrait2Inst := U32.Insts.TraitsParentTrait2U32U32
   convert := U32.Insts.TraitsChildTrait2U32U32.convert
 }
@@ -581,7 +581,8 @@ def Array.Insts.TraitsTrait.LEN (T : Type) (N : Std.Usize) : Std.Usize := N
 /-- Trait implementation: [traits::{traits::Trait for [T; N]}]
     Source: 'tests/src/traits.rs', lines 316:0-318:1 -/
 @[reducible]
-def Array.Insts.TraitsTrait (T : Type) (N : Std.Usize) : Trait (Array T N) := {
+impl_def Array.Insts.TraitsTrait (T : Type) (N : Std.Usize) : Trait (Array T N)
+  := {
   LEN := ok (Array.Insts.TraitsTrait.LEN T N)
 }
 
@@ -596,8 +597,8 @@ def Wrapper.Insts.TraitsTrait.LEN {T : Type} (TraitInst : Trait T)
 /-- Trait implementation: [traits::{traits::Trait for traits::Wrapper<T>}]
     Source: 'tests/src/traits.rs', lines 320:0-322:1 -/
 @[reducible]
-def Wrapper.Insts.TraitsTrait {T : Type} (TraitInst : Trait T) : Trait (Wrapper
-  T) := {
+impl_def Wrapper.Insts.TraitsTrait {T : Type} (TraitInst : Trait T) : Trait
+  (Wrapper T) := {
   LEN := ok (Wrapper.Insts.TraitsTrait.LEN TraitInst)
 }
 

--- a/tests/lean/Tutorial/Tutorial.lean
+++ b/tests/lean/Tutorial/Tutorial.lean
@@ -164,7 +164,7 @@ def Usize.Insts.TutorialCounter.incr
 /-- Trait implementation: [tutorial::{tutorial::Counter for usize}]
     Source: 'src/lib.rs', lines 109:0-115:1 -/
 @[reducible]
-def Usize.Insts.TutorialCounter : Counter Std.Usize := {
+impl_def Usize.Insts.TutorialCounter : Counter Std.Usize := {
   incr := Usize.Insts.TutorialCounter.incr
 }
 


### PR DESCRIPTION
This PR implements the `@[trait_default]` + `impl_def` approach for the Lean backend, as proposed in #953.

This PR was cooked by Gemini CLI, take it with a grain of salt.

### Why is this change required?
When Rust derives traits like `PartialOrd` or `Ord`, it only generates bodies for the core methods (e.g., `cmp`). The remaining methods (`lt`, `le`, `gt`, `ge`, etc.) remain opaque in the LLBC. Previously, Aeneas would either generate undesired axioms for these opaque methods or produce broken Lean code with dangling self-references in trait implementation struct literals.

This change provides a robust mechanism to link Rust's default methods to Lean's library implementations, ensuring behavioral correctness without manual axiomatization.

### Important Details:
- **Lean Library Updates**: Marked `.default` methods with `@[trait_default]` and declared `defaultMethods` in trait definitions for `PartialEq`, `Eq`, `PartialOrd`, `Ord`, `Clone`, and `Iterator`.
- **Compiler Enhancements**:
    - Switched all Lean trait implementations from `def` to the `impl_def` elaborator.
    - Updated the extraction logic to omit fields from struct literals when a method is both opaque in LLBC and has a library default in Lean.
    - Updated `Translate.ml` to skip generating separate function definitions (axioms) for these methods.
    - **Edge case handling**: Updated `Extract.lean` to support methods explicitly listed in the `methods` property of the `rust_trait` attribute, even if they aren't struct fields. This allows traits like `Iterator` to define library defaults for methods like `collect` without introducing circular dependencies in Lean.
- **Metadata**: Regenerated `ExtractBuiltinLean.ml` with updated trait metadata.

### Verification:
- All OCaml/Rust tests pass.
- Verified that generated Lean tests (e.g., `Order.lean`, `StringChars.lean`) no longer contain redundant axioms and that the entire suite compiles successfully with `lake build`.
