### PR TITLE
Core models option

### DIFF
--- a/src/Config.ml
+++ b/src/Config.ml
@@ -595,3 +595,14 @@ let max_recdepth = ref 2048
 (** If [false], evaluate [drop(p)] as [p := bottom]. Otherwise, evaluate it as a
     no-op (which means that we do not borrow-check the drops). *)
 let drop_as_no_op = ref true
+
+(** For Lean only: disable the Rust core library overrides defined in
+    [ExtractBuiltinLean.ml].
+
+    With this flag, references to items such as [core::clone::Clone<[T; N]>]
+    are extracted using the standard name-mangling scheme rather than the
+    hand-tuned names like [core.array.CloneArray.clone], and the associated
+    shape overrides ([keep_params], [can_fail], etc.) are ignored. This is
+    useful when extracting against a separate Lean library that mirrors the
+    Rust core API under the standard names. *)
+let core_models_lib = ref false

--- a/src/Main.ml
+++ b/src/Main.ml
@@ -208,6 +208,14 @@ let () =
          collisions with field projectors. Example: the `len` method in `impl \
          Struct { fn len(&self) -> usize { ... } }` would be named \
          `Struct.impl.len`." );
+      ( "-core-models-lib",
+        Arg.Set core_models_lib,
+        " For Lean: disable the Rust core library overrides from \
+         ExtractBuiltinLean.ml. Items like the `Clone` impl for arrays are \
+         extracted using the standard name-mangling scheme rather than \
+         hand-tuned names such as `core.array.CloneArray.clone`, and the \
+         associated shape overrides (keep_params, can_fail, etc.) are \
+         ignored." );
       ( "-all-computable",
         Arg.Set all_computable,
         " For Lean: do not insert `noncomputable section` at the top of the \
@@ -454,6 +462,9 @@ let () =
   if !lean_gen_lakefile && not (backend () = Lean) then
     fail_with_error
       "The -lean-default-lakefile option is valid only for the Lean backend";
+  if !core_models_lib && not (backend () = Lean) then
+    fail_with_error
+      "The -core-models-lib option is valid only for the Lean backend";
   if !set_max_heartbeats && not (backend () = Lean) then
     fail_with_error
       "The -max-heartbeats option is valid only for the Lean backend";

--- a/src/Translate.ml
+++ b/src/Translate.ml
@@ -1306,6 +1306,8 @@ let extract_file (config : gen_config) (ctx : gen_ctx) (fi : extract_file_info)
       Printf.fprintf out "Module %s.\n" fi.module_name
   | Lean ->
       Printf.fprintf out "import Aeneas\n";
+      if !Config.core_models_lib then
+        Printf.fprintf out "import CoreModels\n";
       (* Add the custom imports *)
       List.iter (fun m -> Printf.fprintf out "import %s\n" m) fi.custom_imports;
       (* Add the custom includes *)

--- a/src/Translate.ml
+++ b/src/Translate.ml
@@ -13,6 +13,12 @@ open Parallel
 (** The local logger *)
 let log = TranslateCore.log
 
+(** When [-core-models-lib] is on, non-local items are skipped from the main
+    extracted files (the user is expected to provide them via a separate
+    Lean library, e.g. [core_models] for [core::*] items). *)
+let skip_for_core_models_lib (is_local : bool) : bool =
+  !Config.core_models_lib && not is_local
+
 (** The result of running the symbolic interpreter on a function:
     - the list of symbolic values used for the input values
     - the generated symbolic AST *)
@@ -707,6 +713,12 @@ let export_types_group (fmt : Format.formatter) (config : gen_config)
   if List.exists (fun b -> b) builtin then
     (* Sanity check *)
     assert (List.for_all (fun b -> b) builtin)
+  else if
+    List.exists
+      (fun (d : Pure.type_decl) ->
+        skip_for_core_models_lib d.item_meta.is_local)
+      defs
+  then ()
   else if List.exists dont_extract defs then
     (* Check if we have to ignore declarations *)
     (* Sanity check *)
@@ -784,6 +796,7 @@ let export_global (fmt : Format.formatter) (config : gen_config) (ctx : gen_ctx)
     && match_name_find_opt ctx.trans_ctx global.item_meta.name
          (builtin_globals_map ())
        = None
+    && not (skip_for_core_models_lib global.item_meta.is_local)
   in
   if extract then
     (* We don't wrap global declaration groups between calls to functions
@@ -911,6 +924,12 @@ let export_functions_group (fmt : Format.formatter) (config : gen_config)
   if List.exists (fun b -> b) builtin then
     (* Sanity check *)
     assert (List.for_all (fun b -> b) builtin)
+  else if
+    List.exists
+      (fun (trans : pure_fun_translation) ->
+        skip_for_core_models_lib trans.f.item_meta.is_local)
+      pure_ls
+  then ()
   else
     (* Utility to check a function has a decrease clause *)
     let has_decreases_clause (def : Pure.fun_decl) : bool =
@@ -1014,7 +1033,10 @@ let export_trait_decl (fmt : Format.formatter) (_config : gen_config)
       (TraitDeclId.Map.find_opt trait_decl_id ctx.trans_trait_decls)
   in
   (* Check if the trait declaration is builtin, in which case we ignore it *)
-  if not (trait_decl_is_builtin ctx trait_decl_id) then (
+  if
+    (not (trait_decl_is_builtin ctx trait_decl_id))
+    && not (skip_for_core_models_lib trait_decl.item_meta.is_local)
+  then (
     let ctx = { ctx with trait_decl_id = Some trait_decl.def_id } in
     if extract_decl then Extract.extract_trait_decl ctx fmt trait_decl;
     if extract_extra_info then
@@ -1030,8 +1052,10 @@ let export_trait_impl (fmt : Format.formatter) (_config : gen_config)
     [%silent_unwrap_opt_span] None
       (TraitImplId.Map.find_opt trait_impl_id ctx.trans_trait_impls)
   in
-  if not (trait_impl_is_builtin ctx trait_impl_id) then
-    Extract.extract_trait_impl ctx fmt ~is_rec trait_impl
+  if
+    (not (trait_impl_is_builtin ctx trait_impl_id))
+    && not (skip_for_core_models_lib trait_impl.item_meta.is_local)
+  then Extract.extract_trait_impl ctx fmt ~is_rec trait_impl
 
 (** A generic utility to generate the extracted definitions: as we may want to
     split the definitions between different files (or not), we can control what

--- a/src/extract/ExtractBase.ml
+++ b/src/extract/ExtractBase.ml
@@ -1873,8 +1873,29 @@ let ctx_compute_trait_impl_name_raw (ctx : extraction_ctx)
             in
             [%ldebug "trait_name: " ^ trait_name];
 
-            (* Put together *)
-            let name = flatten_name [ self_name; "Insts"; trait_name ] in
+            (* Put together. Under [-core-models-lib], non-local trait impls
+               get prefixed with the Rust crate they originate from (matching
+               the convention used for non-impl items, where the crate is the
+               leading namespace component). For local impls, the local crate
+               is stripped, as elsewhere. We also skip the prefix if the self
+               type's name already starts with that crate (the ADT case),
+               which would otherwise yield a duplicated crate component. *)
+            let name_parts = [ self_name; "Insts"; trait_name ] in
+            let name_parts =
+              if !core_models_lib && not trait_impl.item_meta.is_local then
+                match trait_impl.item_meta.name with
+                | PeIdent (crate, _) :: _ ->
+                    let crate = rewrite_crate_for_core_models_lib crate in
+                    let already_prefixed =
+                      self_name = crate
+                      || String.starts_with ~prefix:(crate ^ ".") self_name
+                    in
+                    if already_prefixed then name_parts
+                    else crate :: name_parts
+                | _ -> name_parts
+              else name_parts
+            in
+            let name = flatten_name name_parts in
             [%ldebug "Final name: " ^ name];
             name)
   | Some name -> name

--- a/src/extract/ExtractBuiltin.ml
+++ b/src/extract/ExtractBuiltin.ml
@@ -43,7 +43,7 @@ let builtin_globals () : Pure.builtin_global_info list =
          unit_metadata;
        ];
      ]
-    @ mk_lean_only lean_builtin_consts)
+    @ mk_lean_only_unless_core_models_lib lean_builtin_consts)
 
 let mk_builtin_globals_map () : Pure.builtin_global_info NameMatcherMap.t =
   NameMatcherMap.of_list
