### PR TITLE
Fix an issue in `Decompose.hasNoncomputableDep`

### DIFF
--- a/backends/lean/Aeneas/Command/Decompose.lean
+++ b/backends/lean/Aeneas/Command/Decompose.lean
@@ -622,6 +622,7 @@ private def hasNoncomputableDep (env : Environment) (e : Expr) : Bool :=
     acc || isNoncomputable env n ||
     match env.find? n with
     | some (.opaqueInfo _) => true
+    | some (.axiomInfo _) => true
     | _ => false
 
 /-- Add a definition, or reuse an existing one if the name already exists.


### PR DESCRIPTION
The following would fail (not added to the tests because I don't want to add an axiom):
```lean
import Aeneas
open Aeneas Aeneas.Std Result

axiom opaqueStep (n : Nat) : Result (Option Nat × Nat)

def loopX (n : Nat) (acc : Nat) : Result Nat := do
   let (o, n1) ← opaqueStep n
   match o with
   | none => ok acc
   | some i => loopX n1 (acc + i)
partial_fixpoint

#decompose loopX loopX.fold
   letRange 1 1 => loopX_match
-- error: Failed to find LCNF signature for loopX
```