### PR TITLE
Identify all associated items by an id instead of by name

### DIFF
--- a/charon-pin
+++ b/charon-pin
@@ -1,2 +1,2 @@
 # This is the commit from https://github.com/AeneasVerif/charon that should be used with this version of aeneas.
-a22562ac077b5bcb23fbec8051ef42fe988dea79
+e656e17bff6ca5efac8ab6919b9b74cb9a8dd8ad

--- a/flake.lock
+++ b/flake.lock
@@ -9,11 +9,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1778514158,
-        "narHash": "sha256-OHEvOZoNg9tHOrPvhdeoYFnzppBhez4RzkxB+S+dScw=",
+        "lastModified": 1778592754,
+        "narHash": "sha256-Q+zpB/CDXaYELfdHbE/MnkBL3gn17RQgAIa2WVPaKE8=",
         "owner": "aeneasverif",
         "repo": "charon",
-        "rev": "a22562ac077b5bcb23fbec8051ef42fe988dea79",
+        "rev": "e656e17bff6ca5efac8ab6919b9b74cb9a8dd8ad",
         "type": "github"
       },
       "original": {

--- a/src/PrePasses.ml
+++ b/src/PrePasses.ml
@@ -988,8 +988,8 @@ let filter_marker_traits (crate : crate) : crate =
                 List.map (self#visit_trait_ref env) parent_refs
               in
               let types =
-                List.map
-                  (fun (n, t) -> (n, self#visit_trait_assoc_ty_impl env t))
+                AssocTypeId.Map.map
+                  (fun t -> self#visit_trait_assoc_ty_impl env t)
                   types
               in
               BuiltinOrAuto (data, parent_refs, types)

--- a/src/extract/Extract.ml
+++ b/src/extract/Extract.ml
@@ -762,12 +762,12 @@ and extract_App (span : Meta.span) (ctx : extraction_ctx) (fmt : F.formatter)
             qualif.generics args out_ty
       | ScalarValProj ty, _ ->
           extract_scalar_val_projector span ctx fmt ~inside ty args
-      | TraitConst (trait_ref, const_name), _ ->
+      | TraitConst (trait_ref, const_id), _ ->
           extract_trait_ref span ctx fmt TypeDeclId.Set.empty ~inside:true
             trait_ref;
           let name =
             ctx_get_trait_const span trait_ref.trait_decl_ref.trait_decl_id
-              const_name ctx
+              const_id ctx
           in
           let add_brackets (s : string) =
             if backend () = Coq then "(" ^ s ^ ")" else s
@@ -2722,27 +2722,27 @@ let extract_trait_decl_register_constant_names (ctx : extraction_ctx)
     match builtin_info with
     | None ->
         List.map
-          (fun (item_name, _) ->
+          (fun (const_id, item_name, _) ->
             let name = ctx_compute_trait_const_name ctx trait_decl item_name in
             (* Add a prefix if necessary *)
             let name =
               if !record_fields_short_names then name
               else ctx_compute_trait_decl_name ctx trait_decl ^ name
             in
-            (item_name, name))
+            (const_id, name))
           consts
     | Some info ->
         let const_map = StringMap.of_list info.consts in
         List.map
-          (fun (item_name, _) ->
-            (item_name, StringMap.find item_name const_map))
+          (fun (const_id, item_name, _) ->
+            (const_id, StringMap.find item_name const_map))
           consts
   in
   (* Register the names *)
   List.fold_left
-    (fun ctx (item_name, name) ->
+    (fun ctx (const_id, name) ->
       ctx_add trait_decl.item_meta.span
-        (TraitItemId (trait_decl.def_id, item_name))
+        (TraitConstId (trait_decl.def_id, const_id))
         name ctx)
     ctx constant_names
 
@@ -2763,17 +2763,17 @@ let extract_trait_decl_type_names (ctx : extraction_ctx)
           else ctx_compute_trait_decl_name ctx trait_decl ^ type_name
         in
         List.map
-          (fun item_name ->
+          (fun (type_id, item_name) ->
             (* Type name *)
             let type_name = compute_type_name item_name in
-            (item_name, type_name))
+            (type_id, type_name))
           types
     | Some info ->
         let type_map = StringMap.of_list info.types in
         List.map
-          (fun item_name ->
+          (fun (type_id, item_name) ->
             match StringMap.find_opt item_name type_map with
-            | Some type_name -> (item_name, type_name)
+            | Some type_name -> (type_id, type_name)
             | None ->
                 [%craise] trait_decl.item_meta.span
                   ("Unexpected error: could not find the information for the \
@@ -2785,9 +2785,9 @@ let extract_trait_decl_type_names (ctx : extraction_ctx)
   in
   (* Register the names *)
   List.fold_left
-    (fun ctx (item_name, type_name) ->
+    (fun ctx (type_id, type_name) ->
       ctx_add trait_decl.item_meta.span
-        (TraitItemId (trait_decl.def_id, item_name))
+        (TraitTypeId (trait_decl.def_id, type_id))
         type_name ctx)
     ctx type_names
 
@@ -3117,7 +3117,8 @@ let extract_trait_decl (ctx : extraction_ctx) (fmt : F.formatter)
    in
    let types =
      List.map
-       (fun name -> ctx_get_trait_type decl.item_meta.span decl.def_id name ctx)
+       (fun (type_id, _) ->
+         ctx_get_trait_type decl.item_meta.span decl.def_id type_id ctx)
        decl.types
    in
    let types =
@@ -3142,8 +3143,8 @@ let extract_trait_decl (ctx : extraction_ctx) (fmt : F.formatter)
    in
    let consts =
      List.map
-       (fun (name, _) ->
-         ctx_get_trait_const decl.item_meta.span decl.def_id name ctx)
+       (fun (const_id, _, _) ->
+         ctx_get_trait_const decl.item_meta.span decl.def_id const_id ctx)
        decl.consts
    in
    let consts =
@@ -3191,12 +3192,12 @@ let extract_trait_decl (ctx : extraction_ctx) (fmt : F.formatter)
   let ctx =
     let field_names =
       List.map
-        (fun (name, _) ->
-          ctx_get_trait_const decl.item_meta.span decl.def_id name ctx)
+        (fun (const_id, _, _) ->
+          ctx_get_trait_const decl.item_meta.span decl.def_id const_id ctx)
         decl.consts
       @ List.map
-          (fun name ->
-            ctx_get_trait_type decl.item_meta.span decl.def_id name ctx)
+          (fun (type_id, _) ->
+            ctx_get_trait_type decl.item_meta.span decl.def_id type_id ctx)
           decl.types
       @ List.map
           (fun (method_id, _, _) ->
@@ -3248,9 +3249,9 @@ let extract_trait_decl (ctx : extraction_ctx) (fmt : F.formatter)
 
     (* The constants *)
     List.iter
-      (fun (name, ty) ->
+      (fun (const_id, _, ty) ->
         let item_name =
-          ctx_get_trait_const decl.item_meta.span decl.def_id name ctx
+          ctx_get_trait_const decl.item_meta.span decl.def_id const_id ctx
         in
         let ty () =
           let inside = false in
@@ -3263,10 +3264,10 @@ let extract_trait_decl (ctx : extraction_ctx) (fmt : F.formatter)
 
     (* The types *)
     List.iter
-      (fun name ->
+      (fun (type_id, _) ->
         (* Extract the type *)
         let item_name =
-          ctx_get_trait_type decl.item_meta.span decl.def_id name ctx
+          ctx_get_trait_type decl.item_meta.span decl.def_id type_id ctx
         in
         let ty () =
           F.pp_print_space fmt ();
@@ -3333,18 +3334,18 @@ let extract_trait_decl_coq_arguments (ctx : extraction_ctx) (fmt : F.formatter)
   let params = params @ [ Explicit ] in
   (* The constants *)
   List.iter
-    (fun (name, _) ->
+    (fun (const_id, _, _) ->
       let item_name =
-        ctx_get_trait_const decl.item_meta.span decl.def_id name ctx
+        ctx_get_trait_const decl.item_meta.span decl.def_id const_id ctx
       in
       extract_coq_arguments_instruction ctx fmt item_name params)
     decl.consts;
   (* The types *)
   List.iter
-    (fun name ->
+    (fun (type_id, _) ->
       (* The type *)
       let item_name =
-        ctx_get_trait_type decl.item_meta.span decl.def_id name ctx
+        ctx_get_trait_type decl.item_meta.span decl.def_id type_id ctx
       in
       extract_coq_arguments_instruction ctx fmt item_name params)
     decl.types;
@@ -3531,10 +3532,10 @@ let extract_trait_impl (ctx : extraction_ctx) (fmt : F.formatter)
     let trait_decl = TraitDeclId.Map.find decl_id ctx.trans_trait_decls in
     let field_names =
       List.map
-        (fun (name, _) -> ctx_get_trait_const span decl_id name ctx)
+        (fun (const_id, _, _) -> ctx_get_trait_const span decl_id const_id ctx)
         trait_decl.consts
       @ List.map
-          (fun name -> ctx_get_trait_type span decl_id name ctx)
+          (fun (type_id, _) -> ctx_get_trait_type span decl_id type_id ctx)
           trait_decl.types
       @ List.map
           (fun (method_id, _, _) ->
@@ -3592,8 +3593,8 @@ let extract_trait_impl (ctx : extraction_ctx) (fmt : F.formatter)
 
     (* The constants *)
     List.iter
-      (fun (name, gref) ->
-        let item_name = ctx_get_trait_const span trait_decl_id name ctx in
+      (fun (const_id, _, gref) ->
+        let item_name = ctx_get_trait_const span trait_decl_id const_id ctx in
         (* Lookup the information about the explicit/implicit parameters *)
         let explicit =
           match GlobalDeclId.Map.find_opt gref.global_id ctx.trans_globals with
@@ -3640,9 +3641,9 @@ let extract_trait_impl (ctx : extraction_ctx) (fmt : F.formatter)
 
     (* The types *)
     List.iter
-      (fun (name, ty) ->
+      (fun (type_id, _, ty) ->
         (* Extract the type *)
-        let item_name = ctx_get_trait_type span trait_decl_id name ctx in
+        let item_name = ctx_get_trait_type span trait_decl_id type_id ctx in
         let ty () =
           F.pp_print_space fmt ();
           extract_ty span ctx fmt TypeDeclId.Set.empty ~inside:false ty

--- a/src/extract/ExtractBase.ml
+++ b/src/extract/ExtractBase.ml
@@ -168,8 +168,10 @@ and id =
   | LocalTraitClauseId of generic_origin * TraitClauseId.id
   | TraitDeclConstructorId of TraitDeclId.id
   | TraitMethodId of TraitDeclId.id * trait_method_id
-  | TraitItemId of TraitDeclId.id * string
-      (** A trait associated item which is not a method *)
+  | TraitTypeId of TraitDeclId.id * assoc_type_id
+      (** A trait associated type *)
+  | TraitConstId of TraitDeclId.id * assoc_const_id
+      (** A trait associated constant *)
   | TraitParentClauseId of TraitDeclId.id * TraitClauseId.id
   | KeywordId
       (** Used for stored various strings like keywords, definitions which
@@ -394,8 +396,11 @@ let strict_collisions (id : id) : bool =
 *)
 let allow_collisions (id : id) : bool =
   match id with
-  | FieldId _ | TraitParentClauseId _ | TraitItemId _ | TraitMethodId _ ->
-      !Config.record_fields_short_names
+  | FieldId _
+  | TraitParentClauseId _
+  | TraitTypeId _
+  | TraitConstId _
+  | TraitMethodId _ -> !Config.record_fields_short_names
   | FunId (Pure _ | FromLlbc (FunId (FBuiltin _), _)) ->
       (* We map several builtin functions to the same id *)
       true
@@ -730,11 +735,21 @@ let id_to_string (span : Meta.span option) (id : id) (ctx : extraction_ctx) :
   | TraitParentClauseId (id, clause_id) ->
       "trait_parent_clause_id: " ^ trait_decl_id_to_string id ^ ", clause_id: "
       ^ TraitClauseId.to_string clause_id
-  | TraitItemId (id, name) ->
-      "trait_item_id: " ^ trait_decl_id_to_string id ^ ", type name: " ^ name
+  | TraitTypeId (id, type_id) ->
+      let type_name =
+        Charon.GAstUtils.get_assoc_type_name ctx.crate id type_id
+      in
+      "trait_type_id: " ^ trait_decl_id_to_string id ^ ", type name: "
+      ^ type_name
+  | TraitConstId (id, const_id) ->
+      let const_name =
+        Charon.GAstUtils.get_assoc_const_name ctx.crate id const_id
+      in
+      "trait_const_id: " ^ trait_decl_id_to_string id ^ ", const name: "
+      ^ const_name
   | TraitMethodId (trait_decl_id, method_id) ->
       let method_name =
-        Charon.GAstUtils.format_method_name ctx.crate trait_decl_id method_id
+        Charon.GAstUtils.get_method_name ctx.crate trait_decl_id method_id
       in
       trait_decl_id_to_string trait_decl_id ^ ", method name: " ^ method_name
 
@@ -788,17 +803,13 @@ let ctx_get_trait_impl (span : Meta.span) (id : trait_impl_id)
     (ctx : extraction_ctx) : string =
   ctx_get (Some span) (TraitImplId id) ctx
 
-let ctx_get_trait_item (span : Meta.span) (id : trait_decl_id)
-    (item_name : string) (ctx : extraction_ctx) : string =
-  ctx_get (Some span) (TraitItemId (id, item_name)) ctx
-
 let ctx_get_trait_const (span : Meta.span) (id : trait_decl_id)
-    (item_name : string) (ctx : extraction_ctx) : string =
-  ctx_get_trait_item span id item_name ctx
+    (const_id : assoc_const_id) (ctx : extraction_ctx) : string =
+  ctx_get (Some span) (TraitConstId (id, const_id)) ctx
 
 let ctx_get_trait_type (span : Meta.span) (id : trait_decl_id)
-    (item_name : string) (ctx : extraction_ctx) : string =
-  ctx_get_trait_item span id item_name ctx
+    (type_id : assoc_type_id) (ctx : extraction_ctx) : string =
+  ctx_get (Some span) (TraitTypeId (id, type_id)) ctx
 
 let ctx_get_trait_method (span : Meta.span) (id : trait_decl_id)
     (method_id : trait_method_id) (ctx : extraction_ctx) : string =
@@ -2078,7 +2089,12 @@ let ctx_compute_var_basename (span : Meta.span) (ctx : extraction_ctx)
           | TPureNat -> "n"
           | TPureInt -> "i")
       | TArrow _ -> "f"
-      | TTraitType (_, name) -> name_from_type_ident name
+      | TTraitType (trait_ref, type_id) ->
+          let name =
+            Charon.GAstUtils.get_assoc_type_name ctx.crate
+              trait_ref.trait_decl_ref.trait_decl_id type_id
+          in
+          name_from_type_ident name
       | TNever | TError -> "x"
       | TDynTrait _ -> "dyn")
 
@@ -2291,12 +2307,10 @@ let ctx_add_adt_projector_names (decl_name : string) (field_names : string list)
 
     - [is_trait_decl_field]: [true] if we are computing the name of a field in a
       trait declaration, [false] if we are computing the name of a function
-      declaration.
-    - [is_fun]: [true] if we're computing the name of a function, [false] if
-      we're computing the name of a const. *)
+      declaration. *)
 let ctx_compute_fun_global_name_no_suffix (item_meta : T.item_meta)
-    (src : item_source) ~(is_trait_decl_field : bool) ~(is_fun : bool)
-    (ctx : extraction_ctx) : string =
+    (src : item_source) ~(is_trait_decl_field : bool) (ctx : extraction_ctx) :
+    string =
   let span = item_meta.span in
   (* Rename the declaration if the user added a [rename] attribute.
 
@@ -2311,51 +2325,45 @@ let ctx_compute_fun_global_name_no_suffix (item_meta : T.item_meta)
      we keep this one.
   *)
   match src with
-  | TraitImplItem (trait_impl_ref, trait_decl_ref, item_name, _) ->
+  | TraitImplItem (trait_impl_ref, trait_decl_ref, item_id, _) ->
       let item_meta =
         if Option.is_some item_meta.attr_info.rename then item_meta
         else
-          (* Lookup the trait declaration. TODO: the trait item impl info
-             should directly give us the id of the method declaration. *)
-          match
-            TraitDeclId.Map.find_opt trait_decl_ref.id ctx.trans_trait_decls
-          with
-          | None ->
-              (* This shouldn't happen - we use the decl meta info as a default value *)
-              item_meta
-          | Some trait_decl -> (
-              if is_fun then
-                (* Lookup the method in the trait items *)
-                match
-                  List.find_opt
-                    (fun (_, name, _) -> name = item_name)
-                    trait_decl.methods
-                with
-                | None -> item_meta
-                | Some (_, _, bound_fn) ->
-                    Option.value
-                      (Option.map
-                         (fun (def : A.fun_decl) -> def.item_meta)
-                         (FunDeclId.Map.find_opt bound_fn.binder_value.fun_id
-                            ctx.trans_ctx.fun_ctx.fun_decls))
-                      ~default:item_meta
-              else
-                (* Lookup the const in the trait items *)
-                match
-                  List.find_opt
-                    (fun (name, _) -> name = item_name)
-                    trait_decl.consts
-                with
-                | None -> item_meta
-                | Some _ ->
+          (* Lookup the trait declaration to find the method/const declaration's
+             meta info (where the [rename] attribute lives). *)
+          Option.value
+            (match
+               TraitDeclId.Map.find_opt trait_decl_ref.id ctx.trans_trait_decls
+             with
+            | None -> None
+            | Some trait_decl -> (
+                match item_id with
+                | AssocIdMethod method_id -> (
+                    match
+                      List.find_opt
+                        (fun (mid, _, _) -> mid = method_id)
+                        trait_decl.methods
+                    with
+                    | None -> None
+                    | Some (_, _, bound_fn) ->
+                        Option.map
+                          (fun (def : A.fun_decl) -> def.item_meta)
+                          (FunDeclId.Map.find_opt bound_fn.binder_value.fun_id
+                             ctx.trans_ctx.fun_ctx.fun_decls))
+                | AssocIdConst _ ->
                     (* TODO: missing item meta information *)
-                    item_meta)
+                    None
+                | AssocIdType _ -> None))
+            (* We use the decl meta info as a default value *)
+            ~default:item_meta
       in
       let rename = item_meta.attr_info.rename in
       let item_name =
         match rename with
         | Some name -> name
-        | None -> item_name
+        | None ->
+            Charon.GAstUtils.get_assoc_item_name ctx.crate trait_decl_ref.id
+              item_id
       in
 
       (* Use the trait impl name *)
@@ -2417,7 +2425,7 @@ let ctx_add_global_decl_and_body (def : global_decl) (ctx : extraction_ctx) :
     extraction_ctx =
   let name =
     ctx_compute_fun_global_name_no_suffix def.item_meta def.src ctx
-      ~is_trait_decl_field:false ~is_fun:false
+      ~is_trait_decl_field:false
   in
   ctx_add def.item_meta.span (GlobalId def.def_id) name ctx
 
@@ -2425,7 +2433,7 @@ let ctx_compute_fun_name (def : fun_decl) (is_trait_decl_field : bool)
     (ctx : extraction_ctx) : string =
   let fname =
     ctx_compute_fun_global_name_no_suffix def.item_meta def.src
-      ~is_trait_decl_field ~is_fun:true ctx
+      ~is_trait_decl_field ctx
   in
   (* Compute the suffix *)
   let suffix = default_fun_suffix def.num_loops def.loop_id def.loop_pos in
@@ -2449,7 +2457,7 @@ let ctx_compute_termination_measure_name (decl : fun_decl)
     (ctx : extraction_ctx) : string =
   let fname =
     ctx_compute_fun_global_name_no_suffix decl.item_meta decl.src
-      ~is_trait_decl_field:false ~is_fun:true ctx
+      ~is_trait_decl_field:false ctx
   in
   let lp_suffix =
     default_fun_suffix decl.num_loops decl.loop_id decl.loop_pos
@@ -2481,7 +2489,7 @@ let ctx_compute_decreases_proof_name (decl : fun_decl) (ctx : extraction_ctx) :
     string =
   let fname =
     ctx_compute_fun_global_name_no_suffix decl.item_meta decl.src
-      ~is_trait_decl_field:false ~is_fun:true ctx
+      ~is_trait_decl_field:false ctx
   in
   let lp_suffix =
     default_fun_suffix decl.num_loops decl.loop_id decl.loop_pos

--- a/src/extract/ExtractTypes.ml
+++ b/src/extract/ExtractTypes.ml
@@ -465,12 +465,12 @@ let rec extract_ty (span : Meta.span) (ctx : extraction_ctx) (fmt : F.formatter)
       F.pp_print_space fmt ();
       extract_rec ~inside:false ret_ty;
       if inside then F.pp_print_string fmt ")"
-  | TTraitType (trait_ref, type_name) -> (
+  | TTraitType (trait_ref, type_id) -> (
       if !parameterize_trait_types then [%admit_raise] span "Unimplemented" fmt
       else
         let type_name =
-          ctx_get_trait_type span trait_ref.trait_decl_ref.trait_decl_id
-            type_name ctx
+          ctx_get_trait_type span trait_ref.trait_decl_ref.trait_decl_id type_id
+            ctx
         in
         let add_brackets (s : string) =
           if backend () = Coq then "(" ^ s ^ ")" else s

--- a/src/interp/InterpExpressions.ml
+++ b/src/interp/InterpExpressions.ml
@@ -420,7 +420,7 @@ let eval_operand_no_reorganize (config : config) (span : Meta.span)
                 ("Encountered an unsupported constant: "
                 ^ constant_expr_to_string ctx cv
                 ^ " : " ^ ty_to_string ctx cv.ty))
-      | CTraitConst (trait_ref, const_name) -> (
+      | CTraitConst (trait_ref, const_id) -> (
           [%ldebug "trait constant"];
           let ctx0 = ctx in
           (* Simply introduce a fresh symbolic value.
@@ -463,7 +463,7 @@ let eval_operand_no_reorganize (config : config) (span : Meta.span)
                   ( ctx0,
                     None,
                     value_as_symbolic span sval.value,
-                    SymbolicAst.VaTraitConstValue (trait_ref, const_name),
+                    SymbolicAst.VaTraitConstValue (trait_ref, const_id),
                     e )
               in
               (borrow, ctx, cf)
@@ -476,7 +476,7 @@ let eval_operand_no_reorganize (config : config) (span : Meta.span)
                   ( ctx0,
                     None,
                     value_as_symbolic span v.value,
-                    SymbolicAst.VaTraitConstValue (trait_ref, const_name),
+                    SymbolicAst.VaTraitConstValue (trait_ref, const_id),
                     e )
               in
               (v, ctx, cf))

--- a/src/interp/InterpStatements.ml
+++ b/src/interp/InterpStatements.ml
@@ -637,7 +637,7 @@ let eval_non_builtin_function_call_symbolic_inst (span : Meta.span)
             [%ltrace
               "trait method call:\n- call: " ^ call_to_string ctx call
               ^ "\n- method name: "
-              ^ Charon.GAstUtils.format_method_name ctx.crate
+              ^ Charon.GAstUtils.get_method_name ctx.crate
                   trait_ref.trait_decl_ref.binder_value.id method_id
               ^ "\n- call.generics:\n"
               ^ generic_args_to_string ctx func.generics

--- a/src/llbc/TypesUtils.ml
+++ b/src/llbc/TypesUtils.ml
@@ -401,7 +401,7 @@ let generic_args_no_regions (x : generic_args) : bool =
     (including erased regions) *)
 let trait_type_constraint_no_regions (x : trait_type_constraint) : bool =
   try
-    let { trait_ref; type_name = _; ty } = x in
+    let { trait_ref; type_id = _; ty } = x in
     raise_if_region_ty_visitor#visit_trait_ref () trait_ref;
     raise_if_region_ty_visitor#visit_ty () ty;
     true

--- a/src/pure/PrintPure.ml
+++ b/src/pure/PrintPure.ml
@@ -317,7 +317,11 @@ let rec ty_to_string (env : fmt_env) (inside : bool) (ty : ty) : string =
         ty_to_string env true arg_ty ^ " -> " ^ ty_to_string env false ret_ty
       in
       if inside then "(" ^ ty ^ ")" else ty
-  | TTraitType (trait_ref, type_name) ->
+  | TTraitType (trait_ref, type_id) ->
+      let type_name =
+        Charon.GAstUtils.get_assoc_type_name env.crate
+          trait_ref.trait_decl_ref.trait_decl_id type_id
+      in
       let trait_ref = trait_ref_to_string env false trait_ref in
       let s = trait_ref ^ "::" ^ type_name in
       if inside then "(" ^ s ^ ")" else s
@@ -779,7 +783,11 @@ let decomposed_fun_type_to_string (env : fmt_env) (sg : decomposed_fun_type) :
 
 let trait_type_constraint_to_string (env : fmt_env) (c : trait_type_constraint)
     : string =
-  let { trait_ref; type_name; ty } = c in
+  let { trait_ref; type_id; ty } = c in
+  let type_name =
+    Charon.GAstUtils.get_assoc_type_name env.crate
+      trait_ref.trait_decl_ref.trait_decl_id type_id
+  in
   trait_ref_to_string env false trait_ref
   ^ "." ^ type_name ^ " = " ^ ty_to_string env false ty
 
@@ -865,7 +873,7 @@ let regular_fun_id_to_string (env : fmt_env) (fun_id : fun_id) : string =
         | FunId (FBuiltin fid) -> llbc_builtin_fun_id_to_string fid
         | TraitMethod (trait_ref, method_id, _) ->
             let method_name =
-              Charon.GAstUtils.format_method_name env.crate
+              Charon.GAstUtils.get_method_name env.crate
                 trait_ref.trait_decl_ref.trait_decl_id method_id
             in
             trait_ref_to_string env true trait_ref ^ "." ^ method_name
@@ -1057,7 +1065,11 @@ and app_to_string ?(span : Meta.span option = None) (env : fmt_env)
                 false )
           | ScalarValProj (Signed _) -> ("IScalar.val", [], false)
           | ScalarValProj (Unsigned _) -> ("UScalar.val", [], false)
-          | TraitConst (trait_ref, const_name) ->
+          | TraitConst (trait_ref, const_id) ->
+              let const_name =
+                Charon.GAstUtils.get_assoc_const_name env.crate
+                  trait_ref.trait_decl_ref.trait_decl_id const_id
+              in
               let trait_ref = trait_ref_to_string env true trait_ref in
               let qualif = trait_ref ^ "." ^ const_name in
               (qualif, [], false)

--- a/src/pure/Pure.ml
+++ b/src/pure/Pure.ml
@@ -40,8 +40,10 @@ type const_generic_var_id = T.const_generic_var_id [@@deriving show, ord]
 type trait_decl_id = T.trait_decl_id [@@deriving show, ord]
 type trait_impl_id = T.trait_impl_id [@@deriving show, ord]
 type trait_method_id = T.trait_method_id [@@deriving show, ord]
+type assoc_type_id = T.assoc_type_id [@@deriving show, ord]
+type assoc_const_id = T.assoc_const_id [@@deriving show, ord]
 type trait_clause_id = T.trait_clause_id [@@deriving show, ord]
-type trait_item_name = T.trait_item_name [@@deriving show, ord]
+type trait_item_name = A.trait_item_name [@@deriving show, ord]
 type global_decl_id = T.global_decl_id [@@deriving show, ord]
 type type_decl_id = TypeDeclId.id [@@deriving show, ord]
 type fun_decl_id = A.fun_decl_id [@@deriving show, ord]
@@ -282,6 +284,9 @@ class ['self] iter_ty_base =
     method visit_trait_method_id : 'env -> trait_method_id -> unit =
       fun _ _ -> ()
 
+    method visit_assoc_type_id : 'env -> assoc_type_id -> unit = fun _ _ -> ()
+    method visit_assoc_const_id : 'env -> assoc_const_id -> unit = fun _ _ -> ()
+
     method visit_trait_clause_id : 'env -> trait_clause_id -> unit =
       fun _ _ -> ()
 
@@ -344,6 +349,12 @@ class ['self] map_ty_base =
       fun _ x -> x
 
     method visit_trait_method_id : 'env -> trait_method_id -> trait_method_id =
+      fun _ x -> x
+
+    method visit_assoc_type_id : 'env -> assoc_type_id -> assoc_type_id =
+      fun _ x -> x
+
+    method visit_assoc_const_id : 'env -> assoc_const_id -> assoc_const_id =
       fun _ x -> x
 
     method visit_trait_clause_id : 'env -> trait_clause_id -> trait_clause_id =
@@ -410,6 +421,12 @@ class virtual ['self] reduce_ty_base =
       fun _ _ -> self#zero
 
     method visit_trait_method_id : 'env -> trait_method_id -> 'a =
+      fun _ _ -> self#zero
+
+    method visit_assoc_type_id : 'env -> assoc_type_id -> 'a =
+      fun _ _ -> self#zero
+
+    method visit_assoc_const_id : 'env -> assoc_const_id -> 'a =
       fun _ _ -> self#zero
 
     method visit_trait_clause_id : 'env -> trait_clause_id -> 'a =
@@ -496,6 +513,13 @@ class virtual ['self] mapreduce_ty_base =
         'env -> trait_method_id -> trait_method_id * 'a =
       fun _ x -> (x, self#zero)
 
+    method visit_assoc_type_id : 'env -> assoc_type_id -> assoc_type_id * 'a =
+      fun _ x -> (x, self#zero)
+
+    method visit_assoc_const_id : 'env -> assoc_const_id -> assoc_const_id * 'a
+        =
+      fun _ x -> (x, self#zero)
+
     method visit_trait_clause_id :
         'env -> trait_clause_id -> trait_clause_id * 'a =
       fun _ x -> (x, self#zero)
@@ -536,8 +560,7 @@ type ty =
     (* Note: the `de_bruijn_id`s are incorrect, see comment on `translate_region_binder` *)
   | TLiteral of literal_type
   | TArrow of ty * ty
-  | TTraitType of trait_ref * string
-      (** The string is for the name of the associated type *)
+  | TTraitType of trait_ref * assoc_type_id
   | TNever
   | TDynTrait of dyn_predicate
   | TError
@@ -584,7 +607,7 @@ and generic_params = {
 
 and trait_type_constraint = {
   trait_ref : trait_ref;
-  type_name : trait_item_name;
+  type_id : assoc_type_id;
   ty : ty;
 }
 
@@ -1225,7 +1248,7 @@ and qualif_id =
   | ScalarValProj of integer_type
       (** Projector to the mathematical integer value of a scalar type (e.g.,
           [UScalar.val : UScalar ty -> Nat]) *)
-  | TraitConst of trait_ref * string  (** A trait associated constant *)
+  | TraitConst of trait_ref * assoc_const_id  (** A trait associated constant *)
   | MkDynTrait of trait_ref  (** Dyn trait constructor *)
   | LoopOp  (** Loop fixed-point operator *)
 
@@ -1857,8 +1880,8 @@ type trait_decl = {
   preds : predicates;
   parent_clauses : trait_param list;
   llbc_parent_clauses : Types.trait_param list;
-  consts : (trait_item_name * ty) list;
-  types : trait_item_name list;
+  consts : (assoc_const_id * trait_item_name * ty) list;
+  types : (assoc_type_id * trait_item_name) list;
   methods : (trait_method_id * trait_item_name * fun_decl_ref binder) list;
 }
 [@@deriving show]
@@ -1882,8 +1905,8 @@ type trait_impl = {
           simplification of types like boxes and references. *)
   preds : predicates;
   parent_trait_refs : trait_ref list;
-  consts : (trait_item_name * global_decl_ref) list;
-  types : (trait_item_name * ty) list;
+  consts : (assoc_const_id * trait_item_name * global_decl_ref) list;
+  types : (assoc_type_id * trait_item_name * ty) list;
   methods : (trait_method_id * trait_item_name * fun_decl_ref binder) list;
 }
 [@@deriving show]

--- a/src/pure/PureMicroPassesAnnots.ml
+++ b/src/pure/PureMicroPassesAnnots.ml
@@ -215,7 +215,7 @@ let add_type_annotations_to_fun_decl (trans_ctx : trans_ctx)
             | TraitMethod (tref, method_id, method_decl_id) ->
                 [%ldebug
                   "method name: "
-                  ^ Charon.GAstUtils.format_method_name trans_ctx.crate
+                  ^ Charon.GAstUtils.get_method_name trans_ctx.crate
                       tref.trait_decl_ref.trait_decl_id method_id];
                 if Option.is_some lp_id then
                   [%craise] span

--- a/src/symbolic/PrintSymbolicAst.ml
+++ b/src/symbolic/PrintSymbolicAst.ml
@@ -31,8 +31,12 @@ let value_aggregate_to_string (env : fmt_env) (v : value_aggregate) : string =
   | VaArray vl ->
       "[" ^ String.concat ", " (List.map (Values.tvalue_to_string env) vl) ^ "]"
   | VaCgValue cg_id -> const_generic_db_var_to_string env (Free cg_id)
-  | VaTraitConstValue (trait_ref, item) ->
-      trait_ref_to_string env trait_ref ^ "." ^ item
+  | VaTraitConstValue (trait_ref, const_id) ->
+      let name =
+        Charon.GAstUtils.get_assoc_const_name env.crate
+          trait_ref.trait_decl_ref.binder_value.id const_id
+      in
+      trait_ref_to_string env trait_ref ^ "." ^ name
   | VaDiscriminant sv ->
       "@discriminant(" ^ Values.symbolic_value_to_string env sv ^ ")"
   | VaDynTrait (v, tr) ->

--- a/src/symbolic/SymbolicAst.ml
+++ b/src/symbolic/SymbolicAst.ml
@@ -320,7 +320,8 @@ and value_aggregate =
   | VaCgValue of const_generic_var_id
       (** This is used when evaluating a const generic value: in the
           interpreter, we introduce a fresh symbolic value. *)
-  | VaTraitConstValue of trait_ref * string  (** A trait constant value *)
+  | VaTraitConstValue of trait_ref * assoc_const_id
+      (** A trait constant value *)
   | VaDiscriminant of symbolic_value  (** A discriminant read *)
   | VaDynTrait of tvalue * trait_ref
       (** A dynamic trait. This gets inserted when we convert a box of an

--- a/src/symbolic/SymbolicToPure.ml
+++ b/src/symbolic/SymbolicToPure.ml
@@ -182,7 +182,6 @@ let translate_trait_decl (ctx : Contexts.decls_ctx) (trait_decl : A.trait_decl)
     consts;
     types;
     methods;
-    method_names = _;
     vtable = _;
   } : A.trait_decl =
     trait_decl
@@ -205,7 +204,7 @@ let translate_trait_decl (ctx : Contexts.decls_ctx) (trait_decl : A.trait_decl)
     match_name_find_opt ctx trait_decl.item_meta.name
       (ExtractBuiltin.builtin_trait_decls_map ())
   in
-  if types <> [] && builtin_info = None then
+  if (not (T.AssocTypeId.Map.is_empty types)) && builtin_info = None then
     (* Most associated types are removed by Charon's `--remove-associated-types`. *)
     [%warn] span
       ("Found an associated type in a trait declaration; trait associated \
@@ -218,20 +217,21 @@ let translate_trait_decl (ctx : Contexts.decls_ctx) (trait_decl : A.trait_decl)
           (IdTraitDecl trait_decl.def_id));
   let types =
     List.map
-      (fun (t : A.trait_assoc_ty T.binder) ->
+      (fun ((type_id, t) : T.AssocTypeId.id * A.trait_assoc_ty T.binder) ->
         [%cassert] span
           (t.binder_params = TypesUtils.empty_generic_params)
           "Can not extract trait associated types with parameters";
         let t = t.binder_value in
         [%cassert] span (t.implied_clauses = [])
           "Can not extract trait associated types with implied trait clauses";
-        t.name)
-      types
+        (type_id, t.name))
+      (T.AssocTypeId.Map.to_list types)
   in
   let consts =
     List.map
-      (fun (c : A.trait_assoc_const) -> (c.name, translate_ty c.ty))
-      consts
+      (fun ((const_id, c) : T.AssocConstId.id * A.trait_assoc_const) ->
+        (const_id, c.name, translate_ty c.ty))
+      (T.AssocConstId.Map.to_list consts)
   in
   let methods =
     List.map
@@ -293,9 +293,13 @@ let translate_trait_impl (ctx : Contexts.decls_ctx) (trait_impl : A.trait_impl)
   in
   let consts =
     List.map
-      (fun (name, gref) ->
-        (name, translate_global_decl_ref span translate_ty gref))
-      consts
+      (fun ((const_id, gref) : T.AssocConstId.id * _) ->
+        let name =
+          Charon.GAstUtils.get_assoc_const_name ctx.crate
+            trait_impl.impl_trait.id const_id
+        in
+        (const_id, name, translate_global_decl_ref span translate_ty gref))
+      (T.AssocConstId.Map.to_list consts)
   in
   (* We checked that there were no types in the trait declaration already. *)
   let types = [] in
@@ -303,7 +307,7 @@ let translate_trait_impl (ctx : Contexts.decls_ctx) (trait_impl : A.trait_impl)
     List.map
       (fun ((method_id, m) : TraitMethodId.id * T.fun_decl_ref T.binder) ->
         let name =
-          Charon.GAstUtils.format_method_name ctx.crate trait_impl.impl_trait.id
+          Charon.GAstUtils.get_method_name ctx.crate trait_impl.impl_trait.id
             method_id
         in
         ( method_id,

--- a/src/symbolic/SymbolicToPureExpressions.ml
+++ b/src/symbolic/SymbolicToPureExpressions.ml
@@ -1439,11 +1439,11 @@ and translate_intro_symbolic (ectx : C.eval_ctx) (p : S.mplace option)
         in
         ({ e = StructUpdate su; ty = var.ty }, false)
     | VaCgValue cg_id -> ({ e = CVar cg_id; ty = var.ty }, false)
-    | VaTraitConstValue (trait_ref, const_name) ->
+    | VaTraitConstValue (trait_ref, const_id) ->
         let trait_ref =
           translate_fwd_trait_ref (Some ctx.span) ctx.decls_ctx trait_ref
         in
-        let qualif_id = TraitConst (trait_ref, const_name) in
+        let qualif_id = TraitConst (trait_ref, const_id) in
         let qualif = { id = qualif_id; generics = empty_generic_args } in
         let ty = mk_result_ty var.ty in
         ({ e = Qualif qualif; ty }, true)

--- a/src/symbolic/SymbolicToPureTypes.ml
+++ b/src/symbolic/SymbolicToPureTypes.ml
@@ -206,10 +206,10 @@ let translate_trait_clause (span : Meta.span option) (clause : T.trait_param) :
 
 let translate_strait_type_constraint (span : Meta.span option)
     (ttc : T.trait_type_constraint) : trait_type_constraint =
-  let { T.trait_ref; type_name; ty } = ttc in
+  let { T.trait_ref; type_id; ty } = ttc in
   let trait_ref = translate_strait_ref span trait_ref in
   let ty = translate_sty span ty in
-  { trait_ref; type_name; ty }
+  { trait_ref; type_id; ty }
 
 let translate_type_param (p : T.type_param) : type_param =
   let { index; name } : T.type_param = p in

--- a/tests/src/mutually-recursive-traits.lean.out
+++ b/tests/src/mutually-recursive-traits.lean.out
@@ -3,5 +3,5 @@
 Trait declaration: mutually_recursive_traits::Trait1
 Source: Source: 'tests/src/mutually-recursive-traits.rs', lines 5:0-7:1
 Source: 'tests/src/mutually-recursive-traits.rs', lines 5:0-7:1
-Compiler source: symbolic/SymbolicToPure.ml, line 210
+Compiler source: symbolic/SymbolicToPure.ml, line 209
 


### PR DESCRIPTION
Companion to https://github.com/AeneasVerif/charon/pull/1144.

This isn't fully thorough: there may be some places deep within aeneas that use strings to identify items still, but I fixed the ones I saw.