@@ -170,7 +170,7 @@ let builtin_types () : Pure.builtin_type_info list =
                   ]);
          };
        ])
-  @ mk_lean_only lean_builtin_types
+  @ mk_lean_only_unless_core_models_lib lean_builtin_types
 
 let mk_builtin_types_map () =
   NameMatcherMap.of_list
@@ -324,7 +324,7 @@ let builtin_trait_decls_info () =
       (* Copy *)
       mk_trait "core::marker::Copy" ~parent_clauses:[ "cloneInst" ] ();
     ]
-  @ mk_lean_only lean_builtin_trait_decls
+  @ mk_lean_only_unless_core_models_lib lean_builtin_trait_decls
 
 let mk_builtin_trait_decls_map () =
   NameMatcherMap.of_list
@@ -420,90 +420,93 @@ let builtin_trait_impls_info () : (pattern * Pure.builtin_trait_impl_info) list
       fmt "core::clone::Clone<bool>"
         ~extract_name:(Some "core::clone::CloneBool") ();
     ]
-  @ mk_lean_only lean_builtin_trait_impls
-  (* From<INT, bool> *)
-  @ List.map
-      (fun ty ->
-        fmt
-          ("core::convert::From<" ^ ty ^ ", bool>")
-          ~extract_name:
-            (Some
-               ("core.convert.From"
-               ^ StringUtils.capitalize_first_letter ty
-               ^ "Bool"))
-          ())
-      all_int_names
-  (* From<INT, INT> *)
-  @ List.map
-      (fun (big, small) ->
-        fmt
-          ("core::convert::From<" ^ big ^ ", " ^ small ^ ">")
-          ~extract_name:
-            (Some
-               ("core.convert.From"
-               ^ StringUtils.capitalize_first_letter big
-               ^ StringUtils.capitalize_first_letter small))
-          ())
-      int_and_smaller_list
-  (* Clone<INT> *)
-  @ List.map
-      (fun ty ->
-        fmt
-          ("core::clone::Clone<" ^ ty ^ ">")
-          ~extract_name:
-            (Some ("core.clone.Clone" ^ StringUtils.capitalize_first_letter ty))
-          ())
-      all_int_names
-  (* Copy<INT> *)
-  @ List.map
-      (fun ty ->
-        fmt
-          ("core::marker::Copy<" ^ ty ^ ">")
-          ~extract_name:
-            (Some ("core.marker.Copy" ^ StringUtils.capitalize_first_letter ty))
-          ())
-      all_int_names
-  (* PartialEq<INT, INT> *)
-  @ List.map
-      (fun ty ->
-        fmt
-          ("core::cmp::PartialEq<" ^ ty ^ "," ^ ty ^ ">")
-          ~extract_name:
-            (Some ("core.cmp.PartialEq" ^ StringUtils.capitalize_first_letter ty))
-          ())
-      all_int_names
-  (* Eq<INT> *)
-  @ List.map
-      (fun ty ->
-        fmt
-          ("core::cmp::Eq<" ^ ty ^ ">")
-          ~extract_name:
-            (Some ("core.cmp.Eq" ^ StringUtils.capitalize_first_letter ty))
-          ())
-      all_int_names
-  (* PartialOrd<INT, INT> *)
-  @ List.map
-      (fun ty ->
-        fmt
-          ("core::cmp::PartialOrd<" ^ ty ^ "," ^ ty ^ ">")
-          ~extract_name:
-            (Some
-               ("core.cmp.PartialOrd" ^ StringUtils.capitalize_first_letter ty))
-          ())
-      all_int_names
-  (* Ord<INT> *)
-  @ List.map
-      (fun ty ->
-        fmt
-          ("core::cmp::Ord<" ^ ty ^ ">")
-          ~extract_name:
-            (Some ("core.cmp.Ord" ^ StringUtils.capitalize_first_letter ty))
-          ())
-      all_int_names
-  (* Default<INT> *)
-  @ List.map
-      (fun ty -> fmt ("core::default::Default<" ^ ty ^ ">") ())
-      all_int_names
+  @ mk_lean_only_unless_core_models_lib lean_builtin_trait_impls
+  @ unless_core_models_lib
+      ((* From<INT, bool> *)
+       List.map
+         (fun ty ->
+           fmt
+             ("core::convert::From<" ^ ty ^ ", bool>")
+             ~extract_name:
+               (Some
+                  ("core.convert.From"
+                  ^ StringUtils.capitalize_first_letter ty
+                  ^ "Bool"))
+             ())
+         all_int_names
+      (* From<INT, INT> *)
+      @ List.map
+          (fun (big, small) ->
+            fmt
+              ("core::convert::From<" ^ big ^ ", " ^ small ^ ">")
+              ~extract_name:
+                (Some
+                   ("core.convert.From"
+                   ^ StringUtils.capitalize_first_letter big
+                   ^ StringUtils.capitalize_first_letter small))
+              ())
+          int_and_smaller_list
+      (* Clone<INT> *)
+      @ List.map
+          (fun ty ->
+            fmt
+              ("core::clone::Clone<" ^ ty ^ ">")
+              ~extract_name:
+                (Some ("core.clone.Clone" ^ StringUtils.capitalize_first_letter ty))
+              ())
+          all_int_names
+      (* Copy<INT> *)
+      @ List.map
+          (fun ty ->
+            fmt
+              ("core::marker::Copy<" ^ ty ^ ">")
+              ~extract_name:
+                (Some ("core.marker.Copy" ^ StringUtils.capitalize_first_letter ty))
+              ())
+          all_int_names
+      (* PartialEq<INT, INT> *)
+      @ List.map
+          (fun ty ->
+            fmt
+              ("core::cmp::PartialEq<" ^ ty ^ "," ^ ty ^ ">")
+              ~extract_name:
+                (Some
+                   ("core.cmp.PartialEq" ^ StringUtils.capitalize_first_letter ty))
+              ())
+          all_int_names
+      (* Eq<INT> *)
+      @ List.map
+          (fun ty ->
+            fmt
+              ("core::cmp::Eq<" ^ ty ^ ">")
+              ~extract_name:
+                (Some ("core.cmp.Eq" ^ StringUtils.capitalize_first_letter ty))
+              ())
+          all_int_names
+      (* PartialOrd<INT, INT> *)
+      @ List.map
+          (fun ty ->
+            fmt
+              ("core::cmp::PartialOrd<" ^ ty ^ "," ^ ty ^ ">")
+              ~extract_name:
+                (Some
+                   ("core.cmp.PartialOrd"
+                   ^ StringUtils.capitalize_first_letter ty))
+              ())
+          all_int_names
+      (* Ord<INT> *)
+      @ List.map
+          (fun ty ->
+            fmt
+              ("core::cmp::Ord<" ^ ty ^ ">")
+              ~extract_name:
+                (Some ("core.cmp.Ord" ^ StringUtils.capitalize_first_letter ty))
+              ())
+          all_int_names
+      (* Default<INT> *)
+      @ List.map
+          (fun ty -> fmt ("core::default::Default<" ^ ty ^ ">") ())
+          all_int_names)
 
 let mk_builtin_trait_impls_map () =
   let m = NameMatcherMap.of_list (builtin_trait_impls_info ()) in
