### PR TITLE
Curried postconditions for index_mut / to_slice_mut step specs

### DIFF
--- a/backends/lean/Aeneas/Std/Array/ArraySlice.lean
+++ b/backends/lean/Aeneas/Std/Array/ArraySlice.lean
@@ -250,7 +250,7 @@ theorem Array.index_mut_SliceIndexRangeToUsizeSlice {T : Type} {N : Usize}
     (h : r.end ≤ N) :
     core.array.Array.index_mut (core.ops.index.IndexMutSlice
       (core.slice.index.SliceIndexRangeToUsizeSlice T)) a r
-    ⦃ (s, back) =>
+    ⦃ (s : Slice T) (back : Slice T → Array T N) =>
       s.val = a.val.slice 0 r.end ∧
       s.length = r.end.val ∧
       ∀ s', (back s').val = a.val.setSlice! 0 s'.val ⦄ := by
@@ -279,7 +279,7 @@ theorem Array.index_mut_SliceIndexRangeFromUsizeSlice {T : Type} {N : Usize}
     (h : r.start ≤ N) :
     core.array.Array.index_mut (core.ops.index.IndexMutSlice
       (core.slice.index.SliceIndexRangeFromUsizeSlice T)) a r
-    ⦃ (s, back) =>
+    ⦃ (s : Slice T) (back : Slice T → Array T N) =>
       s.val = a.val.drop r.start ∧
       s.length = N.val - r.start.val ∧
       ∀ s', (back s').val = a.val.setSlice! r.start.val s'.val ⦄ := by

