### PR TITLE
Add AtomicU8 and AtomicU64 as builtin external types

### DIFF
--- a/backends/lean/Aeneas/Std/Core/Atomic.lean
+++ b/backends/lean/Aeneas/Std/Core/Atomic.lean
@@ -2,12 +2,16 @@ import Aeneas.Extract
 
 namespace Aeneas.Std
 
--- TODO
 @[rust_type "core::sync::atomic::AtomicBool"]
 axiom core.sync.atomic.AtomicBool : Type
 
--- TODO
+@[rust_type "core::sync::atomic::AtomicU8"]
+axiom core.sync.atomic.AtomicU8 : Type
+
 @[rust_type "core::sync::atomic::AtomicU32"]
 axiom core.sync.atomic.AtomicU32 : Type
+
+@[rust_type "core::sync::atomic::AtomicU64"]
+axiom core.sync.atomic.AtomicU64 : Type
 
 end Aeneas.Std

--- a/src/extract/ExtractBuiltinLean.ml
+++ b/src/extract/ExtractBuiltinLean.ml
@@ -165,7 +165,14 @@ let lean_builtin_types =
     (* file: "Aeneas/Std/Core/Atomic.lean", line: 6 *)
     mk_type "core::sync::atomic::AtomicBool" "core.sync.atomic.AtomicBool";
     (* file: "Aeneas/Std/Core/Atomic.lean", line: 10 *)
+    mk_type "core::sync::atomic::AtomicU8" "core.sync.atomic.AtomicU8";
+    (* file: "Aeneas/Std/Core/Atomic.lean", line: 14 *)
     mk_type "core::sync::atomic::AtomicU32" "core.sync.atomic.AtomicU32";
+    (* file: "Aeneas/Std/Core/Atomic.lean", line: 18 *)
+    mk_type "core::sync::atomic::AtomicU64" "core.sync.atomic.AtomicU64";
+    (* Note: core::sync::atomic::Ordering is not registered here because Aeneas
+       generates it correctly from the LLBC (it's a simple enum). Only opaque
+       types that Aeneas cannot translate need to be registered as builtins. *)
   ]
 
 let lean_builtin_consts = []


### PR DESCRIPTION
## Summary

- Adds `core::sync::atomic::AtomicU8` and `core::sync::atomic::AtomicU64` as builtin external types in both the OCaml extraction layer and the Lean backend
- Previously only `AtomicBool` and `AtomicU32` were registered

## Motivation

When verifying Rust code that uses `AtomicU8` (e.g., buffer pool frame state management) or `AtomicU64` (e.g., WAL LSN tracking), Aeneas fails to recognize these types as external, leading to translation failures. This adds them following the same pattern as the existing `AtomicBool` and `AtomicU32` registrations.

## Changes

- `backends/lean/Aeneas/Std/Core/Atomic.lean`: Added axioms for `AtomicU8` and `AtomicU64`
- `src/extract/ExtractBuiltinLean.ml`: Added builtin type registrations for both

## Testing

- `ocamlformat` shows no formatting diff
- Lean file builds successfully: `lake build Aeneas.Std.Core.Atomic`
- Full Aeneas binary compiles via `dune build`
- No existing tests reference these types, so test regeneration is not needed