### PR TITLE
Fix syntax issues leading to tokens being reserved

### DIFF
--- a/backends/lean/Aeneas/Command/Decompose.lean
+++ b/backends/lean/Aeneas/Command/Decompose.lean
@@ -190,19 +190,20 @@ inductive DecomposePattern where
 -- Syntax
 -- ============================================================================
 
-declare_syntax_cat decompose_pat
+/- Using `behavior := symbol` to make sure tokens in the syntax ("full", "lam", etc.) can also be used as identifiers-/
+declare_syntax_cat decompose_pat (behavior := symbol)
 
-syntax "letRange " num num : decompose_pat
-syntax "letAt " num " (" decompose_pat ")" : decompose_pat
-syntax "full" : decompose_pat
-syntax "branch " num " (" decompose_pat ")" : decompose_pat
-syntax "branch " num " full" : decompose_pat
-syntax "lam " num " (" decompose_pat ")" : decompose_pat
-syntax "lam " num " full" : decompose_pat
-syntax "appFun " "(" decompose_pat ")" : decompose_pat
-syntax "appFun " "full" : decompose_pat
-syntax "argArg " num " (" decompose_pat ")" : decompose_pat
-syntax "argArg " num " full" : decompose_pat
+syntax &"letRange" num num : decompose_pat
+syntax &"letAt" num "(" decompose_pat ")" : decompose_pat
+syntax &"full" : decompose_pat
+syntax &"branch" num "(" decompose_pat ")" : decompose_pat
+syntax &"branch" num &"full" : decompose_pat
+syntax &"lam" num "(" decompose_pat ")" : decompose_pat
+syntax &"lam" num &"full" : decompose_pat
+syntax &"appFun" "(" decompose_pat ")" : decompose_pat
+syntax &"appFun" &"full" : decompose_pat
+syntax &"argArg" num "(" decompose_pat ")" : decompose_pat
+syntax &"argArg" num &"full" : decompose_pat
 
 partial def elabDecomposePat : Syntax → Except String DecomposePattern
   | `(decompose_pat| letRange $start $count) =>

--- a/backends/lean/Aeneas/Command/Decompose/Tests.lean
+++ b/backends/lean/Aeneas/Command/Decompose/Tests.lean
@@ -10,6 +10,16 @@ open Aeneas.Std
 open Aeneas.Command.Decompose
 
 -- ============================================================================
+-- Test 0: "branch", "lam", etc. can be used as identifiers
+-- (regression test for https://github.com/AeneasVerif/aeneas/issues/1023)
+-- ============================================================================
+
+def test0 (branch : U32) (full : U32) : Result U32 := do
+  let x ← branch + 1#u32
+  let y ← full + 1#u32
+  x + y
+
+-- ============================================================================
 -- Test 1: Simple letRange — extract first 3 bindings
 -- ============================================================================
 

--- a/backends/lean/AeneasMeta/Utils.lean
+++ b/backends/lean/AeneasMeta/Utils.lean
@@ -1244,12 +1244,12 @@ def extractGoal (ref : Syntax) (fullGoal : Bool) : TacticM Unit := do
   let msg := "example" ++ assumptions ++ " :\n  " ++ goal.fmt ++ "\n  := by sorry"
   logInfoAt ref m!"{msg}"
 
-elab ref:"extract_goal0" full:"full"? : tactic => do
+elab ref:"extract_goal0" full:(&"full")? : tactic => do
   withMainContext do
   extractGoal ref full.isSome
 
 -- TODO: actually there already exists `extract_goal` in the standard library
-syntax "extract_goal1" ("full")? : tactic
+syntax "extract_goal1" (&"full")? : tactic
 
 macro_rules
 | `(tactic|extract_goal1) =>


### PR DESCRIPTION
Fixes https://github.com/AeneasVerif/aeneas/issues/1023
There were issues in `#decompose`, but also `extract_goal0` and `extract_goal1`.