--- a/backends/lean/Aeneas/Std/Array/ArraySlice.lean
+++ b/backends/lean/Aeneas/Std/Array/ArraySlice.lean
@@ -30,10 +30,18 @@ theorem Array.from_slice_val {α : Type u} {n : Usize} (a : Array α n) (ns : Sl
   (from_slice a ns).val = ns.val
   := by simp [from_slice, *]
 
-@[step_pure_def]
 def Array.to_slice_mut {α : Type u} {n : Usize} (a : Array α n) :
   Slice α × (Slice α → Array α n) :=
   (Array.to_slice a, Array.from_slice a)
+
+/-- Step theorem for `lift (Array.to_slice_mut a)` with curried postcondition.
+    Handles the new Aeneas translation pattern `let (s, back) ← lift (to_slice_mut a)`. -/
+@[step]
+theorem Array.to_slice_mut_spec {α : Type u} {n : Usize} (a : Array α n) :
+  (lift (Array.to_slice_mut a))
+  ⦃ (s : Slice α) (back : Slice α → Array α n) =>
+    s.val = a.val ∧ back = Array.from_slice a ⦄ := by
+  simp [lift, to_slice_mut, to_slice, WP.spec_ok]
 
 def Array.subslice {α : Type u} {n : Usize} (a : Array α n) (r : Range Usize) : Result (Slice α) :=
   -- TODO: not completely sure here

--- a/backends/lean/Aeneas/Std/Slice.lean
+++ b/backends/lean/Aeneas/Std/Slice.lean
@@ -779,13 +779,13 @@ theorem Slice.setSlice!_val (s : Slice α) (i : ℕ) (s' : List α) :
 @[step]
 theorem core.slice.index.SliceIndexRangeUsizeSlice.index_mut.step_spec (r : core.ops.range.Range Usize) (s : Slice α)
   (h0 : r.start ≤ r.end) (h1 : r.end ≤ s.length) :
-  core.slice.index.SliceIndexRangeUsizeSlice.index_mut r s ⦃ (s1, index_mut_back) =>
+  core.slice.index.SliceIndexRangeUsizeSlice.index_mut r s ⦃ (s1 : Slice α) (index_mut_back : Slice α → Slice α) =>
   s1.val = s.val.slice r.start r.end ∧
   s1.length = r.end - r.start ∧
   ∀ s2, index_mut_back s2 = s.setSlice! r.start.val s2 ⦄ := by
   simp only [index_mut, UScalar.le_equiv, Slice.length]
   split
-  . simp only [spec_ok, true_and]
+  . simp only [spec_ok, WP.predn, true_and]
     simp_lists
     simp_scalar
     simp_lists [Slice.eq_iff]
@@ -821,13 +821,13 @@ theorem Slice.index_SliceIndexRangeToUsizeSliceInst (s : Slice α) (r : core.ops
 theorem core.slice.index.SliceIndexRangeToUsizeSlice.index_mut.step_spec
     (r : core.ops.range.RangeTo Usize) (s : Slice α) (h : r.end ≤ s.length) :
   core.slice.index.SliceIndexRangeToUsizeSlice.index_mut r s
-    ⦃ (s1, back) =>
+    ⦃ (s1 : Slice α) (back : Slice α → Slice α) =>
       s1.val = s.val.slice 0 r.end ∧
       s1.length = r.«end» ∧
       ∀ s', (back s').val = s.val.setSlice! 0 s'.val ⦄ := by
   simp only [index_mut]
   split
-  · simp only [spec_ok]
+  · simp only [spec_ok, WP.predn]
     refine ⟨trivial, ?_, ?_⟩
     · simp [Slice.length]; scalar_tac
     · intro s'; simp
@@ -862,13 +862,13 @@ theorem Slice.index_SliceIndexRangeFromUsizeSliceInst (s : Slice α) (r : core.o
 theorem core.slice.index.SliceIndexRangeFromUsizeSlice.index_mut.step_spec
     (r : core.ops.range.RangeFrom Usize) (s : Slice α) (h : r.start ≤ s.length) :
   core.slice.index.SliceIndexRangeFromUsizeSlice.index_mut r s
-    ⦃ (s1, back) =>
+    ⦃ (s1 : Slice α) (back : Slice α → Slice α) =>
       s1.val = s.val.drop r.start ∧
       s1.length = s.length - r.start.val ∧
       ∀ s', (back s').val = s.val.setSlice! r.start.val s'.val ⦄ := by
   simp only [index_mut, Slice.drop]
   split
-  · simp only [spec_ok]
+  · simp only [spec_ok, WP.predn]
     refine ⟨trivial, ?_, ?_⟩
     · simp [Slice.length, List.length_drop]
     · intro s'; simp

--- a/backends/lean/Aeneas/Std/Vec.lean
+++ b/backends/lean/Aeneas/Std/Vec.lean
@@ -236,7 +236,7 @@ theorem Vec.index_RangeTo_spec {α : Type} (v : Vec α) (r : core.ops.range.Rang
 theorem Vec.index_mut_RangeTo_spec {α : Type} (v : Vec α) (r : core.ops.range.RangeTo Usize)
     (h : r.end ≤ v.length) :
     Vec.index_mut (core.slice.index.SliceIndexRangeToUsizeSlice α) v r
-    ⦃ (s1, back) =>
+    ⦃ (s1 : Slice α) (back : Slice α → Vec α) =>
       s1.val = v.val.slice 0 r.end ∧
       s1.length = r.«end» ∧
       ∀ s', (back s').val = v.val.setSlice! 0 s'.val ⦄ := by
@@ -261,7 +261,7 @@ theorem Vec.index_RangeFrom_spec {α : Type} (v : Vec α) (r : core.ops.range.Ra
 theorem Vec.index_mut_RangeFrom_spec {α : Type} (v : Vec α) (r : core.ops.range.RangeFrom Usize)
     (h : r.start ≤ v.length) :
     Vec.index_mut (core.slice.index.SliceIndexRangeFromUsizeSlice α) v r
-    ⦃ (s1, back) =>
+    ⦃ (s1 : Slice α) (back : Slice α → Vec α) =>
       s1.val = v.val.drop r.start ∧
       s1.length = v.length - r.start.val ∧
       ∀ s', (back s').val = v.val.setSlice! r.start.val s'.val ⦄ := by
@@ -286,7 +286,7 @@ theorem Vec.index_Range_spec {α : Type} (v : Vec α) (r : core.ops.range.Range 
 theorem Vec.index_mut_Range_spec {α : Type} (v : Vec α) (r : core.ops.range.Range Usize)
     (h0 : r.start ≤ r.end) (h1 : r.end ≤ v.length) :
     Vec.index_mut (core.slice.index.SliceIndexRangeUsizeSlice α) v r
-    ⦃ (s1, back) =>
+    ⦃ (s1 : Slice α) (back : Slice α → Vec α) =>
       s1.val = v.val.slice r.start r.end ∧
       s1.length = r.end - r.start ∧
       ∀ s2, back s2 = Slice.setSlice! v r.start.val s2 ⦄ := by

--- a/tests/lean/Bst.lean
+++ b/tests/lean/Bst.lean
@@ -1,0 +1,1 @@
+import Bst.Funs


### PR DESCRIPTION
Updates the `@[step]` specs for mutable indexing / slicing so the postcondition is **curried** rather than tupled, and adds a missing `@[step]` theorem for `Array.to_slice_mut`.

### Motivation

The new Aeneas translation generates destructuring binds:

```lean
let (s, back) ← lift (Array.to_slice_mut a)
```

The previous `@[step_pure_def]` / tupled `⦃ (s, back) => ... ⦄` postconditions left an opaque pair that `step` could not reduce, so users had to manually destructure.

With the curried form `⦃ (s : Slice α) (back : Slice α → ...) => ... ⦄`, `step` introduces `s` and `back` as separate variables matching the destructuring, and the proof obligation simplifies away.

### Changes

Commit 1 — `Add @[step] theorem for Array.to_slice_mut with curried postcondition`
- `backends/lean/Aeneas/Std/Array/ArraySlice.lean`

Commit 2 — `Curried postconditions for all index_mut/to_slice_mut step specs`
- `backends/lean/Aeneas/Std/Slice.lean`: `SliceIndexRangeUsizeSlice.index_mut`, `SliceIndexRangeToUsizeSlice.index_mut`, `SliceIndexRangeFromUsizeSlice.index_mut`
- `backends/lean/Aeneas/Std/Vec.lean`: `Vec.index_mut_RangeTo` / `RangeFrom` / `Range_spec`
- `backends/lean/Aeneas/Std/Array/ArraySlice.lean`: `Array.index_mut_SliceIndexRangeTo` / `From`
- `tests/lean/Bst.lean`: small adjustment

### Notes

- No upstream files changed in this window also touch these definitions, so the rebase onto current `main` is conflict-free (verified locally with `git merge-tree`).
- Used downstream in the SymCrypt ML-KEM verification work — the curried form removes a class of manual destructuring lemmas in proof scripts.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>