### PR TITLE
Support for partial mvcgen specs

### DIFF
--- a/backends/lean/Aeneas/Std/Array/Array.lean
+++ b/backends/lean/Aeneas/Std/Array/Array.lean
@@ -116,9 +116,11 @@ theorem Array.repeat_val (n : Usize) (x : α) : (Array.repeat n x).val = List.re
   simp only [Array.repeat]
 
 @[step]
-theorem Array.index_usize_spec {α : Type u} {n : Usize} (v: Array α n) (i: Usize)
-  (hbound : i.val < v.length) :
-  (v.index_usize i) ⦃ x => x = v.val[i.val] ⦄ := by
+theorem Array.index_usize_spec {α : Type u} {n : Usize} (v: Array α n) (i: Usize) :
+    partialSpec (v.index_usize i)
+      (fun x => ∃ _ : i.val < v.length, x = v.val[i.val])
+      (fun | .arrayOutOfBounds => i.val ≥ v.length | _ => False)
+      False := by
   grind [index_usize]
 
 def Array.set {α : Type u} {n : Usize} (v: Array α n) (i: Usize) (x: α) : Array α n :=
@@ -215,13 +217,14 @@ def Array.update {α : Type u} {n : Usize} (v: Array α n) (i: Usize) (x: α) : 
     ok ⟨ v.val.set i.val x, by have := v.property; simp [*] ⟩
 
 @[step]
-theorem Array.update_spec {α : Type u} {n : Usize} (v: Array α n) (i: Usize) (x : α)
-  (hbound : i.val < v.length) :
-  v.update i x ⦃ nv => nv = v.set i x ⦄
+theorem Array.update_spec {α : Type u} {n : Usize} (v: Array α n) (i: Usize) (x : α) :
+    partialSpec (v.update i x)
+      (fun nv => nv = v.set i x)
+      (fun | .arrayOutOfBounds => i.val ≥ v.length | _ => False)
+      False
   := by
-  simp only [update, set]
-  simp at *
-  split <;> simp_all
+  simp only [partialSpec, update, set]
+  cases hopt : v[i]? <;> simp_all
 
 def Array.index_mut_usize {α : Type u} {n : Usize} (v: Array α n) (i: Usize) :
   Result (α × (α -> Array α n)) := do
@@ -229,12 +232,14 @@ def Array.index_mut_usize {α : Type u} {n : Usize} (v: Array α n) (i: Usize) :
   ok (x, set v i)
 
 @[step]
