### PR TITLE
FYI: Support raw-pointer casts to non-literal pointee types (SHA-NI extraction)

### DIFF
--- a/backends/lean/Aeneas/Std/Array/ArraySlice.lean
+++ b/backends/lean/Aeneas/Std/Array/ArraySlice.lean
@@ -250,7 +250,7 @@ theorem Array.index_mut_SliceIndexRangeToUsizeSlice {T : Type} {N : Usize}
     (h : r.end ≤ N) :
     core.array.Array.index_mut (core.ops.index.IndexMutSlice
       (core.slice.index.SliceIndexRangeToUsizeSlice T)) a r
-    ⦃ (s, back) =>
+    ⦃ (s : Slice T) (back : Slice T → Array T N) =>
       s.val = a.val.slice 0 r.end ∧
       s.length = r.end.val ∧
       ∀ s', (back s').val = a.val.setSlice! 0 s'.val ⦄ := by
@@ -279,7 +279,7 @@ theorem Array.index_mut_SliceIndexRangeFromUsizeSlice {T : Type} {N : Usize}
     (h : r.start ≤ N) :
     core.array.Array.index_mut (core.ops.index.IndexMutSlice
       (core.slice.index.SliceIndexRangeFromUsizeSlice T)) a r
-    ⦃ (s, back) =>
+    ⦃ (s : Slice T) (back : Slice T → Array T N) =>
       s.val = a.val.drop r.start ∧
       s.length = N.val - r.start.val ∧
       ∀ s', (back s').val = a.val.setSlice! r.start.val s'.val ⦄ := by

