### PR TITLE
Fix several issues in the translation

### DIFF
--- a/src/interp/InterpAbs.ml
+++ b/src/interp/InterpAbs.ml
@@ -1619,6 +1619,15 @@ let project_output_at_level span (level : int) (v : tevalue) : tevalue =
 
     TODO: generalize to an arbitrary number of nestings and arbitrary relations
     input/output *)
+
+(** Set [borrow_proj] to the given value in all [EAdt] nodes of a tevalue. *)
+let rec tevalue_set_borrow_proj (bp : bool) (v : tevalue) : tevalue =
+  match v.value with
+  | EAdt { borrow_proj = _; variant_id; fields } ->
+      let fields = List.map (tevalue_set_borrow_proj bp) fields in
+      { v with value = EAdt { borrow_proj = bp; variant_id; fields } }
+  | _ -> v
+
 let abs_cont_destructure_input_output_levels (span : Meta.span) (ctx : eval_ctx)
     (output : tevalue) (input : tevalue) : tevalue * tevalue =
   (* Check if the input is a function call *)
@@ -1644,6 +1653,9 @@ let abs_cont_destructure_input_output_levels (span : Meta.span) (ctx : eval_ctx)
         [%cassert] span (max_level = 1) "Unreachable";
 
         let input1 = project_output_at_level span 1 output in
+        (* input1 was extracted from the borrow output but becomes a loan input:
+           flip borrow_proj to false *)
+        let input1 = tevalue_set_borrow_proj false input1 in
         let output = project_output_at_level span 0 output in
         [%ltrace
           "- input1:\n"

--- a/src/interp/InterpBorrows.ml
+++ b/src/interp/InterpBorrows.ml
@@ -1623,25 +1623,18 @@ and end_proj_loans_symbolic (config : config) (span : Meta.span)
           comp cc
             (end_proj_loans_symbolic config span ~snapshots chain abs_id level
                regions proj ctx))
-  | Some (SharedProjs projs) ->
+  | Some projs ->
       (* We found projectors over shared values: end the abstractions containing
          them at the proper level.  *)
       let ctx, cc =
         let abs_ids =
-          List.map (fun (abs_id, _, level) -> { abs_id; level }) projs
+          List.map
+            (fun (abs_id, _, level) -> { abs_id; level })
+            (projs.shared_projs @ projs.non_shared_projs)
         in
         let abs_ids = AbsIdWithLevelSet.of_list abs_ids in
         (* End the abstractions and continue *)
         end_abs_set_aux config span ~snapshots chain abs_ids ctx
-      in
-      (* End the loan itself *)
-      let ctx = update_aproj_loans_to_ended span abs_id proj.sv_id ctx in
-      (ctx, cc)
-  | Some (NonSharedProj (abs_id', _proj_ty, level')) ->
-      (* We found one projector of borrows in an abstraction: end the abstraction
-         at the corresponding level. *)
-      let ctx, cc =
-        end_abs_aux config span ~snapshots chain abs_id' level' ctx
       in
       (* Retry ending the projector of loans *)
       let ctx, cc =

--- a/src/interp/InterpBorrows.ml
+++ b/src/interp/InterpBorrows.ml
@@ -2572,7 +2572,8 @@ let rec simplify_dummy_values_useless_abs_aux (config : config)
       rec_call ctx
 
 let simplify_dummy_values_useless_abs (config : config)
-    ?(snapshots : bool = true) (span : Meta.span) : cm_fun =
+    ?(snapshots : bool = true) ?(filter_avalues : bool = true)
+    (span : Meta.span) : cm_fun =
  fun ctx0 ->
   [%ldebug eval_ctx_to_string ctx0];
   (* Simplify the context as long as it leads to changes - TODO: make this more efficient *)
@@ -2590,7 +2591,9 @@ let simplify_dummy_values_useless_abs (config : config)
       comp cc (simplify ctx))
   in
   let ctx, cc = simplify ctx0 in
-  let ctx = eliminate_ended_shared_loans span ctx in
+  let ctx =
+    if filter_avalues then eliminate_ended_shared_loans span ctx else ctx
+  in
   [%ltrace
     "- ctx0:\n" ^ eval_ctx_to_string ctx0 ^ "\n- ctx1:\n"
     ^ if ctx.env = ctx0.env then "UNCHANGED" else eval_ctx_to_string ctx];

--- a/src/interp/InterpBorrows.ml
+++ b/src/interp/InterpBorrows.ml
@@ -2215,7 +2215,7 @@ let find_first_endable_loan_proj_in_abs (span : Meta.span) (ctx : eval_ctx)
         | AProjLoans proj ->
             (* Check if there are borrow projectors in the context
                or symbolic values with the same id *)
-            let explore_shared = false in
+            let explore_shared = true in
             (* Look for the symbolic values first *)
             let visitor =
               object

--- a/src/interp/InterpBorrows.mli
+++ b/src/interp/InterpBorrows.mli
@@ -179,4 +179,4 @@ val eliminate_ended_shared_loans : Meta.span -> eval_ctx -> eval_ctx
       abstractions which are specified by the set of abstraction ids (we do not
       end them, nor their loans). *)
 val simplify_dummy_values_useless_abs :
