### PR TITLE
Add `public` in the list of Lean keywords

### DIFF
--- a/src/extract/ExtractBase.ml
+++ b/src/extract/ExtractBase.ml
@@ -1142,6 +1142,7 @@ let keywords () =
           "prelude";
           "private";
           "protected";
+          "public";
           "raw";
           "record";
           "reduce";


### PR DESCRIPTION
The keyword `public` was added in Lean 4.22.0, this PR add public to the list of keywords which get escaped in Lean. It occurred when extracting libsignal.