### PR TITLE
Add bitwise operators on booleans.

### DIFF
--- a/backends/coq/Primitives.v
+++ b/backends/coq/Primitives.v
@@ -70,6 +70,8 @@ Definition char_of_byte := Coq.Strings.Ascii.ascii_of_byte.
 
 Definition core_mem_replace {a : Type} (x : a) (y : a) : a * a := (x, x) .
 
+Definition bool_xor (a b : bool) : bool := xorb a b.
+
 Record mut_raw_ptr (T : Type) := { mut_raw_ptr_v : T }.
 Record const_raw_ptr (T : Type) := { const_raw_ptr_v : T }.
 

--- a/backends/coq/Primitives.v
+++ b/backends/coq/Primitives.v
@@ -70,6 +70,8 @@ Definition char_of_byte := Coq.Strings.Ascii.ascii_of_byte.
 
 Definition core_mem_replace {a : Type} (x : a) (y : a) : a * a := (x, x) .
 
+Definition bool_and (a b : bool) : bool := andb a b.
+Definition bool_or (a b : bool) : bool := orb a b.
 Definition bool_xor (a b : bool) : bool := xorb a b.
 
 Record mut_raw_ptr (T : Type) := { mut_raw_ptr_v : T }.

--- a/backends/fstar/Primitives.fst
+++ b/backends/fstar/Primitives.fst
@@ -58,6 +58,8 @@ let decrease (n: nat{n > 0}) : nat = n - 1
 
 let core_mem_replace (#a : Type0) (x : a) (y : a) : a & a = (x, x)
 
+let bool_xor (a b : bool) : bool = a <> b
+
 // We don't really use raw pointers for now
 type mut_raw_ptr (t : Type0) = { v : t }
 type const_raw_ptr (t : Type0) = { v : t }

--- a/src/extract/Extract.ml
+++ b/src/extract/Extract.ml
@@ -589,8 +589,8 @@ let extract_binop (span : Meta.span) (ctx : extraction_ctx)
   (* Some binary operations have a special notation depending on the backend *)
   (match (backend (), binop) with
   | HOL4, (Eq _ | Ne _)
-  | (FStar | Coq | Lean), (Eq _ | Lt _ | Le _ | Ne _ | Ge _ | Gt _ | BoolOr)
-  | (FStar | Coq | Lean), BoolAnd
+  | (FStar | Coq | Lean), (Eq _ | Lt _ | Le _ | Ne _ | Ge _ | Gt _)
+  | (FStar | Lean), (BoolAnd | BoolOr)
   | Lean, BoolXor
   | ( Lean,
       ( Div (OPanic, _)
@@ -628,7 +628,6 @@ let extract_binop (span : Meta.span) (ctx : extraction_ctx)
       in
       let binop_str =
         match (backend (), binop) with
-        | Coq, (BoolAnd | BoolOr) -> binop_str
         | Coq, _ -> "s" ^ binop_str
         | _ -> binop_str
       in

--- a/src/extract/Extract.ml
+++ b/src/extract/Extract.ml
@@ -590,6 +590,8 @@ let extract_binop (span : Meta.span) (ctx : extraction_ctx)
   (match (backend (), binop) with
   | HOL4, (Eq _ | Ne _)
   | (FStar | Coq | Lean), (Eq _ | Lt _ | Le _ | Ne _ | Ge _ | Gt _ | BoolOr)
+  | (FStar | Coq | Lean), BoolAnd
+  | Lean, BoolXor
   | ( Lean,
       ( Div (OPanic, _)
       | Rem (OPanic, _)
@@ -617,14 +619,16 @@ let extract_binop (span : Meta.span) (ctx : extraction_ctx)
         | BitXor _ -> "^^^"
         | BitOr _ -> "|||"
         | BitAnd _ -> "&&&"
+        | BoolAnd -> "&&"
         | BoolOr -> "||"
+        | BoolXor -> "^^"
         | _ ->
             [%add_loc] admit_string span
               ("Unimplemented binary operation: " ^ binop_to_string ctx binop)
       in
       let binop_str =
         match (backend (), binop) with
-        | Coq, BoolOr -> binop_str
+        | Coq, (BoolAnd | BoolOr) -> binop_str
         | Coq, _ -> "s" ^ binop_str
         | _ -> binop_str
       in

--- a/src/extract/ExtractBase.ml
+++ b/src/extract/ExtractBase.ml
@@ -954,7 +954,9 @@ let named_binop_name (binop : binop) : string =
   | BitOr ty -> add_int_name ty ^ "or"
   | Shl (_, ty, _) -> add_int_name ty ^ "shl"
   | Shr (_, ty, _) -> add_int_name ty ^ "shr"
+  | BoolAnd -> "bool_and"
   | BoolOr -> "bool_or"
+  | BoolXor -> "bool_xor"
   | _ -> raise (Failure "Unreachable")
 
 let dyn_constructor () = "Dyn.mk" (* TODO: backends other than Lean *)

--- a/src/interp/InterpExpressions.ml
+++ b/src/interp/InterpExpressions.ml
@@ -1008,7 +1008,7 @@ let eval_binary_op_concrete_compute (span : Meta.span) (binop : binop)
        (booleans are ordered: [false < true]). *)
     match (v1.value, v2.value) with
     | VLiteral (VBool b1), VLiteral (VBool b2) -> begin
-        (* Booleans only support the comparison operations *)
+        (* Booleans only support the comparison operations and bitwise operators (&, |, ^) *)
         match binop with
         | Lt | Le | Ge | Gt ->
             let b =
@@ -1017,6 +1017,9 @@ let eval_binary_op_concrete_compute (span : Meta.span) (binop : binop)
               | Le -> (not b1) || b2
               | Ge -> b1 || not b2
               | Gt -> b1 && not b2
+              | BitAnd -> b1 && b2
+              | BitOr -> b1 || b2
+              | BitXor -> b1 <> b2
               | _ -> [%craise] span "Unreachable"
             in
             Ok ({ value = VLiteral (VBool b); ty = TLiteral TBool } : tvalue)
@@ -1124,12 +1127,13 @@ let eval_binary_op_symbolic (config : config) (span : Meta.span) (binop : binop)
         "The type is not primitively copyable";
       TLiteral TBool)
     else
-      (* Other operations: input types are integers, with the exception of the
-         comparison operations which also accept booleans (booleans are ordered:
-         [false < true]). *)
+      (* Other operations: input types can be booleans for comparison operators
+       (booleans are ordered: [false < true]), or bitwise operators (&, |, ^).
+       In the other cases, input types are integers *)
       match (v1.ty, v2.ty) with
       | TLiteral TBool, TLiteral TBool
-        when binop = Lt || binop = Le || binop = Ge || binop = Gt ->
+        when binop = Lt || binop = Le || binop = Ge || binop = Gt
+             || binop = BitAnd || binop = BitOr || binop = BitXor ->
           TLiteral TBool
       | TLiteral lty1, TLiteral lty2
         when literal_type_is_integer lty1 && literal_type_is_integer lty2 -> (

--- a/src/interp/InterpExpressions.ml
+++ b/src/interp/InterpExpressions.ml
@@ -1010,7 +1010,7 @@ let eval_binary_op_concrete_compute (span : Meta.span) (binop : binop)
     | VLiteral (VBool b1), VLiteral (VBool b2) -> begin
         (* Booleans only support the comparison operations and bitwise operators (&, |, ^) *)
         match binop with
-        | Lt | Le | Ge | Gt ->
+        | Lt | Le | Ge | Gt | BitAnd | BitOr | BitXor ->
             let b =
               match binop with
               | Lt -> (not b1) && b2

--- a/src/pure/PrintPure.ml
+++ b/src/pure/PrintPure.ml
@@ -947,7 +947,9 @@ let binop_to_string (env : fmt_env) (binop : binop) =
   | SubChecked int_ty -> "checked.-" ^ int_ty_to_string int_ty
   | MulChecked int_ty -> "checked.*" ^ int_ty_to_string int_ty
   | Cmp int_ty -> "cmp" ^ int_ty_to_string int_ty
+  | BoolAnd -> "&&"
   | BoolOr -> "||"
+  | BoolXor -> "^^"
 
 let fun_or_op_id_to_string (env : fmt_env) (fun_id : fun_or_op_id) : string =
   match fun_id with

--- a/src/pure/Pure.ml
+++ b/src/pure/Pure.ml
@@ -644,12 +644,15 @@ and binop =
   | Shl of overflow_mode * integer_type * integer_type
   | Shr of overflow_mode * integer_type * integer_type
   | Cmp of integer_type
+  | BoolAnd
+      (** Boolean conjunction. Used to translate Rust [a & b] on booleans. *)
   | BoolOr
-      (** This doesn't exist in the MIR because && and || are elaborated to lazy
-          boolean operations. We introduce || in the pure code to be able to
-          reconstruct assertions of the shape [assert!(b0 || b1)]. Note that we
-          do not introduce && because we can translate an [assert! (b0 && b1)]
-          to [assert b0; assert b1]. *)
+      (** Boolean disjunction. Used to translate Rust [a | b] on booleans (see
+          [BoolAnd]), and also introduced by the symbolic-to-pure translation to
+          reconstruct assertions of the shape [assert!(b0 || b1)].
+          [assert!(b0 && b1)] can be translated to [assert b0; assert b1]. *)
+  | BoolXor
+      (** Boolean exclusive-or, used to translate Rust [a ^ b] on booleans. *)
 
 and builtin_impl_data =
   | BuiltinCopy

--- a/src/pure/PureMicroPassesGeneral.ml
+++ b/src/pure/PureMicroPassesGeneral.ml
@@ -691,7 +691,8 @@ let inline_unop unop = not (lift_unop unop)
 (** A helper predicate *)
 let lift_binop (binop : binop) : bool =
   match binop with
-  | Eq _ | Lt _ | Le _ | Ne _ | Ge _ | Gt _ | BoolOr -> false
+  | Eq _ | Lt _ | Le _ | Ne _ | Ge _ | Gt _ | BoolAnd | BoolOr | BoolXor ->
+      false
   | BitXor _
   | BitAnd _
   | BitOr _

--- a/src/pure/PureUtils.ml
+++ b/src/pure/PureUtils.ml
@@ -2743,7 +2743,13 @@ let binop_can_fail : binop -> bool = function
   | Mul (OWrap, _)
   | Shl (OWrap, _, _)
   | Shr (OWrap, _, _)
-  | AddChecked _ | SubChecked _ | MulChecked _ | BoolOr | Cmp _ -> false
+  | AddChecked _
+  | SubChecked _
+  | MulChecked _
+  | BoolAnd
+  | BoolOr
+  | BoolXor
+  | Cmp _ -> false
   | Div _ | Rem _ | Add _ | Sub _ | Mul _ | Shl _ | Shr _ -> true
 
 let mk_bool_not (b : texpr) : texpr =

--- a/src/symbolic/SymbolicToPureExpressions.ml
+++ b/src/symbolic/SymbolicToPureExpressions.ml
@@ -627,9 +627,15 @@ and translate_function_call_aux (call : S.call) (e : S.expr) (ctx : bs_ctx) :
             in
             let binop =
               match binop with
-              | Expressions.BitXor -> BitXor (get_single_int_ty ())
-              | Expressions.BitAnd -> BitAnd (get_single_int_ty ())
-              | Expressions.BitOr -> BitOr (get_single_int_ty ())
+              | Expressions.BitXor ->
+                  if arg0.ty = TLiteral TBool then BoolXor
+                  else BitXor (get_single_int_ty ())
+              | Expressions.BitAnd ->
+                  if arg0.ty = TLiteral TBool then BoolAnd
+                  else BitAnd (get_single_int_ty ())
+              | Expressions.BitOr ->
+                  if arg0.ty = TLiteral TBool then BoolOr
+                  else BitOr (get_single_int_ty ())
               | Expressions.Eq ->
                   [%sanity_check] ctx.span (arg0.ty = arg1.ty);
                   Eq arg0.ty

--- a/tests/coq/arrays/Primitives.v
+++ b/tests/coq/arrays/Primitives.v
@@ -70,6 +70,8 @@ Definition char_of_byte := Coq.Strings.Ascii.ascii_of_byte.
 
 Definition core_mem_replace {a : Type} (x : a) (y : a) : a * a := (x, x) .
 
+Definition bool_xor (a b : bool) : bool := xorb a b.
+
 Record mut_raw_ptr (T : Type) := { mut_raw_ptr_v : T }.
 Record const_raw_ptr (T : Type) := { const_raw_ptr_v : T }.
 

--- a/tests/coq/arrays/Primitives.v
+++ b/tests/coq/arrays/Primitives.v
@@ -70,6 +70,8 @@ Definition char_of_byte := Coq.Strings.Ascii.ascii_of_byte.
 
 Definition core_mem_replace {a : Type} (x : a) (y : a) : a * a := (x, x) .
 
+Definition bool_and (a b : bool) : bool := andb a b.
+Definition bool_or (a b : bool) : bool := orb a b.
 Definition bool_xor (a b : bool) : bool := xorb a b.
 
 Record mut_raw_ptr (T : Type) := { mut_raw_ptr_v : T }.

--- a/tests/coq/demo/Primitives.v
+++ b/tests/coq/demo/Primitives.v
@@ -70,6 +70,8 @@ Definition char_of_byte := Coq.Strings.Ascii.ascii_of_byte.
 
 Definition core_mem_replace {a : Type} (x : a) (y : a) : a * a := (x, x) .
 
+Definition bool_xor (a b : bool) : bool := xorb a b.
+
 Record mut_raw_ptr (T : Type) := { mut_raw_ptr_v : T }.
 Record const_raw_ptr (T : Type) := { const_raw_ptr_v : T }.
 

--- a/tests/coq/demo/Primitives.v
+++ b/tests/coq/demo/Primitives.v
@@ -70,6 +70,8 @@ Definition char_of_byte := Coq.Strings.Ascii.ascii_of_byte.
 
 Definition core_mem_replace {a : Type} (x : a) (y : a) : a * a := (x, x) .
 
+Definition bool_and (a b : bool) : bool := andb a b.
+Definition bool_or (a b : bool) : bool := orb a b.
 Definition bool_xor (a b : bool) : bool := xorb a b.
 
 Record mut_raw_ptr (T : Type) := { mut_raw_ptr_v : T }.

--- a/tests/coq/hashmap/Primitives.v
+++ b/tests/coq/hashmap/Primitives.v
@@ -70,6 +70,8 @@ Definition char_of_byte := Coq.Strings.Ascii.ascii_of_byte.
 
 Definition core_mem_replace {a : Type} (x : a) (y : a) : a * a := (x, x) .
 
+Definition bool_xor (a b : bool) : bool := xorb a b.
+
 Record mut_raw_ptr (T : Type) := { mut_raw_ptr_v : T }.
 Record const_raw_ptr (T : Type) := { const_raw_ptr_v : T }.
 

--- a/tests/coq/hashmap/Primitives.v
+++ b/tests/coq/hashmap/Primitives.v
@@ -70,6 +70,8 @@ Definition char_of_byte := Coq.Strings.Ascii.ascii_of_byte.
 
 Definition core_mem_replace {a : Type} (x : a) (y : a) : a * a := (x, x) .
 
+Definition bool_and (a b : bool) : bool := andb a b.
+Definition bool_or (a b : bool) : bool := orb a b.
 Definition bool_xor (a b : bool) : bool := xorb a b.
 
 Record mut_raw_ptr (T : Type) := { mut_raw_ptr_v : T }.

--- a/tests/coq/misc/Bitwise.v
+++ b/tests/coq/misc/Bitwise.v
@@ -40,4 +40,22 @@ Definition or_u32 (a : u32) (b : u32) : result u32 :=
 Definition and_u32 (a : u32) (b : u32) : result u32 :=
   Ok (u32_and a b).
 
+(** [bitwise::and_bool]:
+    Source: 'tests/src/bitwise.rs', lines 30:0-32:1
+    Visibility: public *)
+Definition and_bool (a : bool) (b : bool) : result bool :=
+  Ok (a && b).
+
+(** [bitwise::or_bool]:
+    Source: 'tests/src/bitwise.rs', lines 34:0-36:1
+    Visibility: public *)
+Definition or_bool (a : bool) (b : bool) : result bool :=
+  Ok (a || b).
+
+(** [bitwise::xor_bool]:
+    Source: 'tests/src/bitwise.rs', lines 38:0-40:1
+    Visibility: public *)
+Definition xor_bool (a : bool) (b : bool) : result bool :=
+  Ok (bool_xor a b).
+
 End Bitwise.

--- a/tests/coq/misc/Bitwise.v
+++ b/tests/coq/misc/Bitwise.v
@@ -44,13 +44,13 @@ Definition and_u32 (a : u32) (b : u32) : result u32 :=
     Source: 'tests/src/bitwise.rs', lines 30:0-32:1
     Visibility: public *)
 Definition and_bool (a : bool) (b : bool) : result bool :=
-  Ok (a && b).
+  Ok (bool_and a b).
 
 (** [bitwise::or_bool]:
     Source: 'tests/src/bitwise.rs', lines 34:0-36:1
     Visibility: public *)
 Definition or_bool (a : bool) (b : bool) : result bool :=
-  Ok (a || b).
+  Ok (bool_or a b).
 
 (** [bitwise::xor_bool]:
     Source: 'tests/src/bitwise.rs', lines 38:0-40:1

--- a/tests/coq/misc/Primitives.v
+++ b/tests/coq/misc/Primitives.v
@@ -70,6 +70,8 @@ Definition char_of_byte := Coq.Strings.Ascii.ascii_of_byte.
 
 Definition core_mem_replace {a : Type} (x : a) (y : a) : a * a := (x, x) .
 
+Definition bool_xor (a b : bool) : bool := xorb a b.
+
 Record mut_raw_ptr (T : Type) := { mut_raw_ptr_v : T }.
 Record const_raw_ptr (T : Type) := { const_raw_ptr_v : T }.
 

--- a/tests/coq/misc/Primitives.v
+++ b/tests/coq/misc/Primitives.v
@@ -70,6 +70,8 @@ Definition char_of_byte := Coq.Strings.Ascii.ascii_of_byte.
 
 Definition core_mem_replace {a : Type} (x : a) (y : a) : a * a := (x, x) .
 
+Definition bool_and (a b : bool) : bool := andb a b.
+Definition bool_or (a b : bool) : bool := orb a b.
 Definition bool_xor (a b : bool) : bool := xorb a b.
 
 Record mut_raw_ptr (T : Type) := { mut_raw_ptr_v : T }.

--- a/tests/fstar/arrays/Primitives.fst
+++ b/tests/fstar/arrays/Primitives.fst
@@ -58,6 +58,8 @@ let decrease (n: nat{n > 0}) : nat = n - 1
 
 let core_mem_replace (#a : Type0) (x : a) (y : a) : a & a = (x, x)
 
+let bool_xor (a b : bool) : bool = a <> b
+
 // We don't really use raw pointers for now
 type mut_raw_ptr (t : Type0) = { v : t }
 type const_raw_ptr (t : Type0) = { v : t }

--- a/tests/fstar/demo/Primitives.fst
+++ b/tests/fstar/demo/Primitives.fst
@@ -58,6 +58,8 @@ let decrease (n: nat{n > 0}) : nat = n - 1
 
 let core_mem_replace (#a : Type0) (x : a) (y : a) : a & a = (x, x)
 
+let bool_xor (a b : bool) : bool = a <> b
+
 // We don't really use raw pointers for now
 type mut_raw_ptr (t : Type0) = { v : t }
 type const_raw_ptr (t : Type0) = { v : t }

--- a/tests/fstar/hashmap/Primitives.fst
+++ b/tests/fstar/hashmap/Primitives.fst
@@ -58,6 +58,8 @@ let decrease (n: nat{n > 0}) : nat = n - 1
 
 let core_mem_replace (#a : Type0) (x : a) (y : a) : a & a = (x, x)
 
+let bool_xor (a b : bool) : bool = a <> b
+
 // We don't really use raw pointers for now
 type mut_raw_ptr (t : Type0) = { v : t }
 type const_raw_ptr (t : Type0) = { v : t }

--- a/tests/fstar/misc/Bitwise.fst
+++ b/tests/fstar/misc/Bitwise.fst
@@ -35,3 +35,21 @@ let or_u32 (a : u32) (b : u32) : result u32 =
 let and_u32 (a : u32) (b : u32) : result u32 =
   Ok (u32_and a b)
 
+(** [bitwise::and_bool]:
+    Source: 'tests/src/bitwise.rs', lines 30:0-32:1
+    Visibility: public *)
+let and_bool (a : bool) (b : bool) : result bool =
+  Ok (a && b)
+
+(** [bitwise::or_bool]:
+    Source: 'tests/src/bitwise.rs', lines 34:0-36:1
+    Visibility: public *)
+let or_bool (a : bool) (b : bool) : result bool =
+  Ok (a || b)
+
+(** [bitwise::xor_bool]:
+    Source: 'tests/src/bitwise.rs', lines 38:0-40:1
+    Visibility: public *)
+let xor_bool (a : bool) (b : bool) : result bool =
+  Ok (bool_xor a b)
+

--- a/tests/fstar/misc/Primitives.fst
+++ b/tests/fstar/misc/Primitives.fst
@@ -58,6 +58,8 @@ let decrease (n: nat{n > 0}) : nat = n - 1
 
 let core_mem_replace (#a : Type0) (x : a) (y : a) : a & a = (x, x)
 
+let bool_xor (a b : bool) : bool = a <> b
+
 // We don't really use raw pointers for now
 type mut_raw_ptr (t : Type0) = { v : t }
 type const_raw_ptr (t : Type0) = { v : t }

--- a/tests/lean/Bitwise.lean
+++ b/tests/lean/Bitwise.lean
@@ -46,4 +46,22 @@ def or_u32 (a : Std.U32) (b : Std.U32) : Result Std.U32 := do
 def and_u32 (a : Std.U32) (b : Std.U32) : Result Std.U32 := do
   ok (a &&& b)
 
+/-- [bitwise::and_bool]:
+    Source: 'tests/src/bitwise.rs', lines 30:0-32:1
+    Visibility: public -/
+def and_bool (a : Bool) (b : Bool) : Result Bool := do
+  ok (a && b)
+
+/-- [bitwise::or_bool]:
+    Source: 'tests/src/bitwise.rs', lines 34:0-36:1
+    Visibility: public -/
+def or_bool (a : Bool) (b : Bool) : Result Bool := do
+  ok (a || b)
+
+/-- [bitwise::xor_bool]:
+    Source: 'tests/src/bitwise.rs', lines 38:0-40:1
+    Visibility: public -/
+def xor_bool (a : Bool) (b : Bool) : Result Bool := do
+  ok (a ^^ b)
+
 end bitwise

--- a/tests/src/bitwise.rs
+++ b/tests/src/bitwise.rs
@@ -26,3 +26,15 @@ pub fn or_u32(a: u32, b: u32) -> u32 {
 pub fn and_u32(a: u32, b: u32) -> u32 {
     a & b
 }
+
+pub fn and_bool(a: bool, b: bool) -> bool {
+    a & b
+}
+
+pub fn or_bool(a: bool, b: bool) -> bool {
+    a | b
+}
+
+pub fn xor_bool(a: bool, b: bool) -> bool {
+    a ^ b
+}


### PR DESCRIPTION
Fixes https://github.com/AeneasVerif/aeneas/issues/965

Adds support for bitwise operators on booleans (`&`, `|`, `^`). Their semantics is different than regular boolean `&&` and `||` as they are not short-circuiting. This is why we need to introduce some nodes in the pure AST for `BoolAnd` and `BoolXor` (`BoolOr` already exists as it can be produced by the translation).