-  config -> ?snapshots:bool -> Meta.span -> cm_fun
+  config -> ?snapshots:bool -> ?filter_avalues:bool -> Meta.span -> cm_fun

--- a/src/interp/InterpBorrowsCore.ml
+++ b/src/interp/InterpBorrowsCore.ml
@@ -2241,9 +2241,11 @@ let normalize_proj_ty (regions : RegionId.Set.t) (ty : rty) : rty =
   in
   visitor#visit_ty () ty
 
-(** Compute the union of two normalized projection types *)
-let rec norm_proj_tys_union (span : Meta.span) (ctx : eval_ctx) (ty1 : rty)
-    (ty2 : rty) : rty =
+(** Compute the union of two normalized projection types.
+
+    [strict]: if true, the projection types must be disjoint. *)
+let rec norm_proj_tys_union (span : Meta.span) ?(strict : bool = true)
+    (ctx : eval_ctx) (ty1 : rty) (ty2 : rty) : rty =
   match (ty1, ty2) with
   | TAdt tref1, TAdt tref2 ->
       [%sanity_check] span (tref1.id = tref2.id);
@@ -2251,7 +2253,8 @@ let rec norm_proj_tys_union (span : Meta.span) (ctx : eval_ctx) (ty1 : rty)
         {
           id = tref1.id;
           generics =
-            norm_proj_generic_args_union span ctx tref1.generics tref2.generics;
+            norm_proj_generic_args_union span ~strict ctx tref1.generics
+              tref2.generics;
         }
   | TVar id1, TVar id2 ->
       [%sanity_check] span (id1 = id2);
@@ -2263,12 +2266,12 @@ let rec norm_proj_tys_union (span : Meta.span) (ctx : eval_ctx) (ty1 : rty)
   | TRef (r1, ty1, rk1), TRef (r2, ty2, rk2) ->
       [%sanity_check] span (rk1 = rk2);
       TRef