@@ -583,14 +586,16 @@ let mk_builtin_funs () : (pattern * Pure.builtin_fun_info) list =
              funs)
          all_int_names)
   in
-  List.flatten
-    (List.map
-       (fun op ->
-         mk_scalar_fun
-           (fun ty -> "core::num::{" ^ ty ^ "}::checked_" ^ op)
-           (fun ty -> StringUtils.capitalize_first_letter ty ^ ".checked_" ^ op)
-           ~can_fail:false ())
-       [ "add"; "sub"; "mul"; "div"; "rem" ])
+  unless_core_models_lib
+    (List.flatten
+       (List.map
+          (fun op ->
+            mk_scalar_fun
+              (fun ty -> "core::num::{" ^ ty ^ "}::checked_" ^ op)
+              (fun ty ->
+                StringUtils.capitalize_first_letter ty ^ ".checked_" ^ op)
+              ~can_fail:false ())
+          [ "add"; "sub"; "mul"; "div"; "rem" ])
   (* From<INT, bool> *)
   @ mk_scalar_fun
       (fun ty ->
@@ -657,7 +662,7 @@ let mk_builtin_funs () : (pattern * Pure.builtin_fun_info) list =
         "core.clone.impls.Clone"
         ^ StringUtils.capitalize_first_letter ty
         ^ "." ^ fn)
-      [ (false, "clone"); (false, "clone_from") ]
+      [ (false, "clone"); (false, "clone_from") ])
   (* Definitions not for Lean *)
   @ mk_not_lean
       [
@@ -795,7 +800,7 @@ let mk_builtin_funs () : (pattern * Pure.builtin_fun_info) list =
           ();
       ]
   (* Lean-only definitions *)
