### PR TITLE
Include Rust toolchain metadata in release archives

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -151,6 +151,7 @@
           cp ${charon-portable}/bin/charon ${charon-portable}/bin/charon-driver .
           cp ${aeneas}/bin/aeneas .
           cp -r ${./backends} backends
+          cp ${inputs.charon}/rust-toolchain .
 
           ${pkgs.lib.optionalString pkgs.stdenv.isDarwin ''
             # Make the binary writable so macdylibbundler can modify its load paths


### PR DESCRIPTION
This enables downstream tooling to reflect on what Rust toolchain Aeneas uses.

cc @joshlf 