-        ( norm_proj_regions_union span r1 r2,
-          norm_proj_tys_union span ctx ty1 ty2,
+        ( norm_proj_regions_union span ~strict r1 r2,
+          norm_proj_tys_union span ~strict ctx ty1 ty2,
           rk1 )
   | TRawPtr (ty1, rk1), TRawPtr (ty2, rk2) ->
       [%sanity_check] span (rk1 = rk2);
-      TRawPtr (norm_proj_tys_union span ctx ty1 ty2, rk1)
+      TRawPtr (norm_proj_tys_union span ~strict ctx ty1 ty2, rk1)
   | TTraitType (tr1, item1, generics1), TTraitType (tr2, item2, generics2) ->
       [%sanity_check] span (item1 = item2);
       [%sanity_check] span (generics1 = generics2);
@@ -2302,22 +2305,24 @@ let rec norm_proj_tys_union (span : Meta.span) (ctx : eval_ctx) (ty1 : rty)
       let binder_value =
         {
           is_unsafe = false;
-          inputs = List.map2 (norm_proj_tys_union span ctx) inputs1 inputs2;
-          output = norm_proj_tys_union span ctx output1 output2;
+          inputs =
+            List.map2 (norm_proj_tys_union span ~strict ctx) inputs1 inputs2;
+          output = norm_proj_tys_union span ~strict ctx output1 output2;
           abi = abi1;
         }
       in
       TFnPtr { binder_regions = []; binder_value }
   | TArray (ty0, len0), TArray (ty1, len1) ->
       [%sanity_check] span (len0 = len1);
-      TArray (norm_proj_tys_union span ctx ty0 ty1, len0)
-  | TSlice ty0, TSlice ty1 -> TSlice (norm_proj_tys_union span ctx ty0 ty1)
+      TArray (norm_proj_tys_union span ~strict ctx ty0 ty1, len0)
+  | TSlice ty0, TSlice ty1 ->
+      TSlice (norm_proj_tys_union span ~strict ctx ty0 ty1)
   | _ ->
       [%ltrace
         "- ty1: " ^ ty_to_string ctx ty1 ^ "\n- ty2: " ^ ty_to_string ctx ty2];
       [%internal_error] span
 
-and norm_proj_generic_args_union span (ctx : eval_ctx)
+and norm_proj_generic_args_union span ?(strict : bool = true) (ctx : eval_ctx)
     (generics1 : generic_args) (generics2 : generic_args) : generic_args =
   let {
     regions = regions1;
@@ -2336,8 +2341,8 @@ and norm_proj_generic_args_union span (ctx : eval_ctx)
     generics2
   in
   {
-    regions = List.map2 (norm_proj_regions_union span) regions1 regions2;
-    types = List.map2 (norm_proj_tys_union span ctx) types1 types2;
+    regions = List.map2 (norm_proj_regions_union span ~strict) regions1 regions2;
+    types = List.map2 (norm_proj_tys_union span ctx ~strict) types1 types2;
     const_generics =
       List.map2
         (norm_proj_const_generics_union span)
@@ -2346,12 +2351,13 @@ and norm_proj_generic_args_union span (ctx : eval_ctx)
       List.map2 (norm_proj_trait_refs_union span) trait_refs1 trait_refs2;
   }
 
-and norm_proj_regions_union (span : Meta.span) (r1 : region) (r2 : region) :
-    region =
+and norm_proj_regions_union (span : Meta.span) ?(strict : bool = true)
+    (r1 : region) (r2 : region) : region =
   match (r1, r2) with
   | RVar (Free _), RVar (Free _) ->
-      (* There is an intersection: the regions should be disjoint *)
-      [%internal_error] span
+      (* There is an intersection: if [strict] is true then the regions should be disjoint *)
+      [%cassert] span (not strict) "Unexpected region intersection";
+      r1
   | RVar (Free rid), RErased | RErased, RVar (Free rid) ->
       [%sanity_check] span (rid = RegionId.zero);
       RVar (Free rid)

--- a/src/interp/InterpBorrowsCore.ml
+++ b/src/interp/InterpBorrowsCore.ml
@@ -1114,21 +1114,13 @@ let proj_borrows_intersects_proj_loans (span : Meta.span) (ctx : eval_ctx)
   else false
 
 (** Result of looking up aproj_borrows which intersect a given aproj_loans in
-    the context.
-
-    Note that because we we force the expansion of primitively copyable values
-    before giving them to abstractions, we only have the following
-    possibilities:
-    - no aproj_borrows, in which case the symbolic value was either dropped or
-      is in the context
-    - exactly one aproj_borrows over a non-shared value
-    - potentially several aproj_borrows over shared values
-
-    The result contains the ids of the abstractions in which the projectors were
-    found, as well as the projection types used in those abstractions. *)
-type looked_up_aproj_borrows =
-  | NonSharedProj of AbsId.id * rty * abs_level
-  | SharedProjs of (AbsId.id * rty * abs_level) list
+    the context. *)
+type looked_up_aproj_borrows = {
+  non_shared_projs : (AbsId.id * rty * abs_level) list;
+      (** Projections appearing below a regular symbolic borrows projector *)
+  shared_projs : (AbsId.id * rty * abs_level) list;
+      (** Projections appearing below an [aproj_shared_borrows] *)
+}
 
 (** Lookup the aproj_borrows (including aproj_shared_borrows) over a symbolic
     value which intersect a given set of regions.
@@ -1140,17 +1132,13 @@ type looked_up_aproj_borrows =
 let lookup_intersecting_aproj_borrows_opt (span : Meta.span)
     (lookup_shared : bool) (regions : RegionId.Set.t) (proj : symbolic_proj)
     (ctx : eval_ctx) : looked_up_aproj_borrows option =
-  let found : looked_up_aproj_borrows option ref = ref None in
-  let set_non_shared ((id, ty, level) : AbsId.id * rty * abs_level) : unit =
-    match !found with
-    | None -> found := Some (NonSharedProj (id, ty, level))
-    | Some _ -> [%craise] span "Unreachable"
+  let shared_projs = ref [] in
+  let non_shared_projs = ref [] in
+  let add_non_shared (x : AbsId.id * rty * abs_level) : unit =
+    non_shared_projs := x :: !non_shared_projs
   in
   let add_shared (x : AbsId.id * rty * abs_level) : unit =
-    match !found with
-    | None -> found := Some (SharedProjs [ x ])
-    | Some (SharedProjs pl) -> found := Some (SharedProjs (x :: pl))
-    | Some (NonSharedProj _) -> [%craise] span "Unreachable"
+    shared_projs := x :: !shared_projs
   in
   let check_add_proj_borrows (is_shared : bool) (abs : abs) (level : abs_level)
       (proj' : symbolic_proj) =
@@ -1160,7 +1148,7 @@ let lookup_intersecting_aproj_borrows_opt (span : Meta.span)
         (regions, proj.sv_id, proj.proj_ty)
     then
       let x = (abs.abs_id, proj.proj_ty, level) in
-      if is_shared then add_shared x else set_non_shared x
+      if is_shared then add_shared x else add_non_shared x
     else ()
   in
   let visitor =
@@ -1198,27 +1186,10 @@ let lookup_intersecting_aproj_borrows_opt (span : Meta.span)
   (* Visit *)
   visitor#visit_eval_ctx None ctx;
   (* Return *)
-  !found
-
-(** Lookup the aproj_borrows (not aproj_borrows_shared!) over a symbolic value
-    which intersects a given set of regions.
-
-    Note that there should be **at most one** (one reason is that we force the
-    expansion of primitively copyable values before giving them to
-    abstractions).
-
-    Returns the id of the owning abstraction, and the projection type used in
-    this abstraction. *)
-let lookup_intersecting_aproj_borrows_not_shared_opt (span : Meta.span)
-    (regions : RegionId.Set.t) (proj : symbolic_proj) (ctx : eval_ctx) :
-    (AbsId.id * rty * abs_level) option =
-  let lookup_shared = false in
-  match
-    lookup_intersecting_aproj_borrows_opt span lookup_shared regions proj ctx
-  with
-  | None -> None
-  | Some (NonSharedProj (abs_id, rty, level)) -> Some (abs_id, rty, level)
-  | _ -> [%craise] span "Unexpected"
+  let shared_projs = !shared_projs in
+  let non_shared_projs = !non_shared_projs in
+  if shared_projs = [] && non_shared_projs = [] then None
+  else Some { shared_projs; non_shared_projs }
 
 (** Similar to {!lookup_intersecting_aproj_borrows_opt}, but updates the values.
 
@@ -2384,6 +2355,7 @@ and norm_proj_regions_union (span : Meta.span) (r1 : region) (r2 : region) :
   | RVar (Free rid), RErased | RErased, RVar (Free rid) ->
       [%sanity_check] span (rid = RegionId.zero);
       RVar (Free rid)
+  | RErased, RErased -> RErased
   | _ -> [%internal_error] span
 
 and norm_proj_trait_refs_union (span : Meta.span) (tr1 : trait_ref)

--- a/src/interp/InterpLoops.ml
+++ b/src/interp/InterpLoops.ml
@@ -247,7 +247,11 @@ let eval_loop_symbolic_synthesize_loop_body (config : config) (span : span)
 
                     method! visit_abs _ abs =
                       if AbsId.Set.mem abs.abs_id output_abs then
-                        add_abs_cont_to_abs abs loop_id
+                        let abs = add_abs_cont_to_abs abs loop_id in
+                        (* Also update the kind *)
+                        match abs.kind with
+                        | Loop _ -> abs
+                        | _ -> { abs with kind = Loop loop_id }
                       else abs
                   end
                 in

--- a/src/interp/InterpLoopsFixedPoint.ml
+++ b/src/interp/InterpLoopsFixedPoint.ml
@@ -327,7 +327,10 @@ let compute_loop_break_context (config : config) (span : Meta.span)
       (* Reorder the fresh abstractions *)
       let break_ctx = reorder_fresh_abs span false fixed_aids break_ctx in
 
-      (* Introduce continuation expressions and destructure the region abstractions. *)
+      (* Introduce continuation expressions and destructure the region abstractions.
+         Also update the kind of any fresh (non-fixed) abstraction to [Loop loop_id]:
+         abstractions introduced by function calls inside the loop body should be
+         treated as loop abstractions. *)
       let add_abs_cont_to_abs (abs : abs) (loop_id : loop_id) : abs =
         InterpAbs.add_abs_cont_to_abs span break_ctx abs
           (ELoop (abs.abs_id, loop_id))
@@ -338,12 +341,17 @@ let compute_loop_break_context (config : config) (span : Meta.span)
             inherit [_] map_eval_ctx
 
             method! visit_abs _ abs =
-              match abs.kind with
-              | Loop loop_id ->
-                  let abs = add_abs_cont_to_abs abs loop_id in
-                  InterpBorrows.destructure_abs span abs.kind ~can_end:true
-                    ~destructure_shared_values:true ctx abs
-              | _ -> abs
+              if AbsId.Set.mem abs.abs_id fixed_aids then abs
+              else
+                match abs.kind with
+                | Loop loop_id ->
+                    let abs = add_abs_cont_to_abs abs loop_id in
+                    InterpBorrows.destructure_abs span abs.kind ~can_end:true
+                      ~destructure_shared_values:true ctx abs
+                | _ ->
+                    (* Fresh non-loop abstraction (e.g., from a function call
+                       inside the loop body): update its kind to [Loop] *)
+                    { abs with kind = Loop loop_id }
           end
         in
         visitor#visit_eval_ctx () ctx

--- a/src/interp/InterpStatements.ml
+++ b/src/interp/InterpStatements.ml
@@ -770,6 +770,12 @@ let rec eval_statement (config : config) (st : statement) : stl_cm_fun =
   (* Sanity check *)
   Invariants.check_invariants st.span ctx;
 
+  (* Simplify the context *)
+  let ctx, cc =
+    comp cc
+      (InterpBorrows.simplify_dummy_values_useless_abs config
+         ~filter_avalues:false st.span ctx)
+  in
   (* Evaluate the statement *)
   comp cc (eval_statement_raw config st ctx)
 

--- a/src/interp/InterpStatements.ml
+++ b/src/interp/InterpStatements.ml
@@ -770,12 +770,6 @@ let rec eval_statement (config : config) (st : statement) : stl_cm_fun =
   (* Sanity check *)
   Invariants.check_invariants st.span ctx;
 
-  (* Simplify the context *)
-  let ctx, cc =
-    comp cc
-      (InterpBorrows.simplify_dummy_values_useless_abs config
-         ~filter_avalues:false st.span ctx)
-  in
   (* Evaluate the statement *)
   comp cc (eval_statement_raw config st ctx)
 

--- a/src/interp/Invariants.ml
+++ b/src/interp/Invariants.ml
@@ -792,6 +792,17 @@ let sv_info_to_string (ctx : eval_ctx) (info : sv_info) : string =
   ^ String.concat ", " (List.map (proj_loans_info_to_string ctx) aproj_loans)
   ^ "]\n}"
 
+(** Normalize a projection type, keeping only the "mutable" regions alive.
+
+    This is a variant of {!normalize_proj_ty} that erases shared regions, so
+    that two projections sharing a shared region don't collide. *)
+let normalize_mut_proj_ty (type_infos : TypesAnalysis.type_infos)
+    (owned_regions : RegionId.Set.t) (proj_ty : rty) : rty =
+  let conflict_regions =
+    ty_get_mutable_regions type_infos owned_regions proj_ty
+  in
+  normalize_proj_ty conflict_regions proj_ty
+
 (** Check the invariants over the symbolic values.
 
     - a symbolic value can't be both in proj_borrows and in the concrete env
@@ -803,7 +814,7 @@ let sv_info_to_string (ctx : eval_ctx) (info : sv_info) : string =
     - aproj_loans are mutually disjoint
     - TODO: aproj_borrows are mutually disjoint
     - the union of the aproj_loans contains the aproj_borrows applied on the
-      same symbolic values
+      same symbolic values (for mutable regions)
     - all symbolic evalues should contain mutable borrows/loans *)
 let check_symbolic_values (span : Meta.span) (ctx : eval_ctx) : unit =
   (* Small utility *)
@@ -896,13 +907,12 @@ let check_symbolic_values (span : Meta.span) (ctx : eval_ctx) : unit =
       (* TODO: check that:
        * - the borrows are mutually disjoint
        *)
-      (* The borrows of a symbolic value must come from somewhere: if we find a
-         symbolic values with live borrows (and particular a projection over the
-         borrows of a symbolic value), there *must* be a projection over its loans
-         (otherwise its borrows don't have corresponding loans). *)
       [%sanity_check] span (info.aproj_borrows = [] || info.aproj_loans <> []);
-      (* Check that the loan projections don't intersect and compute
-         the normalized union of those projections *)
+      (* Check that the loan projections don't intersect ON MUTABLE REGIONS
+         and compute the normalized union of those projections.
+
+         We normalize using only the "conflict" regions (mutable regions from
+         TypesAnalysis): two projections sharing a shared region don't collide. *)
       let aproj_loans =
         List.map
           (fun (linfo : proj_loans_info) ->
@@ -934,9 +944,44 @@ let check_symbolic_values (span : Meta.span) (ctx : eval_ctx) : unit =
           let borrow_proj_union =
             List.fold_left
               (fun borrow_proj_union proj_ty ->
-                norm_proj_tys_union span ctx borrow_proj_union proj_ty)
+                norm_proj_tys_union span ~strict:false ctx borrow_proj_union
+                  proj_ty)
               borrow_proj_union aproj_borrows
           in
+          (* Check that the mutable borrow projections don't collide *)
+          let _ =
+            (* Normalize to project only the mutable borrows *)
+            let aproj_mut_borrows =
+              List.filter_map
+                (fun (linfo : proj_borrows_info) ->
+                  if linfo.as_shared_value then None
+                  else
+                    Some
+                      (normalize_mut_proj_ty ctx.type_ctx.type_infos
+                         linfo.regions linfo.proj_ty))
+                info.aproj_borrows
+            in
+            match aproj_mut_borrows with
+            | [] -> () (* Nothing to do *)
+            | union :: aproj_mut_borrows ->
+                (* When using [strict] we check for collisions: if we successfully
+                   compute the union, then there are no collisions *)
+                let _ =
+                  List.fold_left
+                    (fun borrow_proj_union proj_ty ->
+                      norm_proj_tys_union span ~strict:true ctx
+                        borrow_proj_union proj_ty)
+                    union aproj_mut_borrows
+                in
+                ()
+          in
+          [%ldebug
+            "checking loan proj contains borrow proj (sid: "
+            ^ SymbolicValueId.to_string id
+            ^ "):" ^ "\n- loan_proj_union: "
+            ^ ty_to_string ctx loan_proj_union
+            ^ "\n- borrow_proj_union: "
+            ^ ty_to_string ctx borrow_proj_union];
           [%sanity_check] span
             (norm_proj_ty_contains span ctx loan_proj_union borrow_proj_union))
   in

--- a/src/llbc/TypesUtils.ml
+++ b/src/llbc/TypesUtils.ml
@@ -261,6 +261,52 @@ let ty_has_mut_borrow_for_region_in_pred (infos : TypesAnalysis.type_infos)
     false
   with Found -> true
 
+(** Compute which regions from a set are effectively used as mutable borrows in
+    a type. Note that a mutable borrow below a shared borrow is effectively
+    shared. *)
+let ty_get_mutable_regions (infos : TypesAnalysis.type_infos)
+    (owned_regions : RegionId.Set.t) (ty : rty) : RegionId.Set.t =
+  let result = ref RegionId.Set.empty in
+  let add_region (r : region) =
+    match r with
+    | RVar (Free rid) ->
+        if RegionId.Set.mem rid owned_regions then
+          result := RegionId.Set.add rid !result
+    | _ -> ()
+  in
+
+  let obj =
+    object
+      inherit [_] iter_ty as super
+
+      method! visit_TRef env r ty rkind =
+        match rkind with
+        | RMut ->
+            add_region r;
+            super#visit_TRef env r ty rkind
+        | RShared ->
+            (* Stop there: borrows below shared borrows are effectively shared *)
+            ()
+
+      method! visit_TAdt env tref =
+        (* Lookup the information for this ADT *)
+        begin
+          match tref.id with
+          | TTuple | TBuiltin (TBox | TStr) -> ()
+          | TAdtId adt_id ->
+              (* Check which region parameters are mutable *)
+              let info = TypeDeclId.Map.find adt_id infos in
+              RegionId.iteri
+                (fun adt_rid r ->
+                  if RegionId.Set.mem adt_rid info.mut_regions then add_region r)
+                tref.generics.regions
+        end;
+        super#visit_TAdt env tref
+    end
+  in
+  obj#visit_ty () ty;
+  !result
+
 let ty_has_mut_borrow_for_region_in_set (infos : TypesAnalysis.type_infos)
     (regions : RegionId.Set.t) (ty : ty) : bool =
   ty_has_mut_borrow_for_region_in_pred infos

--- a/src/symbolic/SymbolicToPureAbs.ml
+++ b/src/symbolic/SymbolicToPureAbs.ml
@@ -310,6 +310,12 @@ let compute_tevalue_proj_kind (span : Meta.span) (type_infos : type_infos)
           set_has_loans level;
           set_has_mut_loans level)
 
+      method! visit_EValue (level, _ty) _ _ =
+        (* An EValue is essentially an ended loan: it is a concrete value
+           consumed by the backward function. We treat it as a mutable loan
+           so that the containing ADT is not classified as UnknownProj. *)
+        set_has_mut_loans level
+
       method! visit_ESymbolic (level, ty) pm eproj =
         [%sanity_check] span (pm = PNone);
         match eproj with
@@ -718,7 +724,17 @@ let einput_to_texpr (ctx : bs_ctx) (ectx : C.eval_ctx) (rids : T.RegionId.Set.t)
                       match (f, args) with
                       | (V.ELoop _ | V.EJoin _), [ args ] -> args
                       | V.EFunCall _, _ ->
-                          List.map (mk_simpl_tuple_texpr span) args
+                          (* Filter out empty argument groups (e.g., from
+                             unit return values that got filtered away) *)
+                          let args =
+                            List.filter_map
+                              (fun args ->
+                                match args with
+                                | [] -> None
+                                | _ -> Some (mk_simpl_tuple_texpr span args))
+                              args
+                          in
+                          args
                       | _ -> [%internal_error] span
                     in
                     (Some ([%add_loc] mk_apps span fvar args), can_fail)
@@ -741,8 +757,7 @@ let einput_to_texpr (ctx : bs_ctx) (ectx : C.eval_ctx) (rids : T.RegionId.Set.t)
               in
               mk_adt_texpr span ty variant_id fields)
             (mk_simpl_tuple_texpr span)
-            (* Stop filtering once we enter an ADT *)
-            ~filter:false ctx input input.ty fields
+            ~filter ctx input input.ty fields
         in
         match out with
         | None -> (ctx, false, None)

--- a/src/symbolic/SymbolicToPureExpressions.ml
+++ b/src/symbolic/SymbolicToPureExpressions.ml
@@ -1072,18 +1072,27 @@ and translate_end_abstraction_fun_call (ectx : C.eval_ctx) (abs : V.abs)
       !inputs
     in
     (* Retrieve the values given back by this function: those are the output
-     * values. We rely on the fact that there are no nested borrows to use the
-     * meta-place information from the input values given to the forward function
-     * (we need to add [None] for the return avalue) *)
+       values. We rely on the fact that there are no nested borrows to use the
+       meta-place information from the input values given to the forward function
+       (we need to add [None] for the return avalue).
+
+       Note: [simplify_dummy_vales_useless_abs] modifies the structure of the
+       abstractions with the consequence that the avalues don't match the
+       places - we check that the length is the same for this reason.
+       TODO: fix the issue. The problem comes from the fact that [simplify_dummy_vales_useless_abs]
+       sometimes filters avalues. We should store the place the value comes from
+       as meta-information. *)
     let output_mpl =
-      List.append
-        (List.map
-           (translate_opt_mplace (Some call.span) ctx.decls_ctx)
-           call.args_places)
-        [ None ]
+      let mpl =
+        List.append
+          (List.map
+             (translate_opt_mplace (Some call.span) ctx.decls_ctx)
+             call.args_places)
+          [ None ]
+      in
+      if List.length mpl = List.length abs.avalues then Some mpl else None
     in
-    [%sanity_check] ctx.span (List.length output_mpl = List.length abs.avalues);
-    let ctx, outputs = abs_to_given_back (Some output_mpl) abs abs_level ctx in
+    let ctx, outputs = abs_to_given_back output_mpl abs abs_level ctx in
     (* Group the output values together *)
     let output = mk_simpl_tuple_pat outputs in
     (* Translate the next expression *)

--- a/src/symbolic/SymbolicToPureExpressions.ml
+++ b/src/symbolic/SymbolicToPureExpressions.ml
@@ -1082,6 +1082,7 @@ and translate_end_abstraction_fun_call (ectx : C.eval_ctx) (abs : V.abs)
            call.args_places)
         [ None ]
     in
+    [%sanity_check] ctx.span (List.length output_mpl = List.length abs.avalues);
     let ctx, outputs = abs_to_given_back (Some output_mpl) abs abs_level ctx in
     (* Group the output values together *)
     let output = mk_simpl_tuple_pat outputs in

--- a/src/symbolic/SymbolicToPureValues.ml
+++ b/src/symbolic/SymbolicToPureValues.ml
@@ -386,8 +386,6 @@ let gtranslate_adt_fields ~(project_borrows : bool)
             let info_fields = List.filter_map (fun x -> x) info_fields in
             if info_fields = [] then (ctx, None)
             else
-              (* Note that if there is exactly one field value,
-               * [mk_simpl_tuple_rvalue] is the identity *)
               let info, fields = List.split info_fields in
               (ctx, Some (info, mk_tuple fields))
           else

--- a/tests/lean/Loops.lean
+++ b/tests/lean/Loops.lean
@@ -1234,4 +1234,28 @@ def as_radix_minimized : Result Unit := do
   let scalar := Array.repeat 4#usize 0#u64
   as_radix_minimized_loop scalar 0#usize
 
+/-- [loops::single_break]: loop body 0:
+    Source: 'tests/src/loops.rs', lines 583:4-587:5 -/
+@[rust_loop_body]
+def single_break_loop.body
+  (d : Slice Std.U8) : Result (ControlFlow Unit Unit) := do
+  let i ← Slice.index_usize d 0#usize
+  if i = 0#u8
+  then ok (done ())
+  else ok (cont ())
+
+/-- [loops::single_break]: loop 0:
+    Source: 'tests/src/loops.rs', lines 583:4-587:5 -/
+@[rust_loop]
+def single_break_loop (d : Slice Std.U8) : Result Unit := do
+  loop
+    (fun () => single_break_loop.body d)
+    ()
+
+/-- [loops::single_break]:
+    Source: 'tests/src/loops.rs', lines 582:0-588:1 -/
+@[reducible]
+def single_break (d : Slice Std.U8) : Result Unit := do
+  single_break_loop d
+
 end loops

--- a/tests/lean/NestedBorrows.lean
+++ b/tests/lean/NestedBorrows.lean
@@ -378,7 +378,7 @@ structure MutBorrow where
   p : Std.U32
 
 /-- [nested_borrows::{nested_borrows::MutBorrow<'a>}::store]:
-    Source: 'tests/src/nested-borrows.rs', lines 169:4-169:51
+    Source: 'tests/src/nested-borrows.rs', lines 169:4-171:5
     Visibility: public -/
 def MutBorrow.store
   (self : MutBorrow) (v : Std.U32) :
@@ -387,7 +387,7 @@ def MutBorrow.store
   ok ({ p := v }, fun self1 => self1)
 
 /-- [nested_borrows::use_mut_borrow]: loop body 0:
-    Source: 'tests/src/nested-borrows.rs', lines 174:4-177:5
+    Source: 'tests/src/nested-borrows.rs', lines 176:4-179:5
     Visibility: public -/
 @[rust_loop_body]
 def use_mut_borrow_loop.body
@@ -402,7 +402,7 @@ def use_mut_borrow_loop.body
   else ok (done (back i))
 
 /-- [nested_borrows::use_mut_borrow]: loop 0:
-    Source: 'tests/src/nested-borrows.rs', lines 174:4-177:5
+    Source: 'tests/src/nested-borrows.rs', lines 176:4-179:5
     Visibility: public -/
 @[rust_loop]
 def use_mut_borrow_loop
@@ -414,7 +414,7 @@ def use_mut_borrow_loop
     (back, i, i1)
 
 /-- [nested_borrows::use_mut_borrow]:
-    Source: 'tests/src/nested-borrows.rs', lines 172:0-178:1
+    Source: 'tests/src/nested-borrows.rs', lines 174:0-180:1
     Visibility: public -/
 def use_mut_borrow (b : MutBorrow) (n : Std.Usize) : Result MutBorrow := do
   let back ← use_mut_borrow_loop (fun i => i) b.p n 0#usize

--- a/tests/lean/NestedBorrows.lean
+++ b/tests/lean/NestedBorrows.lean
@@ -371,4 +371,53 @@ def BitReader.peek
   let i1 ← lift (i &&& 1#u64)
   ok (i1, { data := s, bit_buf := i })
 
+/-- [nested_borrows::MutBorrow]
+    Source: 'tests/src/nested-borrows.rs', lines 164:0-166:1
+    Visibility: public -/
+structure MutBorrow where
+  p : Std.U32
+
+/-- [nested_borrows::{nested_borrows::MutBorrow<'a>}::store]:
+    Source: 'tests/src/nested-borrows.rs', lines 169:4-169:51
+    Visibility: public -/
+def MutBorrow.store
+  (self : MutBorrow) (v : Std.U32) :
+  Result (MutBorrow × (MutBorrow → MutBorrow))
+  := do
+  ok ({ p := v }, fun self1 => self1)
+
+/-- [nested_borrows::use_mut_borrow]: loop body 0:
+    Source: 'tests/src/nested-borrows.rs', lines 174:4-177:5
+    Visibility: public -/
+@[rust_loop_body]
+def use_mut_borrow_loop.body
+  (n : Std.Usize) (back : Std.U32 → Std.U32) (i : Std.U32) (i1 : Std.Usize) :
+  Result (ControlFlow ((Std.U32 → Std.U32) × Std.U32 × Std.Usize) Std.U32)
+  := do
+  if i1 < n
+  then
+    let (b, store_back) ← MutBorrow.store { p := i } 0#u32
+    let i2 ← i1 + 1#usize
+    ok (cont (fun i3 => back (store_back { p := i3 }).p, b.p, i2))
+  else ok (done (back i))
+
+/-- [nested_borrows::use_mut_borrow]: loop 0:
+    Source: 'tests/src/nested-borrows.rs', lines 174:4-177:5
+    Visibility: public -/
+@[rust_loop]
+def use_mut_borrow_loop
+  (back : Std.U32 → Std.U32) (i : Std.U32) (n : Std.Usize) (i1 : Std.Usize) :
+  Result Std.U32
+  := do
+  loop
+    (fun (back1, i2, i3) => use_mut_borrow_loop.body n back1 i2 i3)
+    (back, i, i1)
+
+/-- [nested_borrows::use_mut_borrow]:
+    Source: 'tests/src/nested-borrows.rs', lines 172:0-178:1
+    Visibility: public -/
+def use_mut_borrow (b : MutBorrow) (n : Std.Usize) : Result MutBorrow := do
+  let back ← use_mut_borrow_loop (fun i => i) b.p n 0#usize
+  ok { p := back }
+
 end nested_borrows

--- a/tests/lean/lakefile.lean
+++ b/tests/lean/lakefile.lean
@@ -65,7 +65,7 @@ package «tests» {}
 @[default_target] lean_lib MiniTree
 @[default_target] lean_lib MultiTarget
 @[default_target] lean_lib MutBorrowInSharedBorrow
-@[default_target] lean_lib OpaqueMutRegions
+@[default_target] lean_lib OpaqueMutRegion
 @[default_target] lean_lib Names
 @[default_target] lean_lib NestedBorrows
 @[default_target] lean_lib NoNestedBorrows

--- a/tests/src/loops.rs
+++ b/tests/src/loops.rs
@@ -575,3 +575,14 @@ fn as_radix_minimized() {
         i += 1;
     }
 }
+
+// Combination of a loop with a single break and a single function call.
+// Used to trigger a bug where the fresh region abstractions would not see their
+// kind updated from [FunCall] to [Loop].
+fn single_break(d: &[u8]) {
+    loop {
+        if d[0] == 0 {
+            break;
+        }
+    }
+}

--- a/tests/src/nested-borrows.rs
+++ b/tests/src/nested-borrows.rs
@@ -166,7 +166,9 @@ pub struct MutBorrow<'a> {
 }
 
 impl<'a> MutBorrow<'a> {
-    pub fn store(&mut self, v: u32) { *self.p = v }
+    pub fn store(&mut self, v: u32) {
+        *self.p = v
+    }
 }
 
 pub fn use_mut_borrow(mut b: MutBorrow<'_>, n: usize) {
@@ -176,7 +178,6 @@ pub fn use_mut_borrow(mut b: MutBorrow<'_>, n: usize) {
         i += 1;
     }
 }
-
 
 /*
 pub fn id_mut_mut<'a, 'b, T>(x: &'a mut &'b mut T) -> &'a mut &'b mut T {

--- a/tests/src/nested-borrows.rs
+++ b/tests/src/nested-borrows.rs
@@ -161,6 +161,23 @@ impl<'a> BitReader<'a> {
     fn refill(&mut self) {}
 }
 
+pub struct MutBorrow<'a> {
+    p: &'a mut u32,
+}
+
+impl<'a> MutBorrow<'a> {
+    pub fn store(&mut self, v: u32) { *self.p = v }
+}
+
+pub fn use_mut_borrow(mut b: MutBorrow<'_>, n: usize) {
+    let mut i = 0usize;
+    while i < n {
+        b.store(0);
+        i += 1;
+    }
+}
+
+
 /*
 pub fn id_mut_mut<'a, 'b, T>(x: &'a mut &'b mut T) -> &'a mut &'b mut T {
     x

--- a/tests/src/step_by.rs
+++ b/tests/src/step_by.rs
@@ -165,6 +165,6 @@ mod tests {
     #[should_panic]
     fn step_by_0_panics() {
         let v: [u32; 3] = [1, 2, 3];
-        v.iter().step_by(0);
+        let _ = v.iter().step_by(0);
     }
 }


### PR DESCRIPTION
This fixes the following issues:
- there can exist intersecting borrow projectors for shared borrows (or mutable borrows that are used behind shared borrows)
- the code that computed the contexts at break points would not properly update the kind of some region abstractions to `Loop`
- there were minor bugs in `SymbolicToPure...` when translating functions that manipulate ADTs