### PR TITLE
feat: step spec for TryFromSharedArraySlice.try_from

### DIFF
--- a/backends/lean/Aeneas/Std/Array/ArraySlice.lean
+++ b/backends/lean/Aeneas/Std/Array/ArraySlice.lean
@@ -176,6 +176,17 @@ def core.array.TryFromSharedArraySlice.try_from
   if h: s.len = N then .ok (.Ok ⟨s.val, by scalar_tac⟩)
   else .ok (.Err ())
 
+/-- When the slice has the right length, `try_from` returns `.Ok` with the
+slice contents repackaged as an array. -/
+@[step]
+theorem core.array.TryFromSharedArraySlice.try_from.step_spec
+    {T : Type} (N : Usize) (s : Slice T) (h : s.length = N.val) :
+    core.array.TryFromSharedArraySlice.try_from N s
+      ⦃ r => ∃ a : Array T N, r = core.result.Result.Ok a ∧ a.val = s.val ⦄ := by
+  unfold core.array.TryFromSharedArraySlice.try_from
+  have hlen : s.len = N := UScalar.eq_of_val_eq (by simp [h])
+  simp [hlen]
+
 @[reducible, rust_trait_impl
   "core::convert::TryFrom<&'a [@T; @N], &'a [@T], core::array::TryFromSliceError>"]
 def core.convert.TryFromSharedArraySliceTryFromSliceError (T : Type) (N : Usize) :


### PR DESCRIPTION
Allows `step` to advance through `<&[T; N]>::try_from(slice)` when the slice has length `N`, yielding `.Ok a` with `a.val = s.val`.

AI-assisted: light, reviewed line by line, Opus 4.7