### PR TITLE
Update Charon

### DIFF
--- a/charon-pin
+++ b/charon-pin
@@ -1,2 +1,2 @@
 # This is the commit from https://github.com/AeneasVerif/charon that should be used with this version of aeneas.
-04e1e52d51f58b53b7ee4ef5d98ad3368acf3d3f
+ee7dbd8c304908e267c3b8fa5157ca972ddc29be

--- a/flake.lock
+++ b/flake.lock
@@ -9,11 +9,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1778145534,
-        "narHash": "sha256-Yp6Q1IATDselOlR+G1zm+GdUllR/mWhz2KtTwdS9NQg=",
+        "lastModified": 1778253406,
+        "narHash": "sha256-2Ic8z1vLQkjxh/XkiKhgPOaMqUNrzm1IfQUie00fSq0=",
         "owner": "aeneasverif",
         "repo": "charon",
-        "rev": "04e1e52d51f58b53b7ee4ef5d98ad3368acf3d3f",
+        "rev": "ee7dbd8c304908e267c3b8fa5157ca972ddc29be",
         "type": "github"
       },
       "original": {

--- a/src/Main.ml
+++ b/src/Main.ml
@@ -554,8 +554,7 @@ let () =
   in
 
   (* Load the module *)
-  let json = Yojson.Basic.from_file filename in
-  match crate_of_json json with
+  match crate_of_json_file filename with
   | Error s ->
       log#error "error: %s\n" s;
       exit 1


### PR DESCRIPTION
Partner PR to https://github.com/AeneasVerif/charon/pull/1118; it adds a function to directly deserialize a file, while also validating the file is indeed json. This will be relevant once you start switching to the new, smaller and faster format, to get nicer errors if the file format is wrong.