### PR TITLE
fix: treat RErased regions as non-outliving

### DIFF
--- a/src/llbc/TypesAnalysis.ml
+++ b/src/llbc/TypesAnalysis.ml
@@ -692,7 +692,7 @@ let compute_outlive_proj_ty (span : Meta.span option)
         (* Sanity check *)
         let add =
           match r with
-          | RErased -> [%craise_opt_span] span "Expected a type with regions"
+          | RErased -> false
           | RVar (Free rid) -> RegionId.Set.mem rid regions
           | RVar (Bound _) -> [%craise_opt_span] span "Not handled yet"
           | RStatic -> false


### PR DESCRIPTION
Erased regions do not encode lifetime information, so treating them as not outliving the requested region set should match the intended check.

(Noticed this while experimenting with iterators/zip/slices.)

Edit: See [this](https://github.com/AeneasVerif/aeneas/issues/1053) issue.