### PR TITLE
Break release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,18 +41,22 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-latest
+          - os: [self-hosted, linux, nix]
             artifact_name: aeneas-linux-x86_64
             nix_attr: aeneas-static-release
+            use_nix_cache: false
           - os: ubuntu-24.04-arm
             artifact_name: aeneas-linux-aarch64
             nix_attr: aeneas-static-release
+            use_nix_cache: true
           - os: macos-15-intel
             artifact_name: aeneas-macos-x86_64
             nix_attr: aeneas-release
+            use_nix_cache: true
           - os: macos-latest
             artifact_name: aeneas-macos-aarch64
             nix_attr: aeneas-release
+            use_nix_cache: true
 
     steps:
       - uses: actions/checkout@v4
@@ -64,6 +68,7 @@ jobs:
             keep-env-derivations = true
             keep-outputs = true
       - name: Restore Nix Cache
+        if: matrix.use_nix_cache
         id: restore-nix-cache
         uses: nix-community/cache-nix-action/restore@v6
         with:
@@ -148,7 +153,7 @@ jobs:
           files: ${{ matrix.artifact_name }}.tar.gz
 
       - name: Save Nix Cache
-        if: always()
+        if: ${{ always() && matrix.use_nix_cache }}
         uses: nix-community/cache-nix-action/save@v6
         with:
           primary-key: ${{ steps.restore-nix-cache.outputs.primary-key }}

--- a/flake.nix
+++ b/flake.nix
@@ -59,11 +59,6 @@
                         '';
                       });
 
-                      containers = oPrev.containers.overrideAttrs (_: {
-                        # Tests include a flaky float computation that fails on macos-aarch64.
-                        doCheck = false;
-                      });
-
                       core_unix = oPrev.core_unix.overrideAttrs (old: {
                         # Work around a compilation error in `musl` when using
                         # GCC 14, where a `struct msghdr` field is incorrectly


### PR DESCRIPTION
Now that the release CI job is fixed (#1048), let's break it again! Specifically I'd like to see if I can reproduce the weird macos build issue (https://github.com/c-cube/ocaml-containers/issues/491) and if I can run one of the jobs on the self-hosted runner that has a nix store.