-  @ mk_lean_only
+  @ mk_lean_only_unless_core_models_lib
       ((* PartialEq, Eq, PartialOrd, Ord *)
        mk_scalar_funs
          (fun ty fun_name ->

--- a/src/extract/ExtractBuiltinCore.ml
+++ b/src/extract/ExtractBuiltinCore.ml
@@ -39,6 +39,26 @@ let mk_lean_only (funs : 'a list) : 'a list =
   | Lean -> funs
   | _ -> []
 
+(** Like [mk_lean_only], but additionally returns [[]] when the
+    [-core-models-lib] CLI option is on. Used to disable the Rust core library
+    overrides defined in [ExtractBuiltinLean.ml] (both the hand-tuned extract
+    names and the associated shape overrides such as [keep_params] and
+    [can_fail]). *)
+let mk_lean_only_unless_core_models_lib (funs : 'a list) : 'a list =
+  match backend () with
+  | Lean -> if !core_models_lib then [] else funs
+  | _ -> []
+
+(** Returns [[]] when the [-core-models-lib] CLI option is on, otherwise
+    returns the input list unchanged. Used to disable Rust core library
+    overrides that produce hand-tuned, Lean-style flat names (e.g.
+    [core.convert.num.FromU16U8.from]) and the associated shape overrides
+    (e.g. [~can_fail:false]) for sections that are otherwise applied to all
+    backends. The flag is rejected on non-Lean backends, so this only ever
+    affects Lean. *)
+let unless_core_models_lib (funs : 'a list) : 'a list =
+  if !core_models_lib then [] else funs
+
 let mk_not_lean (funs : 'a list) : 'a list =
   match backend () with
   | Lean -> []

--- a/src/extract/ExtractName.ml
+++ b/src/extract/ExtractName.ml
@@ -113,6 +113,12 @@ let pattern_to_extract_name_visitor =
       else super#visit_EPrimAdt () adt g
   end
 
+(** Under [-core-models-lib], the [core] Rust crate is renamed to [core_models]
+    in extracted names so that the user's [core_models] Lean library is
+    referenced instead of Aeneas's standard library. *)
+let rewrite_crate_for_core_models_lib (crate : string) : string =
+  if !Config.core_models_lib && crate = "core" then "core_models" else crate
+
 (** Helper to convert name patterns to names for extraction.
 
     For impl blocks, we simply use the name of the type (without its arguments)
@@ -124,8 +130,8 @@ let pattern_to_extract_name (_span : Meta.span option) (name : pattern) :
   let name = visitor#visit_pattern () name in
   let names = List.map (pattern_elem_to_string c) name in
   match names with
-  | "core" :: rest when !Config.core_models_lib -> "core_models" :: rest
-  | _ -> names
+  | head :: rest -> rewrite_crate_for_core_models_lib head :: rest
+  | [] -> []
 
 let name_matcher_expr_to_extract_name (_span : Meta.span option) (name : expr) :
     string =

--- a/src/extract/ExtractName.ml
+++ b/src/extract/ExtractName.ml
@@ -122,7 +122,10 @@ let pattern_to_extract_name (_span : Meta.span option) (name : pattern) :
   let c = { tgt = TkName } in
   let visitor = pattern_to_extract_name_visitor in
   let name = visitor#visit_pattern () name in
-  List.map (pattern_elem_to_string c) name
+  let names = List.map (pattern_elem_to_string c) name in
+  match names with
+  | "core" :: rest when !Config.core_models_lib -> "core_models" :: rest
+  | _ -> names
 
 let name_matcher_expr_to_extract_name (_span : Meta.span option) (name : expr) :
     string =


### PR DESCRIPTION
Adds option for using the core-models library (provided by hax). When the cli flag is added, names for some items in the core library will be produced following the same conventions as other items (by default aeneas changes the conventions to match what is in the lean library). This allows compatibility with the core models library which is extracted from Rust using Aeneas.