### PR TITLE
Ship skills as a Claude Code plugin marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,13 @@
+{
+  "name": "aeneas",
+  "owner": {
+    "name": "AeneasVerif"
+  },
+  "plugins": [
+    {
+      "name": "aeneas",
+      "source": "./",
+      "description": "Skills for verifying Rust programs with Aeneas"
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,7 @@
+{
+  "name": "aeneas",
+  "description": "Skills for verifying Rust programs with Aeneas",
+  "homepage": "https://aeneasverif.github.io/",
+  "repository": "https://github.com/AeneasVerif/aeneas",
+  "license": "Apache-2.0"
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,8 +6,16 @@ Aeneas translates Rust programs to pure Lean code for formal verification.
 
 All detailed instructions for AI agents live in `documentation/skills/`. These are
 the **source of truth** — they are symlinked to `.github/instructions/` (for GitHub
-Copilot) and `.claude/skills/` (for Claude Code). **Always edit files in
+Copilot), `.claude/skills/` (for Claude Code in this repo), and `skills/` (for the
+Claude Code plugin marketplace; see `.claude-plugin/`). **Always edit files in
 `documentation/skills/`**; changes propagate automatically through the symlinks.
+
+External users can install these skills via:
+
+```
+/plugin marketplace add AeneasVerif/aeneas
+/plugin install aeneas@aeneas
+```
 
 | Skill file | Covers |
 |---|---|

--- a/skills/aeneas-compiler-dev/SKILL.md
+++ b/skills/aeneas-compiler-dev/SKILL.md
@@ -1,0 +1,1 @@
+../../documentation/skills/aeneas-compiler-dev.instructions.md

--- a/skills/aeneas-crypto-verification/SKILL.md
+++ b/skills/aeneas-crypto-verification/SKILL.md
@@ -1,0 +1,1 @@
+../../documentation/skills/aeneas-crypto-verification.instructions.md

--- a/skills/aeneas-lean-core/SKILL.md
+++ b/skills/aeneas-lean-core/SKILL.md
@@ -1,0 +1,1 @@
+../../documentation/skills/aeneas-lean-core.instructions.md

--- a/skills/aeneas-tactics-quickref/SKILL.md
+++ b/skills/aeneas-tactics-quickref/SKILL.md
@@ -1,0 +1,1 @@
+../../documentation/skills/aeneas-tactics-quickref.instructions.md

--- a/skills/agent-fleet-management/SKILL.md
+++ b/skills/agent-fleet-management/SKILL.md
@@ -1,0 +1,1 @@
+../../documentation/skills/agent-fleet-management.instructions.md

--- a/skills/formalizing-crypto-specs/SKILL.md
+++ b/skills/formalizing-crypto-specs/SKILL.md
@@ -1,0 +1,1 @@
+../../documentation/skills/formalizing-crypto-specs.instructions.md

--- a/skills/launching-proof-agents/SKILL.md
+++ b/skills/launching-proof-agents/SKILL.md
@@ -1,0 +1,1 @@
+../../documentation/skills/launching-proof-agents.instructions.md

--- a/skills/lean-lsp-mcp/SKILL.md
+++ b/skills/lean-lsp-mcp/SKILL.md
@@ -1,0 +1,1 @@
+../../documentation/skills/lean-lsp-mcp.instructions.md

--- a/skills/proof-patterns/SKILL.md
+++ b/skills/proof-patterns/SKILL.md
@@ -1,0 +1,1 @@
+../../documentation/skills/proof-patterns.instructions.md

--- a/skills/skill-file-authoring/SKILL.md
+++ b/skills/skill-file-authoring/SKILL.md
@@ -1,0 +1,1 @@
+../../documentation/skills/skill-file-authoring.instructions.md

--- a/skills/verification-campaigns/SKILL.md
+++ b/skills/verification-campaigns/SKILL.md
@@ -1,0 +1,1 @@
+../../documentation/skills/verification-campaigns.instructions.md


### PR DESCRIPTION
Closes #973.

Adds `.claude-plugin/{plugin,marketplace}.json` and `skills/<name>/SKILL.md` file symlinks into `documentation/skills/`, so users can install via:

```
/plugin marketplace add AeneasVerif/aeneas
/plugin install aeneas@aeneas
```

Tested against my fork, all 11 skills load under the `aeneas:` namespace.

Authored with assistance from Claude Code (claude-opus-4-7), tested and reviewed by a real human 