### PR TITLE
Improve the micro-pass that removes useless tuple decompositions

### DIFF
--- a/src/pure/PureMicroPassesGeneral.ml
+++ b/src/pure/PureMicroPassesGeneral.ml
@@ -3112,7 +3112,7 @@ let add_fuel (ctx : ctx) (trans : pure_fun_translation) : pure_fun_translation =
 (** Perform the following transformation:
 
     {[
-      let y <-- f x   (* Must be an application, is not necessarily monadic *)
+      let y <-- f x   (* Not necessarily monadic *)
       let (a, b) := y (* Tuple decomposition *)
       ...
     ]}
@@ -3122,49 +3122,95 @@ let add_fuel (ctx : ctx) (trans : pure_fun_translation) : pure_fun_translation =
     {[
       let (a, b) <-- f x
       ...
+    ]}
+
+    More generally, if [pat] is any pattern (not just a single variable), we
+    absorb any immediately following pure let-bindings that decompose an open
+    sub-field of [pat] into a tuple. For example:
+
+    {[
+      let (p, back) <-- f x
+      let (a, b) := p
+      ...
+    ]}
+
+    becomes:
+
+    {[
+      let ((a, b), back) <-- f x
+      ...
     ]} *)
 let merge_let_app_then_decompose_tuple_visitor (ctx : ctx) (def : fun_decl) =
   let span = def.item_meta.span in
+
+  (* Replace the open variable [var_id] in [pat] with [replacement] *)
+  let replace_open_in_pat (var_id : fvar_id) (replacement : tpat) (p : tpat) :
+      tpat =
+    let visitor =
+      object
+        inherit [_] map_tpat as super
+
+        method! visit_tpat () p =
+          match p.pat with
+          | POpen (v, _) when v.id = var_id -> replacement
+          | _ -> super#visit_tpat () p
+      end
+    in
+    visitor#visit_tpat () p
+  in
+
+  (* Repeatedly absorb pure let-bindings that decompose an open sub-field
+     of [pat] into a tuple.
+
+     Returns the updated pattern, the remaining continuation, and the
+     updated substitution environment. *)
+  let rec absorb_decompositions (open_vars : FVarId.Set.t)
+      (env : texpr FVarId.Map.t) (pat : tpat) (next : texpr) :
+      tpat * texpr * texpr FVarId.Map.t =
+    match next.e with
+    | Let (false, pat1, { e = FVar var_id; _ }, next1)
+      when FVarId.Set.mem var_id open_vars && is_pat_tuple pat1 ->
+        (* [next] is [let <tuple_pat> := <var>] where <var> is an open
+           sub-field of [pat]. Merge [pat1] into [pat]. *)
+        let pat1 =
+          tpat_replace_ignored_vars_with_free_vars ctx.fresh_fvar_id pat1
+        in
+        let pat1_expr = [%silent_unwrap] span (tpat_to_texpr span pat1) in
+        let env = FVarId.Map.add var_id pat1_expr env in
+        let new_pat = replace_open_in_pat var_id pat1 pat in
+        (* Update the set of open variables: remove the merged one,
+           add any new open variables from the replacement pattern *)
+        let open_vars = FVarId.Set.remove var_id open_vars in
+        let open_vars = FVarId.Set.union open_vars (tpat_get_fvars pat1) in
+        absorb_decompositions open_vars env new_pat next1
+    | _ -> (pat, next, env)
+  in
+
   object (self)
     inherit [_] map_expr
 
     method! visit_Let env monadic0 pat0 bound0 next0 =
       let bound0 = self#visit_texpr env bound0 in
-      (* Check if we need to merge two let-bindings *)
-      if is_pat_open pat0 then
-        let var0, _ = [%add_loc] as_pat_open span pat0 in
-        match next0.e with
-        | Let (false, pat1, { e = FVar var_id; _ }, next1) when var_id = var0.id
-          -> begin
-            (* Check if we are decomposing a tuple *)
-            if is_pat_tuple pat1 then
-              (* Introduce fresh variables for all the ignored variables
-                   to make sure we can turn the pattern into an expression *)
-              let pat1 =
-                tpat_replace_ignored_vars_with_free_vars ctx.fresh_fvar_id pat1
-              in
-              let pat1_expr = Option.get (tpat_to_texpr span pat1) in
-              (* Register the mapping from the variable we remove to the expression *)
-              let env = FVarId.Map.add var0.id pat1_expr env in
-              (* Continue *)
-              let next1 = self#visit_texpr env next1 in
-              Let (monadic0, pat1, bound0, next1)
-            else
-              let next0 = self#visit_texpr env next0 in
-              Let (monadic0, pat0, bound0, next0)
-          end
-        | _ ->
-            let next0 = self#visit_texpr env next0 in
-            Let (monadic0, pat0, bound0, next0)
-      else
-        let next0 = self#visit_texpr env next0 in
-        Let (monadic0, pat0, bound0, next0)
+      (* Try to absorb any immediately following pure let-bindings that
+         decompose open sub-fields of [pat0] into tuples *)
+      let open_vars = tpat_get_fvars pat0 in
+      let pat0, next0, env =
+        if FVarId.Set.is_empty open_vars then (pat0, next0, env)
+        else absorb_decompositions open_vars env pat0 next0
+      in
+      let next0 = self#visit_texpr env next0 in
+      Let (monadic0, pat0, bound0, next0)
 