--- a/backends/lean/Aeneas/Std/Array/ArraySlice.lean
+++ b/backends/lean/Aeneas/Std/Array/ArraySlice.lean
@@ -30,10 +30,18 @@ theorem Array.from_slice_val {α : Type u} {n : Usize} (a : Array α n) (ns : Sl
   (from_slice a ns).val = ns.val
   := by simp [from_slice, *]
 
-@[step_pure_def]
 def Array.to_slice_mut {α : Type u} {n : Usize} (a : Array α n) :
   Slice α × (Slice α → Array α n) :=
   (Array.to_slice a, Array.from_slice a)
+
+/-- Step theorem for `lift (Array.to_slice_mut a)` with curried postcondition.
+    Handles the new Aeneas translation pattern `let (s, back) ← lift (to_slice_mut a)`. -/
+@[step]
+theorem Array.to_slice_mut_spec {α : Type u} {n : Usize} (a : Array α n) :
+  (lift (Array.to_slice_mut a))
+  ⦃ (s : Slice α) (back : Slice α → Array α n) =>
+    s.val = a.val ∧ back = Array.from_slice a ⦄ := by
+  simp [lift, to_slice_mut, to_slice, WP.spec_ok]
 
 def Array.subslice {α : Type u} {n : Usize} (a : Array α n) (r : Range Usize) : Result (Slice α) :=
   -- TODO: not completely sure here

--- a/backends/lean/Aeneas/Std/RawPtr.lean
+++ b/backends/lean/Aeneas/Std/RawPtr.lean
@@ -30,4 +30,20 @@ def RawPtr.cast_scalar {T} {M} (T' : Type) (M' : Mutability) [IsScalar T] [IsSca
   Result (RawPtr T' M') :=
   .fail .undef
 
+/-- Generic raw-pointer cast.
+
+Used to lower Rust raw-pointer casts whose pointee is not a scalar type
+(for example casts of the form `*const u8 as *const __m128i`, which are
+ubiquitous in SIMD intrinsics code). The source and target pointee
+types are left implicit and inferred by Lean from the surrounding
+context; only the target mutability is provided explicitly because it
+cannot in general be deduced from the use site.
+
+Like [RawPtr.cast_scalar], this is a placeholder: it always returns
+[.fail .undef]. We can give it a meaningful definition once we have
+separation logic. -/
+def RawPtr.cast {T T' : Type} {M : Mutability} (M' : Mutability) (_ : RawPtr T M) :
+  Result (RawPtr T' M') :=
+  .fail .undef
+
 end Aeneas.Std

--- a/backends/lean/Aeneas/Std/Slice.lean
+++ b/backends/lean/Aeneas/Std/Slice.lean
@@ -781,13 +781,13 @@ theorem Slice.setSlice!_val (s : Slice α) (i : ℕ) (s' : List α) :
 @[step]
 theorem core.slice.index.SliceIndexRangeUsizeSlice.index_mut.step_spec (r : core.ops.range.Range Usize) (s : Slice α)
   (h0 : r.start ≤ r.end) (h1 : r.end ≤ s.length) :
-  core.slice.index.SliceIndexRangeUsizeSlice.index_mut r s ⦃ (s1, index_mut_back) =>
+  core.slice.index.SliceIndexRangeUsizeSlice.index_mut r s ⦃ (s1 : Slice α) (index_mut_back : Slice α → Slice α) =>
   s1.val = s.val.slice r.start r.end ∧
   s1.length = r.end - r.start ∧
   ∀ s2, index_mut_back s2 = s.setSlice! r.start.val s2 ⦄ := by
   simp only [index_mut, UScalar.le_equiv, Slice.length]
   split
-  . simp only [spec_ok, true_and]
+  . simp only [spec_ok, WP.predn, true_and]
     simp_lists
     simp_scalar
     simp_lists [Slice.eq_iff]
@@ -823,13 +823,13 @@ theorem Slice.index_SliceIndexRangeToUsizeSliceInst (s : Slice α) (r : core.ops
 theorem core.slice.index.SliceIndexRangeToUsizeSlice.index_mut.step_spec
     (r : core.ops.range.RangeTo Usize) (s : Slice α) (h : r.end ≤ s.length) :
   core.slice.index.SliceIndexRangeToUsizeSlice.index_mut r s
-    ⦃ (s1, back) =>
+    ⦃ (s1 : Slice α) (back : Slice α → Slice α) =>
       s1.val = s.val.slice 0 r.end ∧
       s1.length = r.«end» ∧
       ∀ s', (back s').val = s.val.setSlice! 0 s'.val ⦄ := by
   simp only [index_mut]
   split
-  · simp only [spec_ok]
+  · simp only [spec_ok, WP.predn]
     refine ⟨trivial, ?_, ?_⟩
     · simp [Slice.length]; scalar_tac
     · intro s'; simp
@@ -864,13 +864,13 @@ theorem Slice.index_SliceIndexRangeFromUsizeSliceInst (s : Slice α) (r : core.o
 theorem core.slice.index.SliceIndexRangeFromUsizeSlice.index_mut.step_spec
     (r : core.ops.range.RangeFrom Usize) (s : Slice α) (h : r.start ≤ s.length) :
   core.slice.index.SliceIndexRangeFromUsizeSlice.index_mut r s
-    ⦃ (s1, back) =>
+    ⦃ (s1 : Slice α) (back : Slice α → Slice α) =>
       s1.val = s.val.drop r.start ∧
       s1.length = s.length - r.start.val ∧
       ∀ s', (back s').val = s.val.setSlice! r.start.val s'.val ⦄ := by
   simp only [index_mut, Slice.drop]
   split
-  · simp only [spec_ok]
+  · simp only [spec_ok, WP.predn]
     refine ⟨trivial, ?_, ?_⟩
     · simp [Slice.length, List.length_drop]
     · intro s'; simp

--- a/backends/lean/Aeneas/Std/Vec.lean
+++ b/backends/lean/Aeneas/Std/Vec.lean
@@ -236,7 +236,7 @@ theorem Vec.index_RangeTo_spec {α : Type} (v : Vec α) (r : core.ops.range.Rang
 theorem Vec.index_mut_RangeTo_spec {α : Type} (v : Vec α) (r : core.ops.range.RangeTo Usize)
     (h : r.end ≤ v.length) :
     Vec.index_mut (core.slice.index.SliceIndexRangeToUsizeSlice α) v r
-    ⦃ (s1, back) =>
+    ⦃ (s1 : Slice α) (back : Slice α → Vec α) =>
       s1.val = v.val.slice 0 r.end ∧
       s1.length = r.«end» ∧
       ∀ s', (back s').val = v.val.setSlice! 0 s'.val ⦄ := by
@@ -261,7 +261,7 @@ theorem Vec.index_RangeFrom_spec {α : Type} (v : Vec α) (r : core.ops.range.Ra
 theorem Vec.index_mut_RangeFrom_spec {α : Type} (v : Vec α) (r : core.ops.range.RangeFrom Usize)
     (h : r.start ≤ v.length) :
     Vec.index_mut (core.slice.index.SliceIndexRangeFromUsizeSlice α) v r
-    ⦃ (s1, back) =>
+    ⦃ (s1 : Slice α) (back : Slice α → Vec α) =>
       s1.val = v.val.drop r.start ∧
       s1.length = v.length - r.start.val ∧
       ∀ s', (back s').val = v.val.setSlice! r.start.val s'.val ⦄ := by
@@ -286,7 +286,7 @@ theorem Vec.index_Range_spec {α : Type} (v : Vec α) (r : core.ops.range.Range 
 theorem Vec.index_mut_Range_spec {α : Type} (v : Vec α) (r : core.ops.range.Range Usize)
     (h0 : r.start ≤ r.end) (h1 : r.end ≤ v.length) :
     Vec.index_mut (core.slice.index.SliceIndexRangeUsizeSlice α) v r
-    ⦃ (s1, back) =>
+    ⦃ (s1 : Slice α) (back : Slice α → Vec α) =>
       s1.val = v.val.slice r.start r.end ∧
       s1.length = r.end - r.start ∧
       ∀ s2, back s2 = Slice.setSlice! v r.start.val s2 ⦄ := by

--- a/src/extract/Extract.ml
+++ b/src/extract/Extract.ml
@@ -505,33 +505,17 @@ let extract_cast_kind_gen (span : Meta.span)
       F.pp_print_space fmt ();
       extract_expr ~inside:true arg;
       if inside then F.pp_print_string fmt ")"
-  | CastRawPtr ((_, _), (tgt_ty, tgt_mut)) ->
+  | CastRawPtr ((_, _), (_, tgt_mut)) ->
       [%cassert] span
         (backend () = Lean)
         "Casts between raw pointers are only supported in the Lean backend";
       if inside then F.pp_print_string fmt "(";
-      (* Print the name of the function *)
-      F.pp_print_string fmt "RawPtr.cast_scalar";
-      (* Print the target type argument and mutability *)
-      let tgt_ty : integer_type =
-        match tgt_ty with
-        | TInt ty -> Signed ty
-        | TUInt ty -> Unsigned ty
-        | _ ->
-            [%craise] span "Can only generate code for casts between integers"
-      in
-      let integer_type_to_string (ty : integer_type) : string =
-        if backend () = Lean then
-          match ty with
-          | Unsigned _ -> "Std." ^ int_name ty
-          | Signed _ -> "Std." ^ int_name ty
-        else
-          StringUtils.capitalize_first_letter
-            (PrintPure.integer_type_to_string ty)
-      in
-      let tgt = integer_type_to_string tgt_ty in
-      F.pp_print_space fmt ();
-      F.pp_print_string fmt tgt;
+      (* Emit a generic cast which leaves the source and target pointee
+         types implicit — Lean infers them from the surrounding context.
+         This lets us handle casts whose pointee is an opaque builtin
+         type such as [core::core_arch::x86::__m128i] without having to
+         print the type from OCaml here. *)
+      F.pp_print_string fmt "RawPtr.cast";
       let tgt_mut =
         match tgt_mut with
         | Mut -> ".Mut"

--- a/src/pure/PrintPure.ml
+++ b/src/pure/PrintPure.ml
@@ -879,7 +879,7 @@ let cast_kind_to_string (env : fmt_env) (kind : cast_kind) : string =
           ty_to_string env false
             (TAdt
                ( TBuiltin (TRawPtr mut),
-                 mk_generic_args_from_types [ TLiteral ty ] ))
+                 mk_generic_args_from_types [ ty ] ))
         in
         (mk src src_mut, mk tgt tgt_mut)
   in

--- a/src/pure/Pure.ml
+++ b/src/pure/Pure.ml
@@ -1162,9 +1162,14 @@ type unop =
 
 and cast_kind =
   | CastLit of literal_type * literal_type
-  | CastRawPtr of (literal_type * mutability) * (literal_type * mutability)
-      (** When casting between raw pointers, we only support a subset of casts
-      *)
+  | CastRawPtr of (ty * mutability) * (ty * mutability)
+      (** Cast between raw pointers: the source and target pointee types may
+          be arbitrary [ty]s (literal scalars, ADTs, or opaque builtin types
+          such as [core::core_arch::x86::__m128i] / [__m256i]).
+
+          On the Lean backend this is emitted as a generic [RawPtr.cast]
+          which simply rebrands the pointer's type parameter; on other
+          backends we still restrict to literal scalar types. *)
 
 and fn_ptr_kind =
   | FunId of llbc_fun_id

--- a/src/symbolic/SymbolicToPureExpressions.ml
+++ b/src/symbolic/SymbolicToPureExpressions.ml
@@ -451,27 +451,30 @@ and translate_function_call_aux (call : S.call) (e : S.expr) (ctx : bs_ctx) :
               let tgt_ty = translate_literal_type tgt_ty in
               (CastLit (src_ty, tgt_ty), not (Config.backend () = Lean))
           | CastRawPtr (src_ty, tgt_ty) ->
-              (* We only support casts between pointers to literal types for now *)
+              (* Casts between raw pointers: we accept any pointee type
+                 (including opaque builtin types such as [__m128i]). The
+                 actual lowering happens in the backend; on Lean we emit a
+                 generic [RawPtr.cast] that simply rebrands the pointer's
+                 type parameter. *)
               let get_ty (ty : T.ty) =
                 match ty with
-                | TRawPtr (TLiteral lit, rkind) ->
+                | TRawPtr (pointee, rkind) ->
                     let mut =
                       match rkind with
                       | RMut -> Mut
                       | RShared -> Const
                     in
-                    (lit, mut)
+                    (pointee, mut)
                 | _ ->
                     let env = bs_ctx_to_fmt_env ctx in
                     [%craise] ctx.span
-                      ("Raw ptr casts are only supported between pointers to \
-                        literal types; found: "
-                      ^ Charon.Print.cast_kind_to_string env kind)
+                      ("Raw ptr cast applied to a non-pointer type; found: "
+                      ^ Charon.PrintExpressions.cast_kind_to_string env kind)
               in
               let src_ty, src_mut = get_ty src_ty in
               let tgt_ty, tgt_mut = get_ty tgt_ty in
-              let src_ty = translate_literal_type src_ty in
-              let tgt_ty = translate_literal_type tgt_ty in
+              let src_ty = ctx_translate_fwd_ty ctx src_ty in
+              let tgt_ty = ctx_translate_fwd_ty ctx tgt_ty in
               (CastRawPtr ((src_ty, src_mut), (tgt_ty, tgt_mut)), true)
           | CastFnPtr _ -> [%craise] ctx.span "TODO: function casts"
           | CastUnsize _ ->

--- a/tests/lean/Bst.lean
+++ b/tests/lean/Bst.lean
@@ -1,0 +1,1 @@
+import Bst.Funs


### PR DESCRIPTION
**FYI** — sharing for visibility / discussion. Not requesting merge.

Three small commits surfaced while preparing the SymCrypt SHA-2 SHA-NI
verification target.

## 1. `Add @[step] theorem for Array.to_slice_mut with curried postcondition`

Adds a `@[step]` theorem so that `step` can decompose
`Array.to_slice_mut`. Uses the curried `⦃ s lib => ... ⦄` postcondition
form so callers don't need to destructure a tuple.

## 2. `Curried postconditions for all index_mut/to_slice_mut step specs`

Sweep across `Array/ArraySlice.lean`, `Slice.lean`, `Vec.lean` to convert
the existing `index_mut` / `to_slice_mut` step theorems to the curried
form. One Bst test updated.

## 3. `Support raw-pointer casts to non-literal pointee types`

Generalize `CastRawPtr`'s source/target pointee from `literal_type` to
`ty`, so casts whose pointee is an opaque builtin (e.g. `*const __m128i`,
`*const __m256i`) or any other non-scalar type are translated rather than
raising a fatal error.

On the Lean backend this is emitted as a generic `RawPtr.cast` that
leaves the source and target pointee types implicit (Lean infers them
from the surrounding context, e.g. the argument type of
`_mm_loadu_si128`). On other backends we still restrict to literal
scalar pointees as before.

This fixes the OOM observed when extracting SymCrypt's SHA-NI fast path
(`sha2::sha2_impl::append_blocks_256_shani`), which contains many
`*const u8 as *const __m128i` casts via primitives like:

```rust
unsafe fn loadu_u32xn<const N: usize>(arr: &[u32; N], at: usize)
    -> __m128i {
    _mm_loadu_si128(arr.as_ptr().add(at) as *const __m128i)
}
```

Validated end-to-end: extraction of the full SymCrypt SHA-2 module
including the SHA-NI fast path now produces clean Lean (`def`s for the
load/store primitives, axiomatised intrinsics for `_mm_sha256rnds2_epu32`
etc.).

## Conflict resolution

The cherry-pick of #3 onto current `origin/main` produced a single
trivial conflict against the recent Charon update (`d9d473d0 Update
Charon`): both branches independently renamed
`Charon.Print.cast_kind_to_string` → `Charon.PrintExpressions.cast_kind_to_string`
in the same error site. Resolution: kept this PR's version, which also
updates the surrounding code path.
