### PR TITLE
feat: step spec for Result.unwrap

### DIFF
--- a/backends/lean/Aeneas/Std/Core/Fmt.lean
+++ b/backends/lean/Aeneas/Std/Core/Fmt.lean
@@ -30,6 +30,15 @@ def core.result.Result.unwrap.mut {T E : Type}
   | .Ok x => .ok (x, fun x => .Ok x)
   | .Err _ => .fail .panic
 
+/-- `Result.unwrap` extracts the value when the result is statically known
+to be `.Ok`. -/
+@[step]
+theorem core.result.Result.unwrap.step_spec
+    {T E : Type} (D : core.fmt.Debug E) (r : core.result.Result T E) (a : T)
+    (h : r = core.result.Result.Ok a) :
+    core.result.Result.unwrap D r ⦃ x => x = a ⦄ := by
+  rw [h]; simp [core.result.Result.unwrap]
+
 
 -- TODO: this is a simplistic model
 @[rust_type "core::fmt::Arguments"]


### PR DESCRIPTION
Allows `step` to advance through `Result.unwrap` when the result is statically known to be `.Ok`.

AI-assisted: light, reviewed line by line, Opus 4.7