-    (* Replace the variables *)
+    (* Replace the variables.
+       We apply substitutions recursively: if [var_id] maps to an expression
+       that itself contains variables in the env (due to chained tuple
+       decompositions), those are also substituted. This is safe because
+       fresh variable ids are monotonically increasing, so cycles are
+       impossible. *)
     method! visit_FVar env var_id =
       match FVarId.Map.find_opt var_id env with
       | None -> FVar var_id
-      | Some e -> e.e
+      | Some e -> (self#visit_texpr env e).e
   end
 
 let merge_let_app_then_decompose_tuple =

--- a/src/symbolic/SymbolicToPure.ml
+++ b/src/symbolic/SymbolicToPure.ml
@@ -345,7 +345,7 @@ let translate_trait_impl (ctx : Contexts.decls_ctx) (trait_impl : A.trait_impl)
 
 let translate_global (ctx : Contexts.decls_ctx) (decl : A.global_decl) :
     global_decl =
-  let { A.item_meta; def_id; generics = llbc_generics; ty; src; value; _ } =
+  let { A.item_meta; def_id; generics = llbc_generics; ty; src; value = _; _ } =
     decl
   in
   let body_id = Option.get (Charon.GAstUtils.init_fun_id_of_global decl) in

--- a/tests/lean/AdtBorrows.lean
+++ b/tests/lean/AdtBorrows.lean
@@ -215,8 +215,7 @@ def MutWrapper2.id
     Source: 'tests/src/adt-borrows.rs', lines 148:0-157:1 -/
 def use_mut_wrapper2 : Result Unit := do
   let (w, create_back, create_back1) ← MutWrapper2.create 0#i32 10#i32
-  let (p, unwrap_back, unwrap_back1) ← MutWrapper2.unwrap w
-  let (px, py) := p
+  let ((px, py), unwrap_back, unwrap_back1) ← MutWrapper2.unwrap w
   let px1 ← px + 1#i32
   let py1 ← py + 1#i32
   let x := create_back { w with x := (unwrap_back px1).x }

--- a/tests/lean/Issue789LoopCtxMatch.lean
+++ b/tests/lean/Issue789LoopCtxMatch.lean
@@ -40,8 +40,7 @@ def the_loop_loop.body
     × (Slice Std.U8) × Bool))
   := do
   let (s1, to_slice_mut_back) ← lift (Array.to_slice_mut s.y)
-  let (result, i, s2) ← f s.x next_in s1
-  let (done1, n) := result
+  let ((done1, n), i, s2) ← f s.x next_in s1
   let next_in1 ←
     core.slice.index.Slice.index
       (core.slice.index.SliceIndexRangeFromUsizeSlice Std.U8) next_in

--- a/tests/lean/Slices.lean
+++ b/tests/lean/Slices.lean
@@ -49,12 +49,26 @@ def split_at_mut
   {T : Type} (x : Slice T) (n : Std.Usize) :
   Result (((Slice T) × (Slice T)) × (((Slice T) × (Slice T)) → Slice T))
   := do
-  let (p, split_at_mut_back) ← core.slice.Slice.split_at_mut x n
-  let back := fun p1 => split_at_mut_back p1
-  ok (p, back)
+  let ((s, s1), split_at_mut_back) ← core.slice.Slice.split_at_mut x n
+  let back := fun p => split_at_mut_back p
+  ok ((s, s1), back)
+
+/-- [slices::split_at_mut_and_deref]:
+    Source: 'tests/src/slices.rs', lines 19:0-22:1
+    Visibility: public -/
+def split_at_mut_and_deref
+  {T : Type} (coremarkerCopyInst : core.marker.Copy T) (x : Slice T)
+  (n : Std.Usize) :
+  Result ((T × T) × (Slice T))
+  := do
+  let ((left, right), split_at_mut_back) ← core.slice.Slice.split_at_mut x n
+  let t ← Slice.index_usize left 0#usize
+  let t1 ← Slice.index_usize right 0#usize
+  let x1 := split_at_mut_back (left, right)
+  ok ((t, t1), x1)
 
 /-- [slices::swap]:
-    Source: 'tests/src/slices.rs', lines 19:0-21:1
+    Source: 'tests/src/slices.rs', lines 24:0-26:1
     Visibility: public -/
 def swap
   {T : Type} (x : Slice T) (n : Std.Usize) (m : Std.Usize) :
@@ -63,7 +77,7 @@ def swap
   core.slice.Slice.swap x n m
 
 /-- [slices::from_vec]:
-    Source: 'tests/src/slices.rs', lines 23:0-25:1
+    Source: 'tests/src/slices.rs', lines 28:0-30:1
     Visibility: public -/
 def from_vec {T : Type} (x : alloc.vec.Vec T) : Result (Slice T) := do
   alloc.vec.FromBoxSliceVec.from x

--- a/tests/src/slices.rs
+++ b/tests/src/slices.rs
@@ -16,6 +16,11 @@ pub fn split_at_mut<T>(x: &mut [T], n: usize) -> (&mut [T], &mut [T]) {
     x.split_at_mut(n)
 }
 
+pub fn split_at_mut_and_deref<T: Copy>(x: &mut [T], n: usize) -> (T, T) {
+    let (left, right) = x.split_at_mut(n);
+    (left[0], right[0])
+}
+
 pub fn swap<T>(x: &mut [T], n: usize, m: usize) {
     x.swap(n, m)
 }


### PR DESCRIPTION
This PR improves `PureMicroPasses.merge_let_app_then_decompose_tuple_visitor` to make it more general.