-theorem Array.index_mut_usize_spec {α : Type u} {n : Usize} (v: Array α n) (i: Usize)
-  (hbound : i.val < v.length) :
-  v.index_mut_usize i ⦃ x back => x = v.val[i.val] ∧ back = set v i ⦄ := by
-  simp only [index_mut_usize, Bind.bind, bind]
-  have ⟨ x, h ⟩ := spec_imp_exists (index_usize_spec v i hbound)
-  simp [h]
+theorem Array.index_mut_usize_spec {α : Type u} {n : Usize} (v: Array α n) (i: Usize) :
+    partialSpec (v.index_mut_usize i)
+      (uncurry' fun x back => ∃ _ : i.val < v.length, x = v.val[i.val] ∧ back = set v i)
+      (fun | .arrayOutOfBounds => i.val ≥ v.length | _ => False)
+      False := by
+  have h := index_usize_spec v i
+  simp only [partialSpec, index_mut_usize, Bind.bind, bind, uncurry'] at h ⊢
+  cases hres : v.index_usize i <;> simp_all
 
 @[simp]
 theorem Array.set_getElem!_eq {α} {n : Usize} [Inhabited α] (x : Array α n) (i : Usize) :

--- a/backends/lean/Aeneas/Std/Array/ArraySlice.lean
+++ b/backends/lean/Aeneas/Std/Array/ArraySlice.lean
@@ -54,16 +54,20 @@ def Array.subslice {α : Type u} {n : Usize} (a : Array α n) (r : Range Usize) 
     fail panic
 
 @[step]
-theorem Array.subslice_spec {α : Type u} {n : Usize} [Inhabited α] (a : Array α n) (r : Range Usize)
-  (h0 : r.start.val < r.end.val) (h1 : r.end.val ≤ a.val.length) :
-  subslice a r ⦃ s =>
-  s.val = a.val.slice r.start.val r.end.val ∧
-  (∀ i, i + r.start.val < r.end.val → s.val[i]! = a.val[r.start.val + i]!) ⦄
+theorem Array.subslice_spec {α : Type u} {n : Usize} [Inhabited α] (a : Array α n) (r : Range Usize) :
+    partialSpec (subslice a r)
+      (fun s =>
+        s.val = a.val.slice r.start.val r.end.val ∧
+        (∀ i, i + r.start.val < r.end.val → s.val[i]! = a.val[r.start.val + i]!))
+      (fun | .panic => ¬ (r.start.val < r.end.val ∧ r.end.val ≤ a.val.length) | _ => False)
+      False
   := by
-  simp only [subslice, true_and, h0, h1, ↓reduceIte, spec_ok, true_and]
-  intro i _
-  have := List.getElem!_slice r.start.val r.end.val i a.val (by scalar_tac)
-  simp only [this]
+  unfold subslice
+  split <;> rename_i h <;> simp [partialSpec]
+  · intro i _
+    have := List.getElem!_slice r.start.val r.end.val i a.val (by scalar_tac)
+    simp only [this]
+  · scalar_tac
 
 
 def Array.update_subslice {α : Type u} {n : Usize} (a : Array α n) (r : Range Usize) (s : Slice α) : Result (Array α n) :=
@@ -79,17 +83,20 @@ def Array.update_subslice {α : Type u} {n : Usize} (a : Array α n) (r : Range 
 -- We should introduce special symbols for the monadic arithmetic operations
 -- (the user will never write those symbols directly).
 @[step]
-theorem Array.update_subslice_spec {α : Type u} {n : Usize} [Inhabited α] (a : Array α n) (r : Range Usize) (s : Slice α)
-  (_ : r.start.val < r.end.val) (_ : r.end.val ≤ a.length) (_ : s.length = r.end.val - r.start.val) :
-  update_subslice a r s ⦃ na =>
-  (∀ i, i < r.start.val → na[i]! = a[i]!) ∧
-  (∀ i, r.start.val ≤ i → i < r.end.val → na[i]! = s[i - r.start.val]!) ∧
-  (∀ i, r.end.val ≤ i → i < n.val → na[i]! = a[i]!) ⦄ := by
-  simp [update_subslice]
-  split
-  . simp [spec_ok]
-    simp_lists
-  . scalar_tac
+theorem Array.update_subslice_spec {α : Type u} {n : Usize} [Inhabited α] (a : Array α n) (r : Range Usize) (s : Slice α) :
+    partialSpec (update_subslice a r s)
+      (fun na =>
+        (∀ i, i < r.start.val → na[i]! = a[i]!) ∧
+        (∀ i, r.start.val ≤ i → i < r.end.val → na[i]! = s[i - r.start.val]!) ∧
+        (∀ i, r.end.val ≤ i → i < n.val → na[i]! = a[i]!))
+      (fun | .panic =>
+              ¬ (r.start.val < r.end.val ∧ r.end.val ≤ a.length ∧ s.val.length = r.end.val - r.start.val)
+           | _ => False)
+      False := by
+  unfold update_subslice
+  split <;> rename_i h <;> simp [partialSpec]
+  · simp_lists
+  · scalar_tac
 
 @[rust_fun "core::array::{core::ops::index::Index<[@T; @N], @I, @O>}::index"]
 def core.array.Array.index
@@ -399,38 +406,41 @@ theorem Array.index_SliceIndexRangeUsizeSlice {T : Type} {N : Usize}
 
 @[step]
 theorem Array.index_SliceIndexRangeUsizeSlice.step {T : Type} {N : Usize} [Inhabited T]
-    (a : Array T N) (r : core.ops.range.Range Usize)
-    (h0 : r.start ≤ r.end) (h1 : r.end ≤ N) :
-    core.array.Array.index (core.ops.index.IndexSlice
-      (core.slice.index.SliceIndexRangeUsizeSlice T)) a r
-    ⦃ (s : Slice T) =>
-      s.val = a.val.slice r.start r.end ∧
-      s.length = r.end.val - r.start.val ⦄ := by
+    (a : Array T N) (r : core.ops.range.Range Usize) :
+    partialSpec
+      (core.array.Array.index (core.ops.index.IndexSlice
+        (core.slice.index.SliceIndexRangeUsizeSlice T)) a r)
+      (fun (s : Slice T) =>
+        s.val = a.val.slice r.start r.end ∧
+        s.length = r.end.val - r.start.val)
+      (fun | .panic => ¬ (r.start ≤ r.end ∧ r.end ≤ N) | _ => False)
+      False := by
   simp only [Array.index_SliceIndexRangeUsizeSlice]
   have hts : a.to_slice.length = N := by simp [Array.to_slice, Slice.length]
-  simp only [core.slice.index.SliceIndexRangeUsizeSlice.index, UScalar.le_equiv, Slice.length]
-  split
-  · simp [spec_ok, Array.to_slice]; scalar_tac
+  unfold core.slice.index.SliceIndexRangeUsizeSlice.index
+  split <;> rename_i h <;> simp [partialSpec, Array.to_slice, Slice.length]
+  · scalar_tac
   · scalar_tac
 
 @[step]
 theorem Array.index_mut_SliceIndexRangeUsizeSlice.step {T : Type} {N : Usize} [Inhabited T]
-    (a : Array T N) (r : core.ops.range.Range Usize)
-    (h0 : r.start ≤ r.end) (h1 : r.end ≤ N) :
-    core.array.Array.index_mut (core.ops.index.IndexMutSlice
-      (core.slice.index.SliceIndexRangeUsizeSlice T)) a r
-    ⦃ (s : Slice T) (back : Slice T → Array T N) =>
-      s.val = a.val.slice r.start r.end ∧
-      s.length = r.end.val - r.start.val ∧
-      ∀ s', (back s').val = a.val.setSlice! r.start.val s'.val ⦄ := by
+    (a : Array T N) (r : core.ops.range.Range Usize) :
+    partialSpec
+      (core.array.Array.index_mut (core.ops.index.IndexMutSlice
+        (core.slice.index.SliceIndexRangeUsizeSlice T)) a r)
+      (uncurry' fun (s : Slice T) (back : Slice T → Array T N) =>
+        s.val = a.val.slice r.start r.end ∧
+        s.length = r.end.val - r.start.val ∧
+        ∀ s', (back s').val = a.val.setSlice! r.start.val s'.val)
+      (fun | .panic => ¬ (r.start ≤ r.end ∧ r.end ≤ N) | _ => False)
+      False := by
   simp only [core.array.Array.index_mut, core.ops.index.IndexMutSlice,
     core.slice.index.Slice.index_mut]
   have hts : a.to_slice.length = N := by simp [Array.to_slice, Slice.length]
-  simp only [core.slice.index.SliceIndexRangeUsizeSlice.index_mut,
-    UScalar.le_equiv, Slice.length]
-  split
-  · simp [spec_ok, Array.from_slice, Array.to_slice]
-    simp_lists; scalar_tac
+  unfold core.slice.index.SliceIndexRangeUsizeSlice.index_mut
+  split <;> rename_i h <;>
+    simp [partialSpec, Array.from_slice, Array.to_slice, uncurry', Slice.length]
+  · simp_lists; scalar_tac
   · scalar_tac
 
 -- Array index/index_mut with RangeTo
@@ -444,23 +454,23 @@ theorem Array.index_SliceIndexRangeToUsizeSlice {T : Type} {N : Usize}
 
 @[step]
 theorem Array.index_mut_SliceIndexRangeToUsizeSlice {T : Type} {N : Usize}
-    (a : Array T N) (r : core.ops.range.RangeTo Usize)
-    (h : r.end ≤ N) :
-    core.array.Array.index_mut (core.ops.index.IndexMutSlice
-      (core.slice.index.SliceIndexRangeToUsizeSlice T)) a r
-    ⦃ (s : Slice T) (back : Slice T → Array T N) =>
-      s.val = a.val.slice 0 r.end ∧
-      s.length = r.end.val ∧
-      ∀ s', (back s').val = a.val.setSlice! 0 s'.val ⦄ := by
+    (a : Array T N) (r : core.ops.range.RangeTo Usize) :
+    partialSpec
+      (core.array.Array.index_mut (core.ops.index.IndexMutSlice
+        (core.slice.index.SliceIndexRangeToUsizeSlice T)) a r)
+      (uncurry' fun (s : Slice T) (back : Slice T → Array T N) =>
+        s.val = a.val.slice 0 r.end ∧
+        s.length = r.end.val ∧
+        ∀ s', (back s').val = a.val.setSlice! 0 s'.val)
+      (fun | .panic => ¬ r.end ≤ N | _ => False)
+      False := by
   simp only [core.array.Array.index_mut, core.ops.index.IndexMutSlice,
     core.slice.index.Slice.index_mut]
   have hts : a.to_slice.length = N := by simp [Array.to_slice, Slice.length]
-  simp only [core.slice.index.SliceIndexRangeToUsizeSlice.index_mut,
-    show (r.end : Usize) ≤ a.to_slice.length from by scalar_tac]
-  refine ⟨?_, ?_, ?_⟩
-  · simp [Array.to_slice]
-  · simp [Slice.length]; scalar_tac
-  · intro s'; simp [Array.from_slice, Array.to_slice]
+  unfold core.slice.index.SliceIndexRangeToUsizeSlice.index_mut
+  split <;> rename_i h <;>
+    simp [partialSpec, Array.from_slice, Array.to_slice, uncurry', Slice.length] <;>
+    scalar_tac
 
 -- Array index/index_mut with RangeFrom
 
@@ -473,24 +483,24 @@ theorem Array.index_SliceIndexRangeFromUsizeSlice {T : Type} {N : Usize}
 
 @[step]
 theorem Array.index_mut_SliceIndexRangeFromUsizeSlice {T : Type} {N : Usize}
-    (a : Array T N) (r : core.ops.range.RangeFrom Usize)
-    (h : r.start ≤ N) :
-    core.array.Array.index_mut (core.ops.index.IndexMutSlice
-      (core.slice.index.SliceIndexRangeFromUsizeSlice T)) a r
-    ⦃ (s : Slice T) (back : Slice T → Array T N) =>
-      s.val = a.val.drop r.start ∧
-      s.length = N.val - r.start.val ∧
-      ∀ s', (back s').val = a.val.setSlice! r.start.val s'.val ⦄ := by
+    (a : Array T N) (r : core.ops.range.RangeFrom Usize) :
+    partialSpec
+      (core.array.Array.index_mut (core.ops.index.IndexMutSlice
+        (core.slice.index.SliceIndexRangeFromUsizeSlice T)) a r)
+      (uncurry' fun (s : Slice T) (back : Slice T → Array T N) =>
+        s.val = a.val.drop r.start ∧
+        s.length = N.val - r.start.val ∧
+        ∀ s', (back s').val = a.val.setSlice! r.start.val s'.val)
+      (fun | .panic => ¬ r.start ≤ N | _ => False)
+      False := by
   simp only [core.array.Array.index_mut, core.ops.index.IndexMutSlice,
     core.slice.index.Slice.index_mut]
   have hts : a.to_slice.length = N := by simp [Array.to_slice, Slice.length]
-  simp only [core.slice.index.SliceIndexRangeFromUsizeSlice.index_mut,
-    Slice.drop,
-    show (r.start : Usize) ≤ a.to_slice.length from by scalar_tac]
-  refine ⟨?_, ?_, ?_⟩
-  · simp [Array.to_slice]
-  · simp [Slice.length, List.length_drop]
-  · intro s'; simp [Array.from_slice, Array.to_slice]
+  unfold core.slice.index.SliceIndexRangeFromUsizeSlice.index_mut
+  split <;> rename_i h <;>
+    simp [partialSpec, Array.from_slice, Array.to_slice, uncurry',
+          Slice.length, Slice.drop, List.length_drop];
+    scalar_tac
 
 @[reducible, rust_trait_impl "core::convert::AsRef<[@T; @N], [@T]>"]
 def Array.Insts.CoreConvertAsRefSlice (T : Type) (N : Std.Usize) :

--- a/backends/lean/Aeneas/Std/Scalar/Ops/Add.lean
+++ b/backends/lean/Aeneas/Std/Scalar/Ops/Add.lean
@@ -39,14 +39,14 @@ theorem UScalar.add_equiv {ty} (x y : UScalar ty) :
   | ok z => x.val + y.val < 2^ty.numBits ∧
     z.val = x.val + y.val ∧
     z.bv = x.bv + y.bv
-  | fail _ => ¬ (UScalar.inBounds ty (x.val + y.val))
+  | fail e => e = .integerOverflow ∧ ¬ (UScalar.inBounds ty (x.val + y.val))
   | _ => ⊥ := by
   have : x + y = add x y := by rfl
   rw [this]
-  simp [add]
-  have h := tryMk_eq ty (↑x + ↑y)
+  simp [add, tryMk, Result.ofOption]
+  have h := tryMkOpt_eq ty (↑x + ↑y)
   simp [inBounds] at h
-  split at h <;> simp_all
+  cases hopt : tryMkOpt ty (↑x + ↑y) <;> simp_all
   zify; simp
   zify at h
   have := @Int.emod_eq_of_lt (x.val + y.val) (2^ty.numBits) (by omega) (by omega)
@@ -58,14 +58,14 @@ theorem IScalar.add_equiv {ty} (x y : IScalar ty) :
     IScalar.inBounds ty (x.val + y.val) ∧
     z.val = x.val + y.val ∧
     z.bv = x.bv + y.bv
-  | fail _ => ¬ (IScalar.inBounds ty (x.val + y.val))
+  | fail e => e = .integerOverflow ∧ ¬ (IScalar.inBounds ty (x.val + y.val))
   | _ => ⊥ := by
   have : x + y = add x y := by rfl
   rw [this]
-  simp [add]
-  have h := tryMk_eq ty (↑x + ↑y)
+  simp [add, tryMk, Result.ofOption]
+  have h := tryMkOpt_eq ty (↑x + ↑y)
   simp [inBounds] at h
-  split at h <;> simp_all
+  cases hopt : tryMkOpt ty (↑x + ↑y) <;> simp_all
   apply BitVec.eq_of_toInt_eq
   simp
   have := bmod_pow_numBits_eq_of_lt ty (x.val + y.val) (by omega) (by omega)
@@ -111,31 +111,41 @@ only integers. Those are the most common to use, so we mark them with the
 
 /-- Generic theorem - shouldn't be used much -/
 @[step]
-theorem UScalar.add_spec {ty} {x y : UScalar ty}
-  (hmax : ↑x + ↑y ≤ UScalar.max ty) :
-  x + y ⦃ z => (↑z : Nat) = ↑x + ↑y ⦄ := by
+theorem UScalar.add_spec {ty} {x y : UScalar ty} :
+    partialSpec (x + y)
+      (fun z => (↑z : Nat) = ↑x + ↑y)
+      (fun | .integerOverflow => ↑x + ↑y > UScalar.max ty | _ => False)
+      False := by
   have h := @add_equiv ty x y
-  split at h <;> simp_all [max]
+  simp only [partialSpec]
+  split <;> simp_all [max]
   have : 0 < 2^ty.numBits := by simp
   omega
 
 /-- Generic theorem - shouldn't be used much -/
 @[step]
-theorem IScalar.add_spec {ty} {x y : IScalar ty}
-  (hmin : IScalar.min ty ≤ ↑x + ↑y)
-  (hmax : ↑x + ↑y ≤ IScalar.max ty) :
-  x + y ⦃ z => (↑z : Int) = ↑x + ↑y ⦄ := by
+theorem IScalar.add_spec {ty} {x y : IScalar ty} :
+    partialSpec (x + y)
+      (fun z => (↑z : Int) = ↑x + ↑y)
+      (fun | .integerOverflow => ↑x + ↑y < IScalar.min ty ∨ ↑x + ↑y > IScalar.max ty | _ => False)
+      False := by
   have h := @add_equiv ty x y
-  split at h <;> simp_all [min, max]
+  simp only [partialSpec]
+  split <;> simp_all [min, max, inBounds]
   omega
 
-uscalar @[step] theorem «%S».add_spec {x y : «%S»} (hmax : x.val + y.val ≤ «%S».max) :
-  x + y ⦃ z => (↑z : Nat) = ↑x + ↑y ⦄ :=
-  UScalar.add_spec (by scalar_tac)
+uscalar @[step] theorem «%S».add_spec {x y : «%S»} :
+    partialSpec (x + y)
+      (fun z => (↑z : Nat) = ↑x + ↑y)
+      (fun | .integerOverflow => ↑x + ↑y > «%S».max | _ => False)
+      False := by
+  convert @UScalar.add_spec _ x y; scalar_tac
 
-iscalar @[step] theorem «%S».add_spec {x y : «%S»}
-  (hmin : «%S».min ≤ ↑x + ↑y) (hmax : ↑x + ↑y ≤ «%S».max) :
-  x + y ⦃ z => (↑z : Int) = ↑x + ↑y ⦄ :=
-  IScalar.add_spec (by scalar_tac) (by scalar_tac)
+iscalar @[step] theorem «%S».add_spec {x y : «%S»} :
+    partialSpec (x + y)
+      (fun z => (↑z : Int) = ↑x + ↑y)
+      (fun | .integerOverflow => ↑x + ↑y < «%S».min ∨ ↑x + ↑y > «%S».max | _ => False)
+      False := by
+  convert @IScalar.add_spec _ x y <;> scalar_tac
 
 end Aeneas.Std

--- a/backends/lean/Aeneas/Std/Scalar/Ops/Div.lean
+++ b/backends/lean/Aeneas/Std/Scalar/Ops/Div.lean
@@ -414,13 +414,36 @@ theorem IScalar.div_spec {ty} {x y : IScalar ty}
   have ⟨ z, hz ⟩ := IScalar.div_bv_spec hzero hNoOverflow
   simp [hz]
 
-uscalar @[step] theorem «%S».div_spec (x : «%S») {y : «%S»} (hnz : ↑y ≠ (0 : Nat)) :
-  (x / y) ⦃ z => (↑z : Nat) = ↑x / ↑y ⦄ :=
-  exists_imp_spec (UScalar.div_spec x hnz)
+uscalar @[step] theorem «%S».div_spec (x : «%S») {y : «%S»} :
+    partialSpec (x / y)
+      (fun z => (↑z : Nat) = ↑x / ↑y)
+      (fun | .divisionByZero => (↑y : Nat) = 0 | _ => False)
+      False := by
+  have hxy : (x / y : Result _) = UScalar.div x y := rfl
+  rw [hxy]
+  by_cases hy : y.val = 0
+  · have hbv : y.bv = 0#_ := by zify; simp_all
+    simp [partialSpec, UScalar.div, hbv]; exact hy
+  · have ⟨ z, hz, hzVal ⟩ := UScalar.div_spec x hy
+    rw [hxy] at hz
+    simp [partialSpec, hz, hzVal]
 
-iscalar @[step] theorem «%S».div_spec {x y : «%S»} (hnz : ↑y ≠ (0 : Int))
-  (hNoOverflow : ¬ (x.val = «%S».min ∧ y.val = -1)) :
-  (x / y) ⦃ z => (↑z : Int) = Int.tdiv ↑x ↑y ⦄ :=
-  exists_imp_spec (IScalar.div_spec hnz (by scalar_tac))
+iscalar @[step] theorem «%S».div_spec {x y : «%S»} :
+    partialSpec (x / y)
+      (fun z => (↑z : Int) = Int.tdiv ↑x ↑y)
+      (fun | .divisionByZero => (↑y : Int) = 0
+           | .integerOverflow => (↑x : Int) = «%S».min ∧ (↑y : Int) = -1
+           | _ => False)
+      False := by
+  have hxy : (x / y : Result _) = IScalar.div x y := rfl
+  rw [hxy]
+  by_cases hy : y.val = 0
+  · simp [partialSpec, IScalar.div, hy]
+  · by_cases ho : x.val = IScalar.min (IScalarTy.«%S») ∧ y.val = -1
+    · simp [partialSpec, IScalar.div, ho.1, ho.2]
+      try scalar_tac
+    · have ⟨ z, hz, hzVal ⟩ := IScalar.div_spec hy ho
+      rw [hxy] at hz
+      simp [partialSpec, hz, hzVal]
 
 end Aeneas.Std

--- a/backends/lean/Aeneas/Std/Scalar/Ops/Mul.lean
+++ b/backends/lean/Aeneas/Std/Scalar/Ops/Mul.lean
@@ -42,23 +42,29 @@ Theorems with a specification which use integers and bit-vectors
 theorem UScalar.mul_equiv {ty} (x y : UScalar ty) :
   match mul x y with
   | ok z => x.val * y.val ≤ UScalar.max ty ∧ (↑z : Nat) = ↑x * ↑y ∧ z.bv = x.bv * y.bv
-  | fail _ => UScalar.max ty < x.val * y.val
+  | fail e => e = .integerOverflow ∧ UScalar.max ty < x.val * y.val
   | .div => False := by
   simp only [mul]
   have := tryMk_eq ty (x.val * y.val)
-  split <;> simp_all only [inBounds, true_and, not_lt, gt_iff_lt]
-  simp_all only [tryMk, ofOption, tryMkOpt, check_bounds, decide_true, dite_true, ok.injEq]
-  rename_i hEq; simp only [← hEq, ofNatCore, val]
-  split_conjs
-  . simp only [bv_toNat, max]; omega
-  . zify at this; zify; simp only [bv_toNat, BitVec.toNat_ofFin, Nat.cast_mul, BitVec.toNat_mul,
-    Int.natCast_emod, Nat.cast_pow, Nat.cast_ofNat] at *
-    rw [Int.emod_eq_of_lt]
-    . apply Int.pos_mul_pos_is_pos <;> simp
-    . simp only [this]
-  . have : 0 < 2^ty.numBits := by simp
-    simp only [max, gt_iff_lt]
-    omega
+  have hfail : ∀ e, mul x y = fail e → e = .integerOverflow := by
+    intro e he
+    simp only [mul, tryMk, Result.ofOption] at he
+    split at he <;> simp_all
+  split <;> simp_all only [inBounds, true_and, not_lt]
+  · simp_all only [tryMk, ofOption, tryMkOpt, check_bounds, decide_true, dite_true, ok.injEq]
+    rename_i hEq; simp only [← hEq, ofNatCore, val]
+    split_conjs
+    . simp only [bv_toNat, max]; omega
+    . zify at this; zify; simp only [bv_toNat, BitVec.toNat_ofFin, Nat.cast_mul, BitVec.toNat_mul,
+      Int.natCast_emod, Nat.cast_pow, Nat.cast_ofNat] at *
+      rw [Int.emod_eq_of_lt]
+      . apply Int.pos_mul_pos_is_pos <;> simp
+      . simp only [this]
+  · refine ⟨ hfail _ ?_, ?_ ⟩
+    · rw [mul]; assumption
+    · have : 0 < 2^ty.numBits := by simp
+      simp only [max, gt_iff_lt]
+      omega
 
 /-- Generic theorem - shouldn't be used much -/
 theorem UScalar.mul_bv_spec {ty} {x y : UScalar ty}
@@ -72,7 +78,7 @@ theorem UScalar.mul_bv_spec {ty} {x y : UScalar ty}
 theorem IScalar.mul_equiv {ty} (x y : IScalar ty) :
   match mul x y with
   | ok z => IScalar.min ty ≤ x.val * y.val ∧ x.val * y.val ≤ IScalar.max ty ∧ z.val = x.val * y.val ∧ z.bv = x.bv * y.bv
-  | fail _ => ¬(IScalar.min ty ≤ x.val * y.val ∧ x.val * y.val ≤ IScalar.max ty)
+  | fail e => e = .integerOverflow ∧ ¬(IScalar.min ty ≤ x.val * y.val ∧ x.val * y.val ≤ IScalar.max ty)
   | .div => False := by
   simp only [mul, not_and, not_le]
   have := tryMk_eq ty (x.val * y.val)
@@ -109,7 +115,7 @@ theorem IScalar.mul_equiv {ty} (x y : IScalar ty) :
       simp_all only [iff_true, sup_eq_left, ge_iff_le, iff_false,
         not_lt, sub_left_inj, sup_eq_left] <;>
       omega
-  . omega
+  . grind
 
 /-- Generic theorem - shouldn't be used much -/
 theorem IScalar.mul_bv_spec {ty} {x y : IScalar ty}
@@ -150,13 +156,24 @@ theorem IScalar.mul_spec {ty} {x y : IScalar ty}
   apply @mul_bv_spec ty x y (by scalar_tac) (by scalar_tac)
   grind
 
-uscalar @[step] theorem «%S».mul_spec {x y : «%S»} (hmax : x.val * y.val ≤ «%S».max) :
-  x * y ⦃ z => (↑z : Nat) = ↑x * ↑y ⦄ :=
-  UScalar.mul_spec (by scalar_tac)
+uscalar @[step] theorem «%S».mul_spec {x y : «%S»} :
+    partialSpec (x * y)
+      (fun z => (↑z : Nat) = ↑x * ↑y)
+      (fun | .integerOverflow => ↑x * ↑y > «%S».max | _ => False)
+      False := by
+  have h := UScalar.mul_equiv x y
+  show partialSpec (UScalar.mul x y) _ _ _
+  simp only [partialSpec]
+  split <;> simp_all <;> scalar_tac
 
-iscalar @[step] theorem «%S».mul_spec {x y : «%S»}
-  (hmin : «%S».min ≤ ↑x * ↑y) (hmax : ↑x * ↑y ≤ «%S».max) :
-  (x * y) ⦃ z => (↑z : Int) = ↑x * ↑y ⦄ :=
-  IScalar.mul_spec (by scalar_tac) (by scalar_tac)
+iscalar @[step] theorem «%S».mul_spec {x y : «%S»} :
+    partialSpec (x * y)
+      (fun z => (↑z : Int) = ↑x * ↑y)
+      (fun | .integerOverflow => ↑x * ↑y < «%S».min ∨ ↑x * ↑y > «%S».max | _ => False)
+      False := by
+  have h := IScalar.mul_equiv x y
+  show partialSpec (IScalar.mul x y) _ _ _
+  simp only [partialSpec]
+  split <;> simp_all; scalar_tac
 
 end Aeneas.Std

--- a/backends/lean/Aeneas/Std/Scalar/Ops/Neg.lean
+++ b/backends/lean/Aeneas/Std/Scalar/Ops/Neg.lean
@@ -6,7 +6,7 @@ import Mathlib.Data.BitVec
 
 namespace Aeneas.Std
 
-open Result Error Arith
+open Result Error Arith WP
 
 /-!
 # Negation: Definitions
@@ -14,11 +14,15 @@ open Result Error Arith
 def IScalar.neg {ty : IScalarTy} (x : IScalar ty) : Result (IScalar ty) := IScalar.tryMk ty (- x.val)
 
 @[step]
-theorem IScalar.neg_step {ty} (x: IScalar ty) (h: x ≠ IScalar.min ty): IScalar.neg x ⦃ r => r = -x.val ⦄ := by
-  simp [neg]
-  have h := tryMk_eq ty (-x.val)
+theorem IScalar.neg_step {ty} (x: IScalar ty) :
+    partialSpec (IScalar.neg x)
+      (fun r => r = -x.val)
+      (fun | .integerOverflow => (x : Int) = IScalar.min ty | _ => False)
+      False := by
+  simp only [neg, tryMk, Result.ofOption]
+  have h := tryMkOpt_eq ty (-x.val)
   simp [inBounds] at h
-  split at h <;> simp_all
+  cases hopt : tryMkOpt ty (-x.val) <;> simp_all [partialSpec]
   have := IScalar.hBounds x
   simp [IScalar.min] at *
   grind
@@ -59,9 +63,12 @@ attribute [match_pattern] HNeg.hNeg
 instance {ty} : HNeg (IScalar ty) (Result (IScalar ty)) where hNeg x := IScalar.neg x
 
 @[step]
-theorem HNeg.hNeg.step {ty} (x: IScalar ty) (h: x ≠ IScalar.min ty): HNeg.hNeg x ⦃ r => r = -x.val ⦄ := by
-  simp [HNeg.hNeg]
-  apply IScalar.neg_step
-  grind
+theorem HNeg.hNeg.step {ty} (x: IScalar ty) :
+    partialSpec (HNeg.hNeg x : Result (IScalar ty))
+      (fun r => r = -x.val)
+      (fun | .integerOverflow => (x : Int) = IScalar.min ty | _ => False)
+      False := by
+  show partialSpec (IScalar.neg x) _ _ _
+  exact IScalar.neg_step x
 
 end Aeneas.Std

--- a/backends/lean/Aeneas/Std/Scalar/Ops/Rem.lean
+++ b/backends/lean/Aeneas/Std/Scalar/Ops/Rem.lean
@@ -117,12 +117,32 @@ theorem IScalar.rem_spec {ty} (x : IScalar ty) {y : IScalar ty} (hzero : y.val �
   · intros x' h
     exact h.1
 
-uscalar @[step] theorem «%S».rem_spec (x : «%S») {y : «%S»} (hnz : y.val ≠ 0) :
-  x % y ⦃ z => (↑z : Nat) = ↑x % ↑y ⦄ :=
-  UScalar.rem_spec x hnz
+uscalar @[step] theorem «%S».rem_spec (x : «%S») {y : «%S»} :
+    partialSpec (x % y)
+      (fun z => (↑z : Nat) = ↑x % ↑y)
+      (fun | .divisionByZero => (↑y : Nat) = 0 | _ => False)
+      False := by
+  have hxy : (x % y : Result _) = UScalar.rem x y := rfl
+  rw [hxy]
+  by_cases hy : y.val = 0
+  · simp [partialSpec, UScalar.rem, hy]
+  · have h := UScalar.rem_spec x hy
+    rw [hxy] at h
+    simp_all [partialSpec]
+    split <;> simp_all
 
-iscalar @[step] theorem «%S».rem_spec (x : «%S») {y : «%S»} (hnz : y.val ≠ 0) :
-  x % y ⦃ z => (↑z : Int) = Int.tmod ↑x ↑y ⦄ :=
-  IScalar.rem_spec x hnz
+iscalar @[step] theorem «%S».rem_spec (x : «%S») {y : «%S»} :
+    partialSpec (x % y)
+      (fun z => (↑z : Int) = Int.tmod ↑x ↑y)
+      (fun | .divisionByZero => (↑y : Int) = 0 | _ => False)
+      False := by
+  have hxy : (x % y : Result _) = IScalar.rem x y := rfl
+  rw [hxy]
+  by_cases hy : y.val = 0
+  · simp [partialSpec, IScalar.rem, hy]
+  · have h := IScalar.rem_spec x hy
+    rw [hxy] at h
+    simp_all [partialSpec]
+    split <;> simp_all
 
 end Aeneas.Std

--- a/backends/lean/Aeneas/Std/Scalar/Ops/Sub.lean
+++ b/backends/lean/Aeneas/Std/Scalar/Ops/Sub.lean
@@ -42,7 +42,7 @@ theorem UScalar.sub_equiv {ty} (x y : UScalar ty) :
     y.val ≤ x.val ∧
     x.val = z.val + y.val ∧
     z.bv = x.bv - y.bv
-  | fail _ => x.val < y.val
+  | fail e => e = .integerOverflow ∧ x.val < y.val
   | _ => ⊥ := by
   have : x - y = sub x y := by rfl
   simp [this, sub]
@@ -86,13 +86,13 @@ theorem IScalar.sub_equiv {ty} (x y : IScalar ty) :
     IScalar.inBounds ty (x.val - y.val) ∧
     z.val = x.val - y.val ∧
     z.bv = x.bv - y.bv
-  | fail _ => ¬ (IScalar.inBounds ty (x.val - y.val))
+  | fail e => e = .integerOverflow ∧ ¬ (IScalar.inBounds ty (x.val - y.val))
   | _ => ⊥ := by
   have : x - y = sub x y := by rfl
-  simp [this, sub]
-  have h := tryMk_eq ty (↑x - ↑y)
+  simp [this, sub, tryMk, Result.ofOption]
+  have h := tryMkOpt_eq ty (↑x - ↑y)
   simp [inBounds] at h
-  split at h <;> simp_all
+  cases hopt : tryMkOpt ty (↑x - ↑y) <;> simp_all
   apply BitVec.eq_of_toInt_eq
   simp
   have := bmod_pow_numBits_eq_of_lt ty (x.val - y.val) (by omega) (by omega)
@@ -134,30 +134,39 @@ Theorems with a specification which only uses integers
 
 /- Generic theorem - shouldn't be used much -/
 @[step]
-theorem UScalar.sub_spec {ty} {x y : UScalar ty}
-  (h : y.val ≤ x.val) :
-  x - y ⦃ z => z.val = x.val - y.val ∧ y.val ≤ x.val ⦄ := by
+theorem UScalar.sub_spec {ty} {x y : UScalar ty} :
+    partialSpec (x - y)
+      (fun z => z.val = x.val - y.val ∧ y.val ≤ x.val)
+      (fun | .integerOverflow => x.val < y.val | _ => False)
+      False := by
   have h := @sub_equiv ty x y
-  split at h <;> simp_all
-  omega
+  simp only [partialSpec]
+  split <;> simp_all
 
 /- Generic theorem - shouldn't be used much -/
 @[step]
-theorem IScalar.sub_spec {ty} {x y : IScalar ty}
-  (hmin : IScalar.min ty ≤ ↑x - ↑y)
-  (hmax : ↑x - ↑y ≤ IScalar.max ty) :
-  x - y ⦃ z => (↑z : Int) = ↑x - ↑y ⦄ := by
+theorem IScalar.sub_spec {ty} {x y : IScalar ty} :
+    partialSpec (x - y)
+      (fun z => (↑z : Int) = ↑x - ↑y)
+      (fun | .integerOverflow => ↑x - ↑y < IScalar.min ty ∨ ↑x - ↑y > IScalar.max ty | _ => False)
+      False := by
   have h := @sub_equiv ty x y
-  split at h <;> simp_all [min, max]
+  simp only [partialSpec]
+  split <;> simp_all [min, max, inBounds]
   omega
 
-uscalar @[step] theorem «%S».sub_spec {x y : «%S»} (h : y.val ≤ x.val) :
-  x - y ⦃ z => z.val = x.val - y.val ∧ y.val ≤ x.val ⦄ :=
-  UScalar.sub_spec h
+uscalar @[step] theorem «%S».sub_spec {x y : «%S»} :
+    partialSpec (x - y)
+      (fun z => z.val = x.val - y.val ∧ y.val ≤ x.val)
+      (fun | .integerOverflow => x.val < y.val | _ => False)
+      False :=
+  @UScalar.sub_spec _ x y
 
-iscalar @[step] theorem «%S».sub_spec {x y : «%S»}
-  (hmin : «%S».min ≤ ↑x - ↑y) (hmax : ↑x - ↑y ≤ «%S».max) :
-  x - y ⦃ z => (↑z : Int) = ↑x - ↑y ⦄ :=
-  IScalar.sub_spec (by scalar_tac) (by scalar_tac)
+iscalar @[step] theorem «%S».sub_spec {x y : «%S»} :
+    partialSpec (x - y)
+      (fun z => (↑z : Int) = ↑x - ↑y)
+      (fun | .integerOverflow => ↑x - ↑y < «%S».min ∨ ↑x - ↑y > «%S».max | _ => False)
+      False := by
+  convert @IScalar.sub_spec _ x y <;> scalar_tac
 
 end Aeneas.Std

--- a/backends/lean/Aeneas/Std/WP.lean
+++ b/backends/lean/Aeneas/Std/WP.lean
@@ -243,6 +243,42 @@ theorem dspec_imp_forall {m:Result α} {P:Post α} :
   dspec m P → (∀ y, m = ok y → P y) := by
   grind only [= dspec_ok]
 
+/-- Partial-correctness variant of `spec`.
+
+`partialSpec x p_ok p_fail p_div` reads as: "if `x` reduces to `ok a` then `p_ok a` holds; if it
+reduces to `fail e` then `p_fail e` holds; if it diverges then `p_div` holds". Unlike `spec`, it
+does not assume the program terminates without exception. -/
+def partialSpec {α} (x : Result α)
+    (p_ok : α → Prop) (p_fail : Error → Prop) (p_div : Prop) : Prop :=
+  match x with
+  | ok a   => p_ok a
+  | fail e => p_fail e
+  | div    => p_div
+
+@[simp, grind =, agrind =]
+theorem partialSpec_ok (a : α) (p_ok : α → Prop) p_fail p_div :
+    partialSpec (ok a) p_ok p_fail p_div ↔ p_ok a := by
+  simp [partialSpec]
+
+@[simp, grind =, agrind =]
+theorem partialSpec_fail (e : Error) p_ok p_fail p_div :
+    partialSpec (α := α) (fail e) p_ok p_fail p_div ↔ p_fail e := by
+  simp [partialSpec]
+
+@[simp, grind =, agrind =]
+theorem partialSpec_div (p_ok : α → Prop) p_fail p_div :
+    partialSpec div p_ok p_fail p_div ↔ p_div := by
+  simp [partialSpec]
+
+/-- Derive a total-correctness `spec` from `partialSpec` by ruling out the failure and divergence
+cases. Used by `@[step]` to generate a step-tactic lemma from a `partialSpec` theorem. -/
+theorem spec_of_partialSpec
+    {α} {x : Result α} {p_ok : α → Prop} {p_fail : Error → Prop} {p_div : Prop}
+    (h : partialSpec x p_ok p_fail p_div)
+    (h_fail : ∀ e, ¬ p_fail e) (h_div : ¬ p_div) :
+    spec x p_ok := by
+  cases x <;> simp_all [partialSpec, spec, theta, wp_return]
+
 end Aeneas.Std.WP
 
 /-
@@ -789,13 +825,24 @@ namespace Aeneas.Std.WP
 open Std Result
 open Std.Do
 
-instance Result.instWP : WP Result.{u} (.except (ULift Error) (.except PUnit .pure)) where
+abbrev Result.postShape : PostShape := (.except (ULift Error) (.except PUnit .pure))
+
+instance Result.instWP : WP Result.{u} postShape where
   wp x := {
     trans Q := match x with | .ok a => Q.1 a | .fail e => Q.2.1 (ULift.up e) | .div => Q.2.2.1 .unit
     conjunctiveRaw Q₁ Q₂ := by
       apply SPred.bientails.of_eq
       cases x <;> simp
   }
+
+abbrev willYield {α : Type u} (r : α) (Q : PostCond α Result.postShape) : Prop :=
+  (Q.1 r).down
+
+abbrev willFail {α : Type u} (e : Error) (Q : PostCond α Result.postShape) : Prop :=
+  (Q.2.1 (.up e)).down
+
+abbrev willDiverge {α : Type u} (Q : PostCond α Result.postShape) : Prop :=
+  (Q.2.2.1 .unit).down
 
 instance : LawfulMonad Result where
     map_const := by intros; rfl
@@ -833,6 +880,19 @@ theorem dspec_to_mvcgen {α : Type u} {x : Result α} {Q : α → Prop}
     ⦃ ⌜ ¬ x = .div ⌝ ⦄ x ⦃ ⇓ r => ⌜ Q r ⌝ ⦄ := by
   simp [Triple, WP.wp, PredTrans.apply, SPred.pure]
   cases x <;> simp [*, dspec] at * <;> trivial
+
+/-- Lift an Aeneas partial-correctness spec to an mvcgen-compatible `Triple`. -/
+theorem partialSpec_to_mvcgen {α : Type u} {x : Result α}
+    {p_ok : α → Prop} {p_fail : Error → Prop} {p_div : Prop}
+    (h : partialSpec x p_ok p_fail p_div)
+    {Q : PostCond α Result.postShape}
+    (h_ok   : ∀ r, p_ok r → willYield r Q)
+    (h_fail : ∀ e, p_fail e → willFail e Q)
+    (h_div  : p_div → willDiverge Q) :
+    ⦃ ⌜ True ⌝ ⦄ x ⦃ Q ⦄ := by
+  cases x
+    <;> simp only [partialSpec] at h
+    <;> simp [Triple, WP.wp, PredTrans.apply, h_ok, h_fail, h_div, h]
 
 end Aeneas.Std.WP
 

--- a/backends/lean/Aeneas/Tactic/Step/Init.lean
+++ b/backends/lean/Aeneas/Tactic/Step/Init.lean
@@ -5,6 +5,7 @@ import AeneasMeta.Extensions
 import Aeneas.Tactic.Step.Trace
 import Aeneas.Std.WP
 import AeneasMeta.OptionConfig
+import Mathlib.Order.Defs.LinearOrder
 
 namespace Aeneas
 
@@ -212,13 +213,7 @@ section Methods
     withLocalDeclsD ⟨ tys ⟩ k
 end Methods
 
-/- Analyze a goal or a step theorem to decompose its arguments.
-
-  StepSpec theorems should be of the following shape:
-  ```
-  ∀ x1 ... xn, H1 → ... Hn → spec (f x1 ... xn) P
-  ```
--/
+/- Analyze a goal or a step theorem to decompose its arguments. -/
 def getStepSpecFunArgsExpr (ty : Expr) :
   MetaM (Expr × SpecInfo) := do
   let ty := ty.consumeMData
@@ -283,65 +278,338 @@ structure StepSpecAttr where
   ext  : Extension
   deriving Inhabited
 
-private def generateMvcgenSpec (toMvcgenThm : Name) (stx : Syntax) (attrKind : AttributeKind)
-    (thDecl : AsyncConstantInfo) : MetaM Unit := do
+/-! ## Register a spec for the `step` tactic -/
+
+/-- Register a theorem using `spec` with `step`. -/
+private def saveStepSpecFromThm (ext : Extension) (attrKind : AttributeKind)
+    (thName : Name) (ty : Expr) : MetaM Unit := do
+  let (fExpr, info) ← getStepSpecFunArgsExpr ty
+  trace[Step] "Registering spec theorem for expr: {fExpr}"
+  -- Convert the function expression to a discrimination tree key
+  let fKey ← DiscrTree.mkPath fExpr
+  -- TODO: use info.name to use a different discrimination tree here!
+  ScopedEnvExtension.add ext ((info.spec_name, fKey), thName) attrKind
+  trace[Step] "Saved the entry"
+
+section
+open Aeneas.Std
+
+/-! ## Convert a `partialSpec` theorem into a theorem for the `step` tactic
+
+The `step` tactic cannot directly handle spec lemmas that use the `partialSpec` predicate.
+So, when the `@[step]` attribute is applied to `partialSpec` theorems, we need to convert
+the statement about `partialSpec` into a statement about `spec`. We use the following mechanisms
+to do that:
+
+- A `partialSpec` theorem may use match-syntax of the form
+  `fun | .integerOverflow => ↑x + ↑y > UScalar.max ty | _ => False`
+  to distinguish various kinds of panics.
+  We canoncialize this syntax into an expression like
+  `fun e => e = integerOverflow ∧ ↑x + ↑y > UScalar.max ty`.
+
+- We apply the lemma `spec_of_partialSpec` to replace the `partialSpec` statement with an
+  corresponding statement using the `spec` predicate
+
+- We use the simplifier with a restricted simp set to make the preconditions of the `spec` theorem
+  look nicer. For instance, we rewrite `¬a ≤ b` into `b < a`.
+-/
+
+/-- For `simplifyStepHypotheses`: rewrites `∀ e, ¬ (e = c ∧ P)` to `¬ P`. -/
+private theorem step_fail_failEq_iff {c : Aeneas.Std.Error} {P : Prop} :
+    (∀ e, ¬ (e = c ∧ P)) ↔ ¬ P :=
+  ⟨fun h hP => h c ⟨rfl, hP⟩, fun h _ h' => h h'.2⟩
+
+/-- For `simplifyStepHypotheses`: rewrites `∀ _ : Error, P` to `P`. -/
+private theorem step_fail_remove_forall_iff {P : Prop} :
+    (∀ _ : Aeneas.Std.Error, P) ↔ P :=
+  ⟨fun h => h Error.panic, fun h _ => h⟩
+
+/-- For `simplifyStepHypotheses`: rewrites `∀ e, ¬ False` to `True`. -/
+private theorem step_fail_False_iff :
+    (∀ (_ : Aeneas.Std.Error), ¬ False) ↔ True :=
+  ⟨fun _ => trivial, fun _ _ h => h⟩
+
+end
+
+/-- Build a `Simp.Context` containing exactly the given lemmas (no default simp set,
+    no simprocs). The resulting `simp` call is equivalent to `simp only [lemmas...]`. -/
+private def mkSimpOnlyContext (lemmas : Array Name) : MetaM Simp.Context := do
+  let mut simpThms : SimpTheorems := {}
+  for thmName in lemmas do
+    simpThms ← simpThms.addConst thmName (post := false) (inv := false)
+  Simp.mkContext
+    (config := { failIfUnchanged := false })
+    (simpTheorems := #[simpThms])
+    (congrTheorems := ← getSimpCongrTheorems)
+
+/-- Recursively split a metavariable whose target is `P ∧ Q` into separate goals
+    for each conjunct. Returns the list of leaf mvars. -/
+private partial def splitAndGoals (mvarId : MVarId) : MetaM (Array MVarId) := do
+  let target ← instantiateMVars (← mvarId.getType)
+  if !target.isAppOfArity ``And 2 then
+    return #[mvarId]
+  let baseTag ← mvarId.getTag
+  Prod.snd <$> go baseTag mvarId 0 #[]
+where
+  go (baseTag : Name) (mvarId : MVarId) (idx : Nat) (acc : Array MVarId) :
+      MetaM (Nat × Array MVarId) := do
+    let target ← instantiateMVars (← mvarId.getType)
+    match target.app2? ``And with
+    | some (p, q) =>
+      let m₁ ← mkFreshExprSyntheticOpaqueMVar p
+      let m₂ ← mkFreshExprSyntheticOpaqueMVar q
+      mvarId.assign (← mkAppM ``And.intro #[m₁, m₂])
+      let (idx, acc) ← go baseTag m₁.mvarId! idx acc
+      go baseTag m₂.mvarId! idx acc
+    | none =>
+      if !baseTag.isAnonymous then
+        mvarId.setTag (baseTag.appendIndexAfter (idx + 1))
+      return (idx + 1, acc.push mvarId)
+
+/-- Simp lemmas shared by `simplifyStepHypotheses` and `simplifyMvcgenHypotheses` -/
+private def commonSimpLemmas : Array Name :=
+  #[``gt_iff_lt, ``ge_iff_le, ``not_or, ``not_lt, ``not_le, ``or_imp, ``imp_true_iff, ``not_true,
+    ``true_implies, ``forall_and, ``true_and, ``and_true]
+
+/-- To bring a match on `Error` into canonical form, the following lemma is helpful.
+It's used in `canonicalizeFailPostcond` below.  -/
+private theorem error_pred_eq_disj (p : Aeneas.Std.Error → Prop) :
+    p = fun e =>
+      (e = .assertionFailure    ∧ p .assertionFailure)    ∨
+      (e = .integerOverflow     ∧ p .integerOverflow)     ∨
+      (e = .divisionByZero      ∧ p .divisionByZero)      ∨
+      (e = .arrayOutOfBounds    ∧ p .arrayOutOfBounds)    ∨
+      (e = .maximumSizeExceeded ∧ p .maximumSizeExceeded) ∨
+      (e = .panic               ∧ p .panic)               ∨
+      (e = .undef               ∧ p .undef) := by
+  funext e; cases e <;> simp
+
+/-- If the failure postcondition `p_fail` of `partialSpec` is written as a `match`
+    of the shape `fun | Cᵢ => Pᵢ | … | _ => False`, return a proof of the
+    same `partialSpec` but with `p_fail` replaced by the equivalent disjunction
+    `fun e => (e = C₁ ∧ p_fail C₁) ∨ … ∨ (e = Cₖ ∧ p_fail Cₖ)`.
+
+    Returns `thApp` unchanged if `p_fail` is not such a `match`. -/
+private def canonicalizeFailPostcond (thApp : Expr) : MetaM Expr := do
+  try
+    let ty ← instantiateMVars (← inferType thApp)
+    let fn := ty.getAppFn
+    unless fn.isConstOf ``Aeneas.Std.WP.partialSpec do return thApp
+    let args := ty.getAppArgs
+    unless args.size == 5 do return thApp
+    let p_fail := args[3]!
+    let isMatch ← withLocalDeclD `e (.const ``Aeneas.Std.Error []) fun e =>
+      return (← matchMatcherApp? (p_fail.beta #[e]).headBeta).isSome
+    unless isMatch do return thApp
+    -- `heq : p_fail = fun e => ⋁ᵢ (e = Cᵢ ∧ p_fail Cᵢ)`; transport `thApp` across it along the
+    -- motive `fun pf => partialSpec x p_ok pf p_div`.
+    let heq ← mkAppM ``error_pred_eq_disj #[p_fail]
+    let motive ← withLocalDeclD `pf (← inferType p_fail) fun pf =>
+      mkLambdaFVars #[pf] (mkAppN fn (args.set! 3 pf))
+    mkEqMP (← mkCongrArg motive heq) thApp
+  catch _ => return thApp
+
+/-- Try to simplify the arguments produced by `spec_of_partialSpec` -/
+private def simplifyStepHypotheses (mvarFail mvarDiv : Expr) : MetaM Unit := do
+  let simpCtx ← mkSimpOnlyContext (#[
+      ``step_fail_failEq_iff, ``step_fail_remove_forall_iff,
+      ``step_fail_False_iff, ``not_false_iff] ++ commonSimpLemmas)
+  let simplify (mv : Expr) (name : String) : MetaM Unit := do
+    trace[Step] "simplifyStepHypotheses: {name} type: {← inferType mv}"
+    try
+      let (mvarId?, _) ← simpTarget mv.mvarId! simpCtx (simprocs := {})
+      if let some mvarId := mvarId? then
+        discard <| splitAndGoals mvarId
+    catch e => trace[Step] "simplifyStepHypotheses: simp on {name} failed: {e.toMessageData}"
+  simplify mvarFail "hFail"
+  simplify mvarDiv "hDiv"
+
+/-- Register a theorem using `partialSpec` with `step`. This function generates a auxiliary lemma
+using `spec` instead of `partialSpec` and registers that one with `step`, so that the `step`
+tactic will only ever see `spec`. -/
+private def saveStepPartialSpecFromThm (ext : Extension) (attrKind : AttributeKind) (stx : Syntax)
+    (thDecl : AsyncConstantInfo) (ty : Expr) : MetaM Unit := do
+  trace[Step] "saveStepPartialSpecFromThm: {thDecl.name}"
+  let sig := thDecl.sig.get
+  let levelParams := sig.levelParams
+  let (newName, newTy) ← forallTelescope ty fun fvars _ => do
+    let thConst := Lean.mkConst thDecl.name (levelParams.map Level.param)
+    let thApp ← canonicalizeFailPostcond (mkAppN thConst fvars)
+    let bridge ← mkAppM ``Aeneas.Std.WP.spec_of_partialSpec #[thApp]
+    let (extraMVars, _, _) ← forallMetaTelescope (← inferType bridge)
+    unless extraMVars.size = 2 do
+      throwError "spec_of_partialSpec: expected 2 extra arguments, got {extraMVars.size}"
+    simplifyStepHypotheses extraMVars[0]! extraMVars[1]!
+    let proof := mkAppN bridge extraMVars
+    let { expr := proofAbstracted, .. } ← abstractMVars proof
+    let proofTerm ← mkLambdaFVars fvars proofAbstracted
+    let thmTy ← inferType proofTerm
+    let name := Name.str thDecl.name "step_spec"
+    let auxDecl : TheoremVal := {
+      name
+      levelParams
+      type  := thmTy
+      value := proofTerm
+    }
+    addDecl (.thmDecl auxDecl)
+    addDeclarationRangesFromSyntax name stx
+    pure (name, thmTy)
+  saveStepSpecFromThm ext attrKind newName newTy
+
+/-! ## Convert a `spec` theorem into a spec theorem for `mvcgen`
+
+The `mvcgen` tactic cannot process spec theorems that use the `spec` predicate. Instead, `mvcgen`
+expects the `Triple` predicate. We use the `spec_to_mvcgen` lemma to convert a statement about
+`spec` into a statement about `Triple`.
+-/
+
+private def saveMvcgenDecl (attrKind : AttributeKind) (stx : Syntax)
+    (originalThDecl : AsyncConstantInfo) (thmTy proofTerm : Expr) : MetaM Unit := do
+  let mvcgenSpecName := Name.str originalThDecl.name "mvcgen_spec"
+  let auxDecl : TheoremVal := {
+    name        := mvcgenSpecName
+    levelParams := originalThDecl.sig.get.levelParams
+    type        := thmTy
+    value       := proofTerm
+  }
+  addDecl (.thmDecl auxDecl)
+  addDeclarationRangesFromSyntax mvcgenSpecName stx
+  -- Register with @[spec] so mvcgen can find it
+  Lean.Attribute.add mvcgenSpecName `spec .missing attrKind
+  trace[Step] "Registered {mvcgenSpecName} as `@[spec]`."
+
+/-- Register a theorem using `spec` with `mvcgen`. -/
+private def saveMvcgenSpecFromThm (stx : Syntax) (attrKind : AttributeKind)
+    (thDecl : AsyncConstantInfo) (ty : Expr) : MetaM Unit := do
+  trace[Step] "saveMvcgenSpecFromThm: {thDecl.name}"
+  let (_, info) ← getStepSpecFunArgsExpr ty
+  let some to_mvcgen := info.to_mvcgen
+    | trace[Step] "No `to_mvcgen` conversion function found: {thDecl.name}"
+      return
   let sig := thDecl.sig.get
   let thName := thDecl.name
   forallTelescope sig.type fun fvars _ => do
-    -- Apply the original theorem to all fvars to get: spec (f args) Q
     let thConst := Lean.mkConst thName (sig.levelParams.map .param)
     let thApp := mkAppN thConst fvars
-    -- Wrap with spec_to_mvcgen to produce: Triple (f args) ⌜True⌝ post⟨...⟩
-    let proof ← mkAppM toMvcgenThm #[thApp]
+    -- Wrap with spec_to_mvcgen to produce a statement about `Triple`.
+    let proof ← mkAppM to_mvcgen #[thApp]
     let innerTy ← inferType proof
-    -- Re-introduce all fvars as binders
     let proofTerm ← mkLambdaFVars fvars proof
     let thmTy ← mkForallFVars fvars innerTy
-    let mvcgenSpecName := Name.str thName "mvcgen_spec"
-    let auxDecl : TheoremVal := {
-      name        := mvcgenSpecName
-      levelParams := sig.levelParams
-      type        := thmTy
-      value       := proofTerm
-    }
-    addDecl (.thmDecl auxDecl)
-    addDeclarationRangesFromSyntax mvcgenSpecName stx
-    -- Register with @[spec] so mvcgen can find it
-    Lean.Attribute.add mvcgenSpecName `spec .missing attrKind
+    saveMvcgenDecl attrKind stx thDecl thmTy proofTerm
 
-private def saveStepSpecFromThm (ext : Extension) (attrKind : AttributeKind) (stx : Syntax)
+/-! ## Convert a `partialSpec` theorem into a spec theorem for `mvcgen`
+
+The `mvcgen` tactic cannot process spec theorems that use the `partialSpec` predicate either.
+We convert a `partialSpec` theorem into a `Triple` theorem for `mvcgen` as follows:
+
+- A `partialSpec` theorem may use match-syntax of the form
+  `fun | .integerOverflow => ↑x + ↑y > UScalar.max ty | _ => False`
+  to distinguish various kinds of panics.
+  We canoncialize this syntax into an expression like
+  `fun e => e = integerOverflow ∧ ↑x + ↑y > UScalar.max ty`.
+
+- We apply the lemma `partialSpec_to_mvcgen` to replace the `partialSpec` statement with an
+  corresponding statement using the `Triple` predicate
+
+- We use the simplifier with a restricted simp set to make the preconditions of the `spec` theorem
+  look nicer. For instance, we rewrite `¬a ≤ b` into `b < a`.
+-/
+section
+open Aeneas.Std WP Result
+
+private theorem mvcgen_fail_failEq_iff {α : Type u} {Q : Std.Do.PostCond α postShape}
+    {c : Error} {P : Prop} :
+    (∀ e, (e = c ∧ P) → willFail e Q) ↔ (P → willFail c Q) :=
+  ⟨fun h hP => h c ⟨rfl, hP⟩, fun h _ ⟨he, hP⟩ => he ▸ h hP⟩
+
+private theorem mvcgen_fail_False_iff {α : Type u} {Q : Std.Do.PostCond α postShape} :
+    (∀ e, False → willFail e Q) ↔ True :=
+  ⟨fun _ => trivial, fun _ _ h => h.elim⟩
+
+private theorem mvcgen_uncurry' {α β} {p : α → β → Prop} {q : α × β → Prop} :
+    (∀ (r : α × β), uncurry' p r → q r) ↔ (∀ (r₁ : α) (r₂ : β), p r₁ r₂ → q (r₁, r₂)) := by simp
+
+end
+
+/-- Try to simplify the arguments produced by `partialSpec_to_mvcgen`. -/
+private def simplifyMvcgenHypotheses (mvarOk mvarFail mvarDiv : Expr) : MetaM Unit := do
+  let simpCtx ← mkSimpOnlyContext (#[
+      ``mvcgen_fail_failEq_iff, ``mvcgen_fail_False_iff,
+      ``mvcgen_uncurry', ``false_imp_iff, ``and_imp, ``forall_eq] ++ commonSimpLemmas)
+  let simplify (mv : Expr) (name : String) : MetaM Unit := do
+    trace[Step] "simplifyMvcgenHypotheses: {name} type: {← inferType mv}"
+    try
+      let (mvarId?, _) ← simpTarget mv.mvarId! simpCtx (simprocs := {})
+      if let some mvarId := mvarId? then
+        discard <| splitAndGoals mvarId
+    catch e => trace[Step] "simplifyMvcgenHypotheses: simp on {name} failed: {e.toMessageData}"
+  simplify mvarOk "hOk"
+  simplify mvarFail "hFail"
+  simplify mvarDiv "hDiv"
+
+/-- Register a theorem using `partialSpec` with `mvcgen`. -/
+private def saveMvcgenPartialSpecFromThm (stx : Syntax) (attrKind : AttributeKind)
+    (thDecl : AsyncConstantInfo) : MetaM Unit := do
+  trace[Step] "saveMvcgenPartialSpecFromThm: {thDecl.name}"
+  let sig := thDecl.sig.get
+  let thName := thDecl.name
+  forallTelescope sig.type fun fvars _ => do
+    let thConst := Lean.mkConst thName (sig.levelParams.map .param)
+    let thApp ← canonicalizeFailPostcond (mkAppN thConst fvars)
+    let bridge ← mkAppOptM ``Aeneas.Std.WP.partialSpec_to_mvcgen
+      #[none, none, none, none, none, some thApp]
+    let (extraMVars, _, _) ← forallMetaTelescope (← inferType bridge)
+    unless extraMVars.size = 4 do
+      throwError "partialSpec_to_mvcgen: expected 4 extra arguments, got {extraMVars.size}"
+    simplifyMvcgenHypotheses extraMVars[1]! extraMVars[2]! extraMVars[3]!
+    let proof := mkAppN bridge extraMVars
+    let { expr := proofAbstracted, .. } ← abstractMVars proof
+    let proofTerm ← mkLambdaFVars fvars proofAbstracted
+    let thmTy ← inferType proofTerm
+    saveMvcgenDecl attrKind stx thDecl thmTy proofTerm
+
+/-! ## Applying the @[step] attribute
+
+When the `@[step]` attribute is attached to a lemma, we register this lemma both with the `step`
+tactic and with the `mvcgen` tactic. Depending whether the lemma uses the `partialSpec` predicate
+or one of the `step`-internal predicates `spec` and `dspec`, we need to apply different
+preprocessing before registering the lemmas.
+-/
+
+/-- Check whether a theorem is a `partialSpec` -/
+def isPartialSpec (ty : Expr) : MetaM Bool := do
+  let ty := ty.consumeMData
+  let (_, _, ty₂) ← forallMetaTelescope ty
+  let (spec?, args) := ty₂.consumeMData.withApp (fun f args => (f, args))
+  pure (spec?.isConstOf ``Std.WP.partialSpec ∧ args.size = 5)
+
+/-- Register a theorem (either `spec` or `partialSpec`) with `step` and `mvcgen`. -/
+private def applyStepAttr (ext : Extension) (attrKind : AttributeKind) (stx : Syntax)
     (thName : Name) : AttrM Unit := do
-  -- Lookup the theorem
-  let env ← getEnv
   -- Ignore some auxiliary definitions (see the comments for attrIgnoreMutRec)
   attrIgnoreAuxDef thName (pure ()) do
     trace[Step] "Registering `step` theorem for {thName}"
-    let some thDecl := env.findAsync? thName
-      | throwError "Could not find theorem {thName}"
-    let type := thDecl.sig.get.type
-    let (fKey, info) ← MetaM.run' (do
+    MetaM.run' do
+      let env ← getEnv
+      let some thDecl := env.findAsync? thName
+        | throwError "Could not find theorem {thName}"
+      let type := thDecl.sig.get.type
       trace[Step] "Theorem: {type}"
-      -- Normalize to eliminate the let-bindings
       let ty ← normalizeLetBindings type
       trace[Step] "Theorem after normalization (to eliminate the let bindings): {ty}"
-      let (fExpr, info) ← getStepSpecFunArgsExpr ty
-      trace[Step] "Registering spec theorem for expr: {fExpr}"
-      -- Convert the function expression to a discrimination tree key
-      pure (← DiscrTree.mkPath fExpr, info))
-    -- Save the entry
-    -- TODO: use info.name to use a different discrimination tree here!
-    ScopedEnvExtension.add ext ((info.spec_name, fKey), thName) attrKind
-    trace[Step] "Saved the entry"
-    -- Also generate a corresponding mvcgen (@[spec]) lemma
-    try
-      trace[Step] "Registering with mvcgen"
-      if let .some thm := info.to_mvcgen then
-        MetaM.run' (generateMvcgenSpec thm stx attrKind thDecl)
-    catch e =>
-      logWarning m!"Could not generate mvcgen spec for {thName}: {e.toMessageData}"
-    pure ()
+      if ← isPartialSpec ty then
+        try saveStepPartialSpecFromThm ext attrKind stx thDecl ty
+        catch e => logWarning m!"Could not generate step spec for {thName}: {e.toMessageData}"
+        try saveMvcgenPartialSpecFromThm stx attrKind thDecl
+        catch e => logWarning m!"Could not generate mvcgen spec for {thName}: {e.toMessageData}"
+      else
+        try saveStepSpecFromThm ext attrKind thName ty
+        catch e => logWarning m!"Could not save step spec for {thName}: {e.toMessageData}"
+        try saveMvcgenSpecFromThm stx attrKind thDecl ty
+        catch e => logWarning m!"Could not generate mvcgen spec for {thName}: {e.toMessageData}"
 
-/- Initiliaze the `step` attribute. -/
+/-- Initialize the `step` attribute. -/
 initialize stepAttr : StepSpecAttr ← do
   let ext ← mkExtension `stepMap
   let attrImpl : AttributeImpl := {
@@ -349,7 +617,7 @@ initialize stepAttr : StepSpecAttr ← do
     descr := "Adds theorems to the `step` database"
     add := fun thName stx attrKind => do
       Attribute.Builtin.ensureNoArgs stx
-      saveStepSpecFromThm ext attrKind stx thName
+      applyStepAttr ext attrKind stx thName
     erase := fun thName => do
       let s := ext.getState (← getEnv)
       let s := s.erase thName
@@ -880,7 +1148,7 @@ initialize stepPureAttribute : StepPureSpecAttr ← do
         -- Introduce the lifted theorem
         let liftedThmName ← MetaM.run' (liftThm stx thName pat)
         -- Save the lifted theorem to the `step` database
-        saveStepSpecFromThm stepAttr.ext attrKind stx liftedThmName
+        applyStepAttr stepAttr.ext attrKind stx liftedThmName
   }
   registerBuiltinAttribute attrImpl
   pure { attr := attrImpl }
@@ -1021,7 +1289,7 @@ initialize stepPureDefAttribute : StepPureDefSpecAttr ← do
         -- Introduce the lifted theorem
         let thmName ← MetaM.run' (mkStepPureDefThm stx pat declName)
         -- Save the lifted theorem to the `step` database
-        saveStepSpecFromThm stepAttr.ext attrKind stx thmName
+        applyStepAttr stepAttr.ext attrKind stx thmName
   }
   registerBuiltinAttribute attrImpl
   pure { attr := attrImpl }

--- a/backends/lean/Aeneas/Tactic/Step/Step.lean
+++ b/backends/lean/Aeneas/Tactic/Step/Step.lean
@@ -1579,7 +1579,7 @@ namespace Test
   -/
   /--
   error: unsolved goals
-case hmax
+case h_fail
 ty : UScalarTy
 x y : UScalar ty
 ⊢ ↑x + ↑y ≤ UScalar.max ty
@@ -1623,7 +1623,7 @@ _✝ : z1 = y + 2
 
   /--
   info: Try this:
-  [apply] let* ⟨ z, h1 ⟩ ← UScalar.add_spec
+  [apply] let* ⟨ z, h1 ⟩ ← UScalar.add_spec.step_spec
   -/
   #guard_msgs in
   example {ty} {x y : UScalar ty} (h : x.val + y.val ≤ UScalar.max ty) :
@@ -1646,7 +1646,7 @@ info: example
   set_option linter.unusedTactic false in
   example {ty} {x y : UScalar ty} (h : x.val + y.val ≤ UScalar.max ty) :
     x + y ⦃ z => z.val = x.val + y.val ⦄ := by
-    let* ⟨ z, h1 ⟩ ← UScalar.add_spec
+    let* ⟨ z, h1 ⟩ ← UScalar.add_spec.step_spec
     extract_goal0
     scalar_tac
 
@@ -1671,8 +1671,8 @@ info: example
     (do
       let z1 ← x + y
       z1 + x) ⦃ z => z.val = 2 * x.val + y.val ⦄ := by
-    let* ⟨ z1, h1 ⟩ ← UScalar.add_spec
-    let* ⟨ z2, h2 ⟩ ← UScalar.add_spec
+    let* ⟨ z1, h1 ⟩ ← UScalar.add_spec.step_spec
+    let* ⟨ z2, h2 ⟩ ← UScalar.add_spec.step_spec
     extract_goal0
     scalar_tac
 
@@ -1680,8 +1680,8 @@ info: example
     (do
       let z1 ← x + y
       z1 + x) ⦃ z => z.val = 2 * x.val + y.val ⦄ := by
-    step with UScalar.add_spec as ⟨ z1, h1 ⟩
-    step with UScalar.add_spec as ⟨ z2, h2 ⟩
+    step with UScalar.add_spec.step_spec as ⟨ z1, h1 ⟩
+    step with UScalar.add_spec.step_spec as ⟨ z2, h2 ⟩
     scalar_tac
 
   example {ty} {x y : UScalar ty}
@@ -1700,40 +1700,40 @@ info: example
   example {ty} {x y : UScalar ty}
     (hmax : x.val + y.val ≤ UScalar.max ty) :
     x + y ⦃ z => z.val = x.val + y.val ⦄ := by
-    step? as ⟨ z, h1 ⟩ says step with UScalar.add_spec as ⟨ z, h1 ⟩
+    step? as ⟨ z, h1 ⟩ says step with UScalar.add_spec.step_spec as ⟨ z, h1 ⟩
     scalar_tac
 
   example {ty} {x y : IScalar ty}
     (hmin : IScalar.min ty ≤ x.val + y.val)
     (hmax : x.val + y.val ≤ IScalar.max ty) :
     x + y ⦃ z => z.val = x.val + y.val ⦄ := by
-    step? as ⟨ z, h1 ⟩ says step with IScalar.add_spec as ⟨ z, h1 ⟩
+    step? as ⟨ z, h1 ⟩ says step with IScalar.add_spec.step_spec as ⟨ z, h1 ⟩
     scalar_tac
 
   example {ty} {x y : UScalar ty}
     (hmax : x.val + y.val ≤ UScalar.max ty) :
     x + y ⦃ z => z.val = x.val + y.val ⦄ := by
-    step with UScalar.add_spec as ⟨ z ⟩
+    step with UScalar.add_spec.step_spec as ⟨ z ⟩
     scalar_tac
 
   example {ty} {x y : IScalar ty}
     (hmin : IScalar.min ty ≤ x.val + y.val)
     (hmax : x.val + y.val ≤ IScalar.max ty) :
     x + y ⦃ z => z.val = x.val + y.val ⦄ := by
-    step with IScalar.add_spec as ⟨ z ⟩
+    step with IScalar.add_spec.step_spec as ⟨ z ⟩
     scalar_tac
 
   example {x y : U32}
     (hmax : x.val + y.val ≤ U32.max) :
     x + y ⦃ z => z.val = x.val + y.val ⦄ := by
     -- This spec theorem is suboptimal (compared to `U32.add_spec`), but it is good to check that it works
-    step with UScalar.add_spec as ⟨ z, h1 ⟩
+    step with UScalar.add_spec.step_spec as ⟨ z, h1 ⟩
     scalar_tac
 
   example {x y : U32}
     (hmax : x.val + y.val ≤ U32.max) :
     x + y ⦃ z => z.val = x.val + y.val ⦄ := by
-    step with U32.add_spec as ⟨ z, h1 ⟩
+    step with U32.add_spec.step_spec as ⟨ z, h1 ⟩
     scalar_tac
 
   example {x y : U32}
@@ -1794,7 +1794,7 @@ info: example
     (hmax : x.val + y.val ≤ IScalar.max ty) :
     False ∨ x + y ⦃ z => z.val = x.val + y.val ⦄ := by
     right
-    step? as ⟨ z, h1 ⟩ says step with IScalar.add_spec as ⟨ z, h1 ⟩
+    step? as ⟨ z, h1 ⟩ says step with IScalar.add_spec.step_spec as ⟨ z, h1 ⟩
     scalar_tac
 
   /--
@@ -1870,7 +1870,7 @@ hf : ∀ (x y : U32), ↑x < 10 → ↑y < 10 → f x y ⦃ x✝ => True ⦄
       let tot := x.val + y.val
       x + y ⦃ z => z.val = tot ⦄ := by
       simp
-      step with U32.add_spec
+      step with U32.add_spec.step_spec
       scalar_tac
 
     def add1 (x y : U32) : Std.Result U32 := do
@@ -1906,8 +1906,8 @@ x y : U32
   example (x y : U32) (h : 2 * x.val + 2 * y.val ≤ U32.max) :
     add1 x y ⦃ _ => True ⦄ := by
     rw [add1]
-    step? as ⟨ z1, h ⟩ says step with U32.add_spec as ⟨ z1, h ⟩
-    step? as ⟨ z2, h ⟩ says step with U32.add_spec as ⟨ z2, h ⟩
+    step? as ⟨ z1, h ⟩ says step with U32.add_spec.step_spec as ⟨ z1, h ⟩
+    step? as ⟨ z2, h ⟩ says step with U32.add_spec.step_spec as ⟨ z2, h ⟩
 end Test
 
 namespace Test
@@ -2012,7 +2012,7 @@ _✝ : ↑z = ↑x + y
   -- Test that we properly extract the names from the post-conditions
   /--
   error: unsolved goals
-case hmax
+case h_fail
 x y : U32
 ⊢ ↑x + ↑y ≤ U32.max
 
@@ -2230,8 +2230,8 @@ h1 : ∀ (i : ℕ) (x : i < s.length), s'[i] = 0#u32
     (do let x ← 1#i32 + 2#i32
         let y ← x + x
         ok y) (fun z => z.val == 6) := by
-    step with I32.add_spec
-    step with I32.add_spec
+    step with I32.add_spec.step_spec
+    step with I32.add_spec.step_spec
     simp [*]
 
   -- test lifting an assumption

--- a/backends/lean/Aeneas/Tactic/Step/StepStar.lean
+++ b/backends/lean/Aeneas/Tactic/Step/StepStar.lean
@@ -928,9 +928,9 @@ def add1 (x0 x1 : U32) : Std.Result U32 := do
 /--
 info: Try this:
 
-  [apply]     let* ⟨ x2, x2_post ⟩ ← U32.add_spec
-    let* ⟨ x3, x3_post ⟩ ← U32.add_spec
-    let* ⟨ ⟩ ← U32.add_spec
+  [apply]     let* ⟨ x2, x2_post ⟩ ← U32.add_spec.step_spec
+    let* ⟨ x3, x3_post ⟩ ← U32.add_spec.step_spec
+    let* ⟨ ⟩ ← U32.add_spec.step_spec
 -/
 #guard_msgs in
 example (x y : U32) (h : 2 * x.val + 2 * y.val + 4 ≤ U32.max) :
@@ -941,9 +941,9 @@ example (x y : U32) (h : 2 * x.val + 2 * y.val + 4 ≤ U32.max) :
 /--
 info: Try this:
 
-  [apply]     let* ⟨ x2, x2_post ⟩ ← [ +scalarTac -grind ] U32.add_spec
-    let* ⟨ x3, x3_post ⟩ ← [ +scalarTac -grind ] U32.add_spec
-    let* ⟨ ⟩ ← [ +scalarTac -grind ] U32.add_spec
+  [apply]     let* ⟨ x2, x2_post ⟩ ← [ +scalarTac -grind ] U32.add_spec.step_spec
+    let* ⟨ x3, x3_post ⟩ ← [ +scalarTac -grind ] U32.add_spec.step_spec
+    let* ⟨ ⟩ ← [ +scalarTac -grind ] U32.add_spec.step_spec
 -/
 #guard_msgs in
 example (x y : U32) (h : 2 * x.val + 2 * y.val + 4 ≤ U32.max) :
@@ -972,8 +972,8 @@ example (x y : U32) (h : 2 * x.val + 2 * y.val + 4 ≤ U32.max) :
 /--
 info: Try this:
 
-  [apply]     let* ⟨ x2, x2_post ⟩ ← U32.add_spec
-    let* ⟨ x3, x3_post ⟩ ← U32.add_spec
+  [apply]     let* ⟨ x2, x2_post ⟩ ← U32.add_spec.step_spec
+    let* ⟨ x3, x3_post ⟩ ← U32.add_spec.step_spec
 ---
 error: unsolved goals
 x y : U32
@@ -996,9 +996,9 @@ example (x y : U32) (h : 2 * x.val + 2 * y.val + 4 ≤ U32.max) :
 info: Try this:
 
   [apply]     simp only [step_simps]
-    let* ⟨ x2, x2_post ⟩ ← U32.add_spec
-    let* ⟨ x3, x3_post ⟩ ← U32.add_spec
-    let* ⟨ z, z_post ⟩ ← U32.add_spec
+    let* ⟨ x2, x2_post ⟩ ← U32.add_spec.step_spec
+    let* ⟨ x3, x3_post ⟩ ← U32.add_spec.step_spec
+    let* ⟨ z, z_post ⟩ ← U32.add_spec.step_spec
     agrind
 -/
 #guard_msgs in
@@ -1021,11 +1021,11 @@ def add2 (b : Bool) (x0 x1 : U32) : Std.Result U32 := do
 info: Try this:
 
   [apply]     spec_split
-    · let* ⟨ x2, x2_post ⟩ ← U32.add_spec
-      let* ⟨ x3, x3_post ⟩ ← U32.add_spec
-      let* ⟨ ⟩ ← U32.add_spec
-    · let* ⟨ y, y_post ⟩ ← U32.add_spec
-      let* ⟨ ⟩ ← U32.add_spec
+    · let* ⟨ x2, x2_post ⟩ ← U32.add_spec.step_spec
+      let* ⟨ x3, x3_post ⟩ ← U32.add_spec.step_spec
+      let* ⟨ ⟩ ← U32.add_spec.step_spec
+    · let* ⟨ y, y_post ⟩ ← U32.add_spec.step_spec
+      let* ⟨ ⟩ ← U32.add_spec.step_spec
 -/
 #guard_msgs in
 example b (x y : U32) (h : 2 * x.val + 2 * y.val + 4 ≤ U32.max) :
@@ -1037,10 +1037,10 @@ example b (x y : U32) (h : 2 * x.val + 2 * y.val + 4 ≤ U32.max) :
 info: Try this:
 
   [apply]     spec_split
-    · let* ⟨ x2, x2_post ⟩ ← U32.add_spec
-      let* ⟨ x3, x3_post ⟩ ← U32.add_spec
-    · let* ⟨ y, y_post ⟩ ← U32.add_spec
-      let* ⟨ ⟩ ← U32.add_spec
+    · let* ⟨ x2, x2_post ⟩ ← U32.add_spec.step_spec
+      let* ⟨ x3, x3_post ⟩ ← U32.add_spec.step_spec
+    · let* ⟨ y, y_post ⟩ ← U32.add_spec.step_spec
+      let* ⟨ ⟩ ← U32.add_spec.step_spec
 ---
 error: unsolved goals
 b : Bool
@@ -1065,25 +1065,25 @@ example b (x y : U32) (h : 2 * x.val + 2 * y.val + 4 ≤ U32.max) :
 info: Try this:
 
   [apply]     spec_split
-    · let* ⟨ x2, x2_post ⟩ ← U32.add_spec
+    · let* ⟨ x2, x2_post ⟩ ← U32.add_spec.step_spec
       · sorry
-      let* ⟨ x3, x3_post ⟩ ← U32.add_spec
+      let* ⟨ x3, x3_post ⟩ ← U32.add_spec.step_spec
       · sorry
-      let* ⟨ ⟩ ← U32.add_spec
+      let* ⟨ ⟩ ← U32.add_spec.step_spec
       · sorry
-    · let* ⟨ y, y_post ⟩ ← U32.add_spec
+    · let* ⟨ y, y_post ⟩ ← U32.add_spec.step_spec
       · sorry
-      let* ⟨ ⟩ ← U32.add_spec
+      let* ⟨ ⟩ ← U32.add_spec.step_spec
       · sorry
 ---
 error: unsolved goals
-case hmax
+case h_fail
 b : Bool
 x y : U32
 h✝ : b = true
 ⊢ ↑x + ↑y ≤ U32.max
 
-case hmax
+case h_fail
 b : Bool
 x y : U32
 h✝ : b = true
@@ -1092,7 +1092,7 @@ _ : [> let x2 ← x + y <]
 x2_post : ↑x2 = ↑x + ↑y
 ⊢ ↑x2 + ↑x2 ≤ U32.max
 
-case hmax
+case h_fail
 b : Bool
 x y : U32
 h✝ : b = true
@@ -1104,13 +1104,13 @@ _ : [> let x3 ← x2 + x2 <]
 x3_post : ↑x3 = ↑x2 + ↑x2
 ⊢ ↑x3 + ↑4#u32 ≤ U32.max
 
-case hmax
+case h_fail
 b : Bool
 x y : U32
 h✝ : ¬b = true
 ⊢ ↑x + ↑y ≤ U32.max
 
-case hmax
+case h_fail
 b : Bool
 x y✝ : U32
 h✝ : ¬b = true
@@ -1130,9 +1130,9 @@ example b (x y : U32) :
 /--
 info: Try this:
 
-  [apply]     let* ⟨ x2, x2_post ⟩ ← U32.add_spec
-    let* ⟨ x3, x3_post ⟩ ← U32.add_spec
-    let* ⟨ _, _ ⟩ ← U32.add_spec
+  [apply]     let* ⟨ x2, x2_post ⟩ ← U32.add_spec.step_spec
+    let* ⟨ x3, x3_post ⟩ ← U32.add_spec.step_spec
+    let* ⟨ _, _ ⟩ ← U32.add_spec.step_spec
     sorry
 ---
 error: unsolved goals
@@ -1304,7 +1304,7 @@ example (a b : U32) (h : a = b) (hbnd : a.val + b.val ≤ U32.max) :
 info: Try this:
 
   [apply]     spec_split
-    · let* ⟨ c, c_post ⟩ ← U32.add_spec
+    · let* ⟨ c, c_post ⟩ ← U32.add_spec.step_spec
       agrind
     · agrind
 -/
@@ -1321,7 +1321,7 @@ example (a b : U32) (h : a = b) (hbnd : a.val + b.val ≤ U32.max) :
     grindContradictionFn a b ⦃ c => c.val = a.val + b.val ⦄ := by
   unfold grindContradictionFn
   spec_split
-  · let* ⟨ c, c_post ⟩ ← U32.add_spec
+  · let* ⟨ c, c_post ⟩ ← U32.add_spec.step_spec
     agrind
   · agrind
 

--- a/backends/lean/Aeneas/Tactic/Step/Tests.lean
+++ b/backends/lean/Aeneas/Tactic/Step/Tests.lean
@@ -4,3 +4,5 @@ import Aeneas.Tactic.Step.Tests.MaxRecDepthMetavar
 import Aeneas.Tactic.Step.Tests.MvcgenSpec
 import Aeneas.Tactic.Step.Tests.TupleDestruct
 import Aeneas.Tactic.Step.Tests.UncurryBind
+import Aeneas.Tactic.Step.Tests.MvcgenSpec
+import Aeneas.Tactic.Step.Tests.SpecPartial

--- a/backends/lean/Aeneas/Tactic/Step/Tests/HigherOrder.lean
+++ b/backends/lean/Aeneas/Tactic/Step/Tests/HigherOrder.lean
@@ -19,7 +19,7 @@ info: Try this:
 
   [apply]     let* ⟨ y, y_post ⟩ ← [ +inferPost ] applyF_spec
     case hf =>
-      let* ⟨ _, _ ⟩ ← [ +inferPost ] U32.add_spec
+      let* ⟨ _, _ ⟩ ← [ +inferPost ] U32.add_spec.step_spec
       agrind
     agrind
 ---
@@ -51,10 +51,10 @@ info: Try this:
 
   [apply]     let* ⟨ ab, ab_post1, ab_post2 ⟩ ← [ +inferPost ] callPair_spec
     case hf =>
-      let* ⟨ _, _ ⟩ ← [ +inferPost ] U32.add_spec
+      let* ⟨ _, _ ⟩ ← [ +inferPost ] U32.add_spec.step_spec
       agrind
     case hg =>
-      let* ⟨ _, _ ⟩ ← [ +inferPost ] U32.add_spec
+      let* ⟨ _, _ ⟩ ← [ +inferPost ] U32.add_spec.step_spec
       agrind
     agrind
 ---
@@ -85,11 +85,11 @@ info: Try this:
 
   [apply]     let* ⟨ y, y_post ⟩ ← [ +inferPost ] callFThenG_spec
     case hf =>
-      let* ⟨ _, _ ⟩ ← [ +inferPost ] U32.add_spec
+      let* ⟨ _, _ ⟩ ← [ +inferPost ] U32.add_spec.step_spec
       agrind
     case hg =>
       intros y _
-      let* ⟨ _, _ ⟩ ← [ +inferPost ] U32.add_spec
+      let* ⟨ _, _ ⟩ ← [ +inferPost ] U32.add_spec.step_spec
       agrind
     agrind
 ---
@@ -111,7 +111,7 @@ info: Try this:
   [apply]     let* ⟨ y, y_post1, y_post2 ⟩ ← [ +inferPost ] Slice.mapM_spec
     case hf =>
       intros i hi
-      let* ⟨ _, _ ⟩ ← [ +inferPost ] U32.add_spec
+      let* ⟨ _, _ ⟩ ← [ +inferPost ] U32.add_spec.step_spec
       agrind
     agrind
 ---
@@ -136,7 +136,7 @@ example (s : Slice U32) (h : ∀ i (hi : i < s.len), s[i] < U32.max) :
   let* ⟨ y, y_post1, y_post2 ⟩ ← [ +inferPost ] Slice.mapM_spec
   case hf =>
     intros i hi
-    let* ⟨ _, _ ⟩ ← [ +inferPost ] U32.add_spec
+    let* ⟨ _, _ ⟩ ← [ +inferPost ] U32.add_spec.step_spec
     agrind (instances := 20) (ematch := 1)
   agrind (instances := 40) (ematch := 2)
 
@@ -151,12 +151,12 @@ info: Try this:
   [apply]     let* ⟨ y, y_post1, y_post2 ⟩ ← [ +inferPost ] Slice.mapM_spec
     case hf =>
       intros i hi
-      let* ⟨ _, _ ⟩ ← [ +inferPost ] U32.add_spec
+      let* ⟨ _, _ ⟩ ← [ +inferPost ] U32.add_spec.step_spec
       agrind
     let* ⟨ z, z_post1, z_post2 ⟩ ← [ +inferPost ] Slice.mapM_spec
     case hf =>
       intros i hi
-      let* ⟨ _, _ ⟩ ← [ +inferPost ] U32.mul_spec
+      let* ⟨ _, _ ⟩ ← [ +inferPost ] U32.mul_spec.step_spec
       agrind
     agrind
 ---
@@ -182,12 +182,12 @@ example (s : Slice U32) (h : ∀ i (hi : i < s.len), (s[i] + 1) * (s[i] + 1) ≤
   let* ⟨ y, y_post1, y_post2 ⟩ ← [ +inferPost ] Slice.mapM_spec
   case hf =>
     intros i hi
-    let* ⟨ _, _ ⟩ ← [ +inferPost ] U32.add_spec
+    let* ⟨ _, _ ⟩ ← [ +inferPost ] U32.add_spec.step_spec
     agrind (instances := 20) (ematch := 1)
   let* ⟨ z, z_post1, z_post2 ⟩ ← [ +inferPost ] Slice.mapM_spec
   case hf =>
     intros i hi
-    let* ⟨ _, _ ⟩ ← [ +inferPost ] U32.mul_spec
+    let* ⟨ _, _ ⟩ ← [ +inferPost ] U32.mul_spec.step_spec
     agrind (instances := 20) (ematch := 1)
   agrind (instances := 100) (ematch := 2)
 

--- a/backends/lean/Aeneas/Tactic/Step/Tests/MvcgenSpec.lean
+++ b/backends/lean/Aeneas/Tactic/Step/Tests/MvcgenSpec.lean
@@ -28,4 +28,4 @@ example (arr : Array U8 25#usize) (i : Usize) (a : U8) (hi : i < arr.length) :
     ⦃ ⌜ True ⌝ ⦄
       Array.update arr i a
     ⦃ ⇓ r => ⌜ r.get? i = some a ⌝ ⦄ := by
-  mvcgen; grind
+  mvcgen <;> grind

--- a/backends/lean/Aeneas/Tactic/Step/Tests/SpecPartial.lean
+++ b/backends/lean/Aeneas/Tactic/Step/Tests/SpecPartial.lean
@@ -1,0 +1,137 @@
+import Aeneas.Std.Scalar
+import Aeneas.Tactic.Step
+
+/-!
+# Tests: `@[step]` accepts `partialSpec` lemmas
+
+For a theorem using `partialSpec`, marking it with `@[step]` should register it for `step*` and
+for `mvcgen`.
+-/
+
+namespace Aeneas.Step.SpecPartialTests
+
+open Aeneas Aeneas.Std Result Std.Do WP
+
+set_option mvcgen.warning false
+
+/- ## Mock division: panics when dividing by zero, but does not specify `Error`. -/
+
+opaque myDiv (x y : U32) : Result U32
+
+@[step]
+axiom myDiv_partialSpec (x y : U32) :
+  partialSpec (myDiv x y)
+    (fun z => z.val = x.val / y.val)
+    (fun _ => y.val = 0)
+    False
+
+/-- step* -/
+example (x y : U32) (h : y.val ≠ 0) :
+    spec (myDiv x y) (fun z => z.val = x.val / y.val) := by
+  step*
+
+/-- mvcgen: total correctness -/
+example (x y : U32) (h : y.val ≠ 0) :
+    ⦃ ⌜ True ⌝ ⦄ (myDiv x y) ⦃ ⇓ z => ⌜ z.val = x.val / y.val ⌝ ⦄ := by
+  mvcgen
+
+/-- mvcgen: partial correctness -/
+example (x y : U32) :
+    ⦃ ⌜ True ⌝ ⦄ (myDiv x y) ⦃ ⇓? z => ⌜ z.val = x.val / y.val ⌝ ⦄ := by
+  mvcgen
+
+/--
+info: Aeneas.Step.SpecPartialTests.myDiv_partialSpec.step_spec (x y : U32) (h_fail : ¬↑y = 0) :
+  myDiv x y ⦃ z => ↑z = ↑x / ↑y ⦄
+-/
+#guard_msgs in
+#check myDiv_partialSpec.step_spec
+
+/--
+info: Aeneas.Step.SpecPartialTests.myDiv_partialSpec.mvcgen_spec (x y : U32) (Q : PostCond U32 Result.postShape)
+  (h_ok : ∀ (r : U32), ↑r = ↑x / ↑y → willYield r Q) (h_fail : ∀ (e : Error), ↑y = 0 → willFail e Q) :
+  ⦃⌜True⌝⦄ myDiv x y ⦃Q⦄
+-/
+#guard_msgs in
+#check myDiv_partialSpec.mvcgen_spec
+
+/- ## Mock addition: panics on overflow, specifies `Error.integerOverflow` -/
+
+opaque myAdd (x y : U32) : Result U32
+
+@[step]
+axiom myAdd_partialSpec (x y : U32) :
+  partialSpec (myAdd x y)
+    (fun z => z.val = x.val + y.val)
+    (fun | .integerOverflow => x.val + y.val > U32.max | _ => False)
+    False
+
+-- Pushing `¬` through `>` should produce `≤`.
+/--
+info: Aeneas.Step.SpecPartialTests.myAdd_partialSpec.step_spec (x y : U32) (h_fail : ↑x + ↑y ≤ U32.max) :
+  myAdd x y ⦃ z => ↑z = ↑x + ↑y ⦄
+-/
+#guard_msgs in
+#check myAdd_partialSpec.step_spec
+
+/--
+info: Aeneas.Step.SpecPartialTests.myAdd_partialSpec.mvcgen_spec (x y : U32) (Q : PostCond U32 Result.postShape)
+  (h_ok : ∀ (r : U32), ↑r = ↑x + ↑y → willYield r Q) (h_fail : U32.max < ↑x + ↑y → willFail Error.integerOverflow Q) :
+  ⦃⌜True⌝⦄ myAdd x y ⦃Q⦄
+-/
+#guard_msgs in
+#check myAdd_partialSpec.mvcgen_spec
+
+
+/- ## Mock signed add: panics on over- and underflow -/
+
+opaque myAddSigned (x y : I32) : Result I32
+
+@[step]
+axiom myAddSigned_partialSpec (x y : I32) :
+  partialSpec (myAddSigned x y)
+    (fun z => z.val = x.val + y.val)
+    (fun | .integerOverflow => (x.val + y.val > I32.max ∨ x.val + y.val < I32.min) | _ => False)
+    False
+
+/--
+info: Aeneas.Step.SpecPartialTests.myAddSigned_partialSpec.step_spec (x y : I32) (h_fail_1 : ↑x + ↑y ≤ I32.max)
+  (h_fail_2 : I32.min ≤ ↑x + ↑y) : myAddSigned x y ⦃ z => ↑z = ↑x + ↑y ⦄
+-/
+#guard_msgs in
+#check myAddSigned_partialSpec.step_spec
+
+/--
+info: Aeneas.Step.SpecPartialTests.myAddSigned_partialSpec.mvcgen_spec (x y : I32) (Q : PostCond I32 Result.postShape)
+  (h_ok : ∀ (r : I32), ↑r = ↑x + ↑y → willYield r Q) (h_fail_1 : I32.max < ↑x + ↑y → willFail Error.integerOverflow Q)
+  (h_fail_2 : ↑x + ↑y < I32.min → willFail Error.integerOverflow Q) : ⦃⌜True⌝⦄ myAddSigned x y ⦃Q⦄
+-/
+#guard_msgs in
+#check myAddSigned_partialSpec.mvcgen_spec
+
+
+/- ## Mock infinte loop: always diverges -/
+
+opaque infiniteLoop : Result Unit
+
+@[step]
+axiom infiniteLoop_partialSpec :
+  partialSpec infiniteLoop
+    (fun _ => False)
+    (fun _ => False)
+    True
+
+/--
+info: Aeneas.Step.SpecPartialTests.infiniteLoop_partialSpec.step_spec (h_div : False) : infiniteLoop ⦃ x✝ => False ⦄
+-/
+#guard_msgs in
+#check infiniteLoop_partialSpec.step_spec
+
+/--
+info: Aeneas.Step.SpecPartialTests.infiniteLoop_partialSpec.mvcgen_spec (Q : PostCond Unit Result.postShape)
+  (h_div : willDiverge Q) : ⦃⌜True⌝⦄ infiniteLoop ⦃Q⦄
+-/
+#guard_msgs in
+#check infiniteLoop_partialSpec.mvcgen_spec
+
+end Aeneas.Step.SpecPartialTests

--- a/tests/lean/BaseTutorial.lean
+++ b/tests/lean/BaseTutorial.lean
@@ -133,9 +133,9 @@ theorem mul2_add1_spec
      the fact that [2 * x + 1 < U32.max]. In case [step] fails to prove a
      precondition, it leaves it as a subgoal.
    -/
-  step with U32.add_spec as ⟨ x1 ⟩
+  step with U32.add_spec.step_spec as ⟨ x1 ⟩
   /- We can call [step] a second time for the second addition -/
-  step with U32.add_spec as ⟨ x2 ⟩
+  step with U32.add_spec.step_spec as ⟨ x2 ⟩
   /- We are now left with the remaining goal. We do this by calling
      [grind], an automated decision procedure
    -/

--- a/tests/lean/Tutorial/Exercises.lean
+++ b/tests/lean/Tutorial/Exercises.lean
@@ -24,7 +24,7 @@ theorem mul2_add1_spec (x : U32) (h : 2 * x.val + 1 ≤ U32.max)
   : mul2_add1 x ⦃ y => ↑y = 2 * ↑x + (1 : Int) ∧ ↑y = 2 * ↑x + (1 : Int) ⦄
   := by
   unfold mul2_add1
-  step with U32.add_spec as ⟨ x1 ⟩
+  step with U32.add_spec.step_spec as ⟨ x1 ⟩
   step as ⟨ x2 ⟩
   scalar_tac
 


### PR DESCRIPTION
This PR adds a new predicate `partialSpec` besides `spec`, allowing us to specify precisely when a function panics or diverges. The PR also modifies the `@[step]` attribute to support the new predicate: A `@[step]` attribute on a lemma using `partialSpec` will generate two additional lemmas: one for the `step` tactic and one for the `mvcgen` tactic. The `step` variant moves the failure and divergence conditions into hypotheses and uses `spec`. The `mvcgen` variant formulates the lemma in a form suitable for proving partial correctness with `mvcgen`.

The tricky part is that the generated spec lemmas should look natural, e.g. not contain expressions like `¬ ... > ...`. I use Lean's simplifier with a special set of simp lemmas to do that.

Moreover, this PR puts the new `partialSpec` predicate to use (in a separate commit): It converts the old spec lemmas into spec_partial lemmas for arithmetic and array/slice operations. I did not convert all specs to keep the PR small enough to review. 

We had discussed two things earlier that are not part of this PR (should they?):
* Reducing the number of `Error` types to just `ub` and `panic`.
* A dedicated attribute to mark specs for `mvcgen` instead of having `@[step]` register both.

The PR was assisted by Claude, but I closely observed and steered the progress, read every generated line, and made several manual changes.
