### PR TITLE
Prepare for the removal of method declaration items

### DIFF
--- a/src/Translate.ml
+++ b/src/Translate.ml
@@ -404,8 +404,8 @@ let translate_crate_to_pure (crate : crate) (marked_ids : marked_ids) :
   let builtin_fun_sigs =
     BuiltinFunIdMap.map
       (fun (info : builtin_fun_info) ->
-        SymbolicToPureTypes.translate_fun_sig trans_ctx (FBuiltin info.fun_id)
-          info.fun_sig
+        SymbolicToPureTypes.translate_fun_sig trans_ctx
+          (Pure.FunId (FBuiltin info.fun_id)) info.fun_sig
           (List.map (fun _ -> None) info.fun_sig.item_binder_value.inputs))
       builtin_fun_infos
   in

--- a/src/Translate.ml
+++ b/src/Translate.ml
@@ -107,8 +107,8 @@ let translate_function_to_pure_aux (trans_ctx : trans_ctx)
     (marked_ids : marked_ids)
     (pure_type_decls : Pure.type_decl Pure.TypeDeclId.Map.t)
     (pure_global_decls : Pure.global_decl GlobalDeclId.Map.t)
-    (fun_sigs : SymbolicToPureCore.fun_sigs FunDeclId.Map.t) (fdef : fun_decl) :
-    pure_fun_translation_no_loops =
+    (fun_sigs : SymbolicToPureCore.fun_sigs FunOrMethodId.Map.t)
+    (fdef : fun_decl) : pure_fun_translation_no_loops =
   (* Debug *)
   [%ltrace
     name_to_string trans_ctx fdef.item_meta.name
@@ -271,8 +271,8 @@ let translate_function_to_pure_aux (trans_ctx : trans_ctx)
 let translate_function_to_pure (trans_ctx : trans_ctx) (marked_ids : marked_ids)
     (pure_type_decls : Pure.type_decl Pure.TypeDeclId.Map.t)
     (pure_global_decls : Pure.global_decl Pure.GlobalDeclId.Map.t)
-    (fun_sigs : SymbolicToPureCore.fun_sigs FunDeclId.Map.t) (fdef : fun_decl) :
-    pure_fun_translation_no_loops option =
+    (fun_sigs : SymbolicToPureCore.fun_sigs FunOrMethodId.Map.t)
+    (fdef : fun_decl) : pure_fun_translation_no_loops option =
   try
     Some
       (translate_function_to_pure_aux trans_ctx marked_ids pure_type_decls
@@ -360,7 +360,7 @@ let translate_crate_to_pure (crate : crate) (marked_ids : marked_ids) :
 
   (* Compute the fun sigs for the whole crate *)
   let fun_sigs =
-    FunDeclId.Map.of_list
+    FunOrMethodId.Map.of_list
       (List.filter_map
          (fun (fdef : LlbcAst.fun_decl) ->
            try
@@ -375,7 +375,11 @@ let translate_crate_to_pure (crate : crate) (marked_ids : marked_ids) :
              let sg = translate_fun_sig_from_decomposed dsg in
              let ty = PureUtils.mk_arrows sg.inputs sg.output in
              let sg : fun_sigs = { dsg; sg; ty } in
-             Some (fdef.def_id, sg)
+             let id =
+               FunsAnalysis.fun_or_method_id_of_fun_decl_id
+                 trans_ctx.fun_ctx.fun_infos fdef.def_id
+             in
+             Some (id, sg)
            with CFailure error ->
              let name = name_to_string trans_ctx fdef.item_meta.name in
              let name_pattern =

--- a/src/Translate.ml
+++ b/src/Translate.ml
@@ -789,8 +789,12 @@ let export_global (fmt : Format.formatter) (config : gen_config) (ctx : gen_ctx)
     Option.get (Charon.GAstUtils.init_fun_id_of_global global)
   in
   let trans =
+    let id =
+      FunsAnalysis.fun_or_method_id_of_fun_decl_id
+        ctx.trans_ctx.fun_ctx.fun_infos global_init
+    in
     [%silent_unwrap_opt_span] None
-      (FunDeclId.Map.find_opt global_init ctx.trans_funs)
+      (FunOrMethodId.Map.find_opt id ctx.trans_funs)
   in
   [%sanity_check] global.item_meta.span (trans.loops = [] && trans.bodies = []);
   let body = trans.f in
@@ -1093,7 +1097,13 @@ let extract_definitions (fmt : Format.formatter) (config : gen_config)
     | FunGroup (NonRecGroup id) -> (
         (* Lookup - the translated function may not be in the map if we had
            to ignore it because of errors *)
-        let pure_fun = FunDeclId.Map.find_opt id ctx.trans_funs in
+        let pure_fun =
+          let id =
+            FunsAnalysis.fun_or_method_id_of_fun_decl_id
+              ctx.trans_ctx.fun_ctx.fun_infos id
+          in
+          FunOrMethodId.Map.find_opt id ctx.trans_funs
+        in
         (* Special case: we skip trait method *declarations* (we will
            extract their type directly in the records we generate for
            the trait declarations themselves, there is no point in having
@@ -1113,7 +1123,12 @@ let extract_definitions (fmt : Format.formatter) (config : gen_config)
         (* Lookup *)
         let pure_funs =
           List.filter_map
-            (fun id -> FunDeclId.Map.find_opt id ctx.trans_funs)
+            (fun id ->
+              let id =
+                FunsAnalysis.fun_or_method_id_of_fun_decl_id
+                  ctx.trans_ctx.fun_ctx.fun_infos id
+              in
+              FunOrMethodId.Map.find_opt id ctx.trans_funs)
             ids
         in
         if List.exists (fun pf -> pf.f.is_global_decl_body) pure_funs then
@@ -1443,10 +1458,15 @@ let extract_translated_crate (filename : string) (dest_dir : string)
     Pure.TypeDeclId.Map.of_list
       (List.map (fun (d : Pure.type_decl) -> (d.def_id, d)) trans_types)
   in
-  let trans_funs : pure_fun_translation FunDeclId.Map.t =
-    FunDeclId.Map.of_list
+  let trans_funs : pure_fun_translation FunOrMethodId.Map.t =
+    FunOrMethodId.Map.of_list
       (List.map
-         (fun (trans : pure_fun_translation) -> (trans.f.def_id, trans))
+         (fun (trans : pure_fun_translation) ->
+           let id =
+             FunsAnalysis.fun_or_method_id_of_fun_decl_id
+               trans_ctx.fun_ctx.fun_infos trans.f.def_id
+           in
+           (id, trans))
          trans_funs)
   in
 
@@ -1568,7 +1588,7 @@ let extract_translated_crate (filename : string) (dest_dir : string)
             );
           ctx)
       ctx
-      (FunDeclId.Map.values trans_funs)
+      (FunOrMethodId.Map.values trans_funs)
   in
 
   let ctx =

--- a/src/extract/Extract.ml
+++ b/src/extract/Extract.ml
@@ -2843,37 +2843,39 @@ let extract_trait_decl_method_names (ctx : extraction_ctx)
     | None ->
         (* Not a builtin function *)
         List.map
-          (fun (method_id, name, bound_fn) ->
+          (fun meth ->
             let default_id, fun_name =
-              compute_item_name name bound_fn.binder_value.fun_id
+              compute_item_name meth.item_name meth.fun_ref.binder_value.fun_id
             in
-            (method_id, default_id, fun_name))
+            (meth.method_id, default_id, fun_name))
           methods
     | Some info ->
         (* This is a builtin *)
         let funs_map = StringMap.of_list info.methods in
         List.map
-          (fun (method_id, item_name, fun_binder) ->
-            match StringMap.find_opt item_name funs_map with
+          (fun meth ->
+            match StringMap.find_opt meth.item_name funs_map with
             | None ->
                 [%warn] trait_decl.item_meta.span
                   ("When retrieving the builtin information for trait decl '"
                  ^ trait_decl.name
-                 ^ "', could not find the information for item '" ^ item_name
-                 ^ "'. The model defined in the " ^ Config.backend_name ()
+                 ^ "', could not find the information for item '"
+                 ^ meth.item_name ^ "'. The model defined in the "
+                 ^ Config.backend_name ()
                  ^ " library seems to be missing the corresponding field.");
                 (* Use the LLBC definition to compute the name *)
                 let default_id, fun_name =
-                  compute_item_name item_name fun_binder.binder_value.fun_id
+                  compute_item_name meth.item_name
+                    meth.fun_ref.binder_value.fun_id
                 in
-                (method_id, default_id, fun_name)
+                (meth.method_id, default_id, fun_name)
             | Some info ->
                 let fun_name = info.extract_name in
                 let default_id =
-                  if info.has_default then Some fun_binder.binder_value.fun_id
+                  if info.has_default then Some meth.fun_ref.binder_value.fun_id
                   else None
                 in
-                (method_id, default_id, fun_name))
+                (meth.method_id, default_id, fun_name))
           methods
   in
   (* Register the names *)
@@ -3044,9 +3046,10 @@ let explicit_info_drop_prefix (g1 : generic_params) (g2 : explicit_info) :
 
     Extract the items for a method in a trait decl. *)
 let extract_trait_decl_method_items_aux (ctx : extraction_ctx)
-    (fmt : F.formatter) (decl : trait_decl) (method_id : trait_method_id)
-    (fn : fun_decl_ref binder) : unit =
+    (fmt : F.formatter) (decl : trait_decl) (meth : trait_method) : unit =
   (* Lookup the definition *)
+  let method_id = meth.method_id in
+  let fn = meth.fun_ref in
   let fun_decl_id = fn.binder_value.fun_id in
   let trans =
     [%silent_unwrap_opt_span] None
@@ -3094,9 +3097,8 @@ let extract_trait_decl_method_items_aux (ctx : extraction_ctx)
   extract_trait_decl_item ctx fmt fun_name ty
 
 let extract_trait_decl_method_items (ctx : extraction_ctx) (fmt : F.formatter)
-    (decl : trait_decl) (method_id : trait_method_id) (fn : fun_decl_ref binder)
-    : unit =
-  try extract_trait_decl_method_items_aux ctx fmt decl method_id fn
+    (decl : trait_decl) (meth : trait_method) : unit =
+  try extract_trait_decl_method_items_aux ctx fmt decl meth
   with CFailure _ ->
     F.pp_print_space fmt ();
     extract_admit fmt
@@ -3208,8 +3210,9 @@ let extract_trait_decl (ctx : extraction_ctx) (fmt : F.formatter)
             ctx_get_trait_type decl.item_meta.span decl.def_id type_id ctx)
           decl.types
       @ List.map
-          (fun (method_id, _, _) ->
-            ctx_get_trait_method decl.item_meta.span decl.def_id method_id ctx)
+          (fun meth ->
+            ctx_get_trait_method decl.item_meta.span decl.def_id meth.method_id
+              ctx)
           decl.methods
       @ List.map
           (fun (clause : trait_param) ->
@@ -3302,8 +3305,7 @@ let extract_trait_decl (ctx : extraction_ctx) (fmt : F.formatter)
 
     (* The methods *)
     List.iter
-      (fun (method_id, _name, fn) ->
-        extract_trait_decl_method_items ctx fmt decl method_id fn)
+      (fun meth -> extract_trait_decl_method_items ctx fmt decl meth)
       decl.methods;
 
     (* Close the outer boxes for the definition *)
@@ -3368,8 +3370,8 @@ let extract_trait_decl_coq_arguments (ctx : extraction_ctx) (fmt : F.formatter)
     decl.parent_clauses;
   (* The  methods *)
   List.iter
-    (fun (method_id, _item_name, bound_fn) ->
-      let explicit_info = bound_fn.binder_explicit_info in
+    (fun meth ->
+      let explicit_info = meth.fun_ref.binder_explicit_info in
       (* TODO: this looks incorrect, we should instantiate the binder properly *)
       let params =
         params
@@ -3381,7 +3383,7 @@ let extract_trait_decl_coq_arguments (ctx : extraction_ctx) (fmt : F.formatter)
       in
       (* Extract *)
       let item_name =
-        ctx_get_trait_method decl.item_meta.span decl.def_id method_id ctx
+        ctx_get_trait_method decl.item_meta.span decl.def_id meth.method_id ctx
       in
       extract_coq_arguments_instruction ctx fmt item_name params)
     decl.methods;
@@ -3546,8 +3548,7 @@ let extract_trait_impl (ctx : extraction_ctx) (fmt : F.formatter)
           (fun (type_id, _) -> ctx_get_trait_type span decl_id type_id ctx)
           trait_decl.types
       @ List.map
-          (fun (method_id, _, _) ->
-            ctx_get_trait_method span decl_id method_id ctx)
+          (fun meth -> ctx_get_trait_method span decl_id meth.method_id ctx)
           trait_decl.methods
       @ List.map
           (fun (clause : trait_param) ->

--- a/src/extract/Extract.ml
+++ b/src/extract/Extract.ml
@@ -288,7 +288,11 @@ let fun_builtin_filter_types_trait_clauses (ty_to_string : 'a -> string)
     | None -> Result.Ok clauses
     | Some filter ->
         if List.length filter <> List.length types then (
-          let decl = FunDeclId.Map.find id ctx.trans_funs in
+          let id =
+            FunsAnalysis.fun_or_method_id_of_fun_decl_id
+              ctx.trans_ctx.fun_ctx.fun_infos id
+          in
+          let decl = A.FunOrMethodId.Map.find id ctx.trans_funs in
           let err =
             "Ill-formed builtin information for function "
             ^ name_to_string ctx decl.f.item_meta.name
@@ -309,7 +313,11 @@ let fun_builtin_filter_types_trait_clauses (ty_to_string : 'a -> string)
     | None -> Result.Ok (types, explicit)
     | Some filter ->
         if List.length filter <> List.length types then (
-          let decl = FunDeclId.Map.find id ctx.trans_funs in
+          let id =
+            FunsAnalysis.fun_or_method_id_of_fun_decl_id
+              ctx.trans_ctx.fun_ctx.fun_infos id
+          in
+          let decl = A.FunOrMethodId.Map.find id ctx.trans_funs in
           let err =
             "Ill-formed builtin information for function "
             ^ name_to_string ctx decl.f.item_meta.name
@@ -995,12 +1003,12 @@ and extract_function_call (span : Meta.span) (ctx : extraction_ctx)
       [%sanity_check] span (generics.const_generics = [] || backend () <> HOL4);
       (* Compute the information about the explicit/implicit input type parameters *)
       let explicit =
-        let lookup is_trait_method fun_decl_id lp_id =
+        let lookup is_trait_method id lp_id =
           try
             (* Lookup the function to retrieve the signature information *)
             let trans_fun =
               [%silent_unwrap] span
-                (A.FunDeclId.Map.find_opt fun_decl_id ctx.trans_funs)
+                (A.FunOrMethodId.Map.find_opt id ctx.trans_funs)
             in
             let trans_fun =
               match lp_id with
@@ -1023,9 +1031,17 @@ and extract_function_call (span : Meta.span) (ctx : extraction_ctx)
         in
         match fun_id with
         | FromLlbc (FunId (FRegular fun_decl_id), lp_id) ->
-            lookup false fun_decl_id lp_id
-        | FromLlbc (TraitMethod (_trait_ref, _method_name, fun_decl_id), lp_id)
-          -> lookup true fun_decl_id lp_id
+            let id =
+              FunsAnalysis.fun_or_method_id_of_fun_decl_id
+                ctx.trans_ctx.fun_ctx.fun_infos fun_decl_id
+            in
+            lookup false id lp_id
+        | FromLlbc (TraitMethod (trait_ref, method_id, _), lp_id) ->
+            let id =
+              A.FunOrMethodId.Method
+                (trait_ref.trait_decl_ref.trait_decl_id, method_id)
+            in
+            lookup true id lp_id
         | FromLlbc (FunId (FBuiltin aid), _) ->
             Some
               (Builtin.BuiltinFunIdMap.find aid ctx.builtin_sigs).explicit_info
@@ -2806,11 +2822,12 @@ let extract_trait_decl_method_names (ctx : extraction_ctx)
   [%ltrace trait_decl.name];
   let methods = trait_decl.methods in
   (* Small helper *)
-  let compute_item_name (item_name : string) (id : fun_decl_id) :
+  let compute_item_name (method_id : trait_method_id) (item_name : string) :
       FunDeclId.id option * string =
     [%ldebug "(" ^ trait_decl.name ^ "): compute_item_name: " ^ item_name];
     let trans : pure_fun_translation =
-      match FunDeclId.Map.find_opt id ctx.trans_funs with
+      let id = A.FunOrMethodId.Method (trait_decl.def_id, method_id) in
+      match A.FunOrMethodId.Map.find_opt id ctx.trans_funs with
       | Some decl -> decl
       | None ->
           [%craise] trait_decl.item_meta.span
@@ -2845,7 +2862,7 @@ let extract_trait_decl_method_names (ctx : extraction_ctx)
         List.map
           (fun meth ->
             let default_id, fun_name =
-              compute_item_name meth.item_name meth.fun_ref.binder_value.fun_id
+              compute_item_name meth.method_id meth.item_name
             in
             (meth.method_id, default_id, fun_name))
           methods
@@ -2865,8 +2882,7 @@ let extract_trait_decl_method_names (ctx : extraction_ctx)
                  ^ " library seems to be missing the corresponding field.");
                 (* Use the LLBC definition to compute the name *)
                 let default_id, fun_name =
-                  compute_item_name meth.item_name
-                    meth.fun_ref.binder_value.fun_id
+                  compute_item_name meth.method_id meth.item_name
                 in
                 (meth.method_id, default_id, fun_name)
             | Some info ->
@@ -3050,10 +3066,10 @@ let extract_trait_decl_method_items_aux (ctx : extraction_ctx)
   (* Lookup the definition *)
   let method_id = meth.method_id in
   let fn = meth.fun_ref in
-  let fun_decl_id = fn.binder_value.fun_id in
   let trans =
+    let id = A.FunOrMethodId.Method (decl.def_id, method_id) in
     [%silent_unwrap_opt_span] None
-      (A.FunDeclId.Map.find_opt fun_decl_id ctx.trans_funs)
+      (A.FunOrMethodId.Map.find_opt id ctx.trans_funs)
   in
   let span = trans.f.item_meta.span in
   (* Extract the items *)
@@ -3408,8 +3424,12 @@ let extract_trait_impl_method_items_aux (ctx : extraction_ctx)
   let method_decl_id = fn.binder_value.fun_id in
   (* Lookup the definition *)
   let trans =
+    let id =
+      FunsAnalysis.fun_or_method_id_of_fun_decl_id
+        ctx.trans_ctx.fun_ctx.fun_infos method_decl_id
+    in
     [%unwrap_with_span] span
-      (A.FunDeclId.Map.find_opt method_decl_id ctx.trans_funs)
+      (A.FunOrMethodId.Map.find_opt id ctx.trans_funs)
       "Could not lookup the translated function, probably because of an error \
        which happened before"
   in

--- a/src/extract/ExtractBase.ml
+++ b/src/extract/ExtractBase.ml
@@ -2382,14 +2382,15 @@ let ctx_compute_fun_global_name_no_suffix (item_meta : T.item_meta)
                 | AssocIdMethod method_id -> (
                     match
                       List.find_opt
-                        (fun (mid, _, _) -> mid = method_id)
+                        (fun meth -> meth.method_id = method_id)
                         trait_decl.methods
                     with
                     | None -> None
-                    | Some (_, _, bound_fn) ->
+                    | Some meth ->
                         Option.map
                           (fun (def : A.fun_decl) -> def.item_meta)
-                          (FunDeclId.Map.find_opt bound_fn.binder_value.fun_id
+                          (FunDeclId.Map.find_opt
+                             meth.fun_ref.binder_value.fun_id
                              ctx.trans_ctx.fun_ctx.fun_decls))
                 | AssocIdConst _ ->
                     (* TODO: missing item meta information *)

--- a/src/extract/ExtractBase.ml
+++ b/src/extract/ExtractBase.ml
@@ -596,7 +596,7 @@ type extraction_ctx = {
   trait_decl_id : trait_decl_id option;
       (** If we are extracting a trait declaration, identifies it *)
   trans_types : Pure.type_decl Pure.TypeDeclId.Map.t;
-  trans_funs : pure_fun_translation A.FunDeclId.Map.t;
+  trans_funs : pure_fun_translation A.FunOrMethodId.Map.t;
   trans_globals : Pure.global_decl Pure.GlobalDeclId.Map.t;
   builtin_sigs : Pure.fun_sig Builtin.BuiltinFunIdMap.t;
   functions_with_decreases_clause : PureUtils.FunLoopIdSet.t;

--- a/src/interp/InterpStatements.ml
+++ b/src/interp/InterpStatements.ml
@@ -579,9 +579,8 @@ let mk_symbolic_fun_call_inst (span : Meta.span) (ctx : eval_ctx)
       instantiate_fun_sig (Some span) ctx inst_generics tr_self signature;
   }
 
-(** Auxiliary helper for [eval_non_builtin_function_call_symbolic] Instantiate
-    the signature and introduce fresh abstractions and region ids while doing
-    so.
+(** Auxiliary helper for [eval_function_call_symbolic] Instantiate the signature
+    and introduce fresh abstractions and region ids while doing so.
 
     We perform some manipulations when instantiating the signature.
 
@@ -638,72 +637,80 @@ let mk_symbolic_fun_call_inst (span : Meta.span) (ctx : eval_ctx)
       let option_has_value (T : Type) (x : Option T) : result bool =
         OptionHasValueImpl.has_value T x
     ]} *)
-let eval_non_builtin_function_call_symbolic_inst (span : Meta.span)
-    (call : call) (ctx : eval_ctx) : symbolic_fun_call_inst =
-  match call.func with
-  | FnOpDynamic _ ->
-      (* Function pointer case: TODO *)
-      [%craise] span "Function pointers are not supported yet"
-  | FnOpRegular func ->
-      let call_info =
-        match func.kind with
-        | FunId (FRegular fid) ->
-            [%ltrace "Regular function"];
-            let tr_self = UnknownTrait __FUNCTION__ in
-            (* Lookup the declaration *)
-            let def = ctx_lookup_fun_decl span ctx fid in
-            let signature = bound_fun_sig_of_decl def in
-            mk_symbolic_fun_call_inst span ctx ~call_kind:func.kind
-              ~call_generics:func.generics ~call_span:def.item_meta.span
-              ~inst_generics:func.generics ~tr_self signature
-        | FunId (FBuiltin _) ->
-            (* Unreachable: must be a transparent function *)
-            [%craise] span "Unreachable"
-        | TraitMethod (trait_ref, method_id, _) ->
-            [%ltrace
-              "trait method call:\n- call: " ^ call_to_string ctx call
-              ^ "\n- method name: "
-              ^ Charon.GAstUtils.get_method_name ctx.crate
-                  trait_ref.trait_decl_ref.binder_value.id method_id
-              ^ "\n- call.generics:\n"
-              ^ generic_args_to_string ctx func.generics
-              ^ "\n- trait_ref.trait_decl_ref: "
-              ^ trait_decl_ref_region_binder_to_string ctx
-                  trait_ref.trait_decl_ref];
-            (* Check that there are no bound regions *)
-            [%cassert] span
-              (trait_ref.trait_decl_ref.binder_regions = [])
-              "Unexpected bound regions";
-            let trait_decl_ref = trait_ref.trait_decl_ref.binder_value in
-            (* This should be a call to a trait clause method (if it were a method
-               coming from an impl, there should be no indirection through the trait
-               reference itself (Charon should have simplified this). *)
-            (*[%sanity_check] span
-              (match trait_ref.kind with
-              | TraitImpl _ -> false
-              | _ -> true);*)
-            (* Lookup the trait decl and substitution *)
-            let trait_decl = ctx_lookup_trait_decl span ctx trait_decl_ref.id in
-            let fn_ref =
-              Option.get
-                (Substitute.lookup_and_subst_trait_decl_method trait_decl
-                   method_id trait_ref func.generics)
-            in
-            (* *)
-            let tr_self = trait_ref.kind in
-            (* Lookup the declaration *)
-            let def = ctx_lookup_fun_decl span ctx fn_ref.id in
-            let signature = bound_fun_sig_of_decl def in
-            mk_symbolic_fun_call_inst span ctx ~call_kind:func.kind
-              ~call_generics:func.generics ~call_span:def.item_meta.span
-              ~inst_generics:fn_ref.generics ~tr_self signature
+let eval_function_call_symbolic_inst (span : Meta.span) (func : fn_ptr)
+    (ctx : eval_ctx) : symbolic_fun_call_inst =
+  match func.kind with
+  | FunId (FRegular fid) ->
+      let tr_self = UnknownTrait __FUNCTION__ in
+      (* Lookup the declaration *)
+      let def = ctx_lookup_fun_decl span ctx fid in
+      let signature = bound_fun_sig_of_decl def in
+      mk_symbolic_fun_call_inst span ctx ~call_kind:func.kind
+        ~call_generics:func.generics ~call_span:def.item_meta.span
+        ~inst_generics:func.generics ~tr_self signature
+  | FunId (FBuiltin fid) ->
+      (* In symbolic mode, the behavior of a function call is completely
+         defined by the signature of the function: we thus simply generate
+         correctly instantiated signatures, and delegate the work to an
+         auxiliary function *)
+      let sg = Builtin.get_builtin_fun_sig fid in
+      (* Sanity check: make sure the type parameters don't contain regions -
+         this is a current limitation of our synthesis, *except if the function
+         is [Box::new] (TODO: the case [Box::new] is a hack) *)
+      if fid = BoxNew then
+        (* Sanity check: check that we are not using nested borrows *)
+        [%classert] span
+          (List.for_all
+             (fun ty ->
+               not
+                 (ty_has_nested_borrows (Some span) ctx.type_ctx.type_infos ty))
+             func.generics.types)
+          (lazy
+            ("Instantiating [Box::new] with nested borrows is not allowed for \
+              now (" ^ fn_ptr_to_string ctx func ^ ")"))
+      else
+        [%classert] span
+          (List.for_all
+             (fun ty -> not (ty_has_mut_borrows ctx.type_ctx.type_infos ty))
+             func.generics.types)
+          (lazy
+            ("Instantiating the type parameters of a function with types \
+              containing mutable borrows is currently not allowed ("
+           ^ fn_ptr_to_string ctx func ^ ")"));
+
+      (* There shouldn't be any reference to Self *)
+      let tr_self = UnknownTrait __FUNCTION__ in
+      mk_symbolic_fun_call_inst span ctx ~call_kind:func.kind
+        ~call_generics:func.generics ~call_span:span
+        ~inst_generics:func.generics ~tr_self sg
+  | TraitMethod (trait_ref, method_id, _) ->
+      (* Check that there are no bound regions *)
+      [%cassert] span
+        (trait_ref.trait_decl_ref.binder_regions = [])
+        "Unexpected bound regions";
+      let trait_decl_ref = trait_ref.trait_decl_ref.binder_value in
+      (* This should be a call to a trait clause method (if it were a method
+         coming from an impl, there should be no indirection through the
+         trait reference itself (Charon should have simplified this). *)
+      (*[%sanity_check] span
+          (match trait_ref.kind with
+          | TraitImpl _ -> false
+          | _ -> true);*)
+      (* Lookup the trait decl and substitution *)
+      let trait_decl = ctx_lookup_trait_decl span ctx trait_decl_ref.id in
+      let fn_ref =
+        Option.get
+          (Substitute.lookup_and_subst_trait_decl_method trait_decl method_id
+             trait_ref func.generics)
       in
-      [%ltrace
-        "- call: " ^ call_to_string ctx call ^ "\n- call.generics:\n"
-        ^ generic_args_to_string ctx call_info.call_generics
-        ^ "\n- def.signature:\n"
-        ^ fun_sig_to_string ctx call_info.call_sig];
-      call_info
+      (* *)
+      let tr_self = trait_ref.kind in
+      (* Lookup the declaration *)
+      let def = ctx_lookup_fun_decl span ctx fn_ref.id in
+      let signature = bound_fun_sig_of_decl def in
+      mk_symbolic_fun_call_inst span ctx ~call_kind:func.kind
+        ~call_generics:func.generics ~call_span:def.item_meta.span
+        ~inst_generics:fn_ref.generics ~tr_self signature
 
 (** Helper to evaluate global references for lifetime static.
 
@@ -1382,15 +1389,22 @@ and eval_function_call_concrete (config : config) (span : Meta.span)
 
 and eval_function_call_symbolic (config : config) (span : Meta.span)
     (call : call) : stl_cm_fun =
+ fun ctx ->
   match call.func with
   | FnOpDynamic _ -> [%craise] span "Function pointers are not supported yet"
-  | FnOpRegular func -> (
-      match func.kind with
-      | FunId (FRegular _) | TraitMethod _ ->
-          eval_non_builtin_function_call_symbolic config span call
-      | FunId (FBuiltin fid) ->
-          eval_builtin_function_call_symbolic config span fid func call.args
-            call.dest)
+  | FnOpRegular func ->
+      [%ltrace
+        "function call:\n- call: " ^ call_to_string ctx call ^ "\n- fn_ptr : "
+        ^ fn_ptr_to_string ctx func];
+      let call_info = eval_function_call_symbolic_inst span func ctx in
+      [%ltrace
+        "- call: " ^ call_to_string ctx call ^ "\n- call.generics:\n"
+        ^ generic_args_to_string ctx call_info.call_generics
+        ^ "\n- def.signature:\n"
+        ^ fun_sig_to_string ctx call_info.call_sig];
+      (* Evaluate the function call *)
+      eval_function_call_symbolic_from_inst_sig config call_info call.args
+        call.dest ctx
 
 (** Evaluate a local (i.e., non-builtin) function call in concrete mode *)
 and eval_non_builtin_function_call_concrete (config : config) (span : Meta.span)
@@ -1481,15 +1495,6 @@ and eval_non_builtin_function_call_concrete (config : config) (span : Meta.span)
       let cf_pop el = List.map2 (fun cf e -> cf e) cfl el in
       (* Continue *)
       (ctx_resl, cc_comp cc cf_pop)
-
-(** Evaluate a local (i.e., non-builtin) function call in symbolic mode *)
-and eval_non_builtin_function_call_symbolic (config : config) (span : Meta.span)
-    (call : call) : stl_cm_fun =
- fun ctx ->
-  let call_info = eval_non_builtin_function_call_symbolic_inst span call ctx in
-  (* Evaluate the function call *)
-  eval_function_call_symbolic_from_inst_sig config call_info call.args call.dest
-    ctx
 
 (** Evaluate a function call in symbolic mode by using the function signature.
 
@@ -1684,49 +1689,6 @@ and eval_function_call_symbolic_from_inst_sig (config : config)
    * where we haven't panicked. Of course, the translation needs to take the
    * panic case into account... *)
   ([ (ctx, Unit) ], cc_singleton __FILE__ __LINE__ span cc)
-
-(** Evaluate a non-local function call in symbolic mode *)
-and eval_builtin_function_call_symbolic (config : config) (span : Meta.span)
-    (fid : builtin_fun_id) (func : fn_ptr) (args : operand list) (dest : place)
-    : stl_cm_fun =
- fun ctx ->
-  (* In symbolic mode, the behavior of a function call is completely defined
-     by the signature of the function: we thus simply generate correctly
-     instantiated signatures, and delegate the work to an auxiliary function *)
-  let sg = Builtin.get_builtin_fun_sig fid in
-  (* Sanity check: make sure the type parameters don't contain regions -
-       this is a current limitation of our synthesis, *except if the function
-       is [Box::new] (TODO: the case [Box::new] is a hack) *)
-  if fid = BoxNew then
-    (* Sanity check: check that we are not using nested borrows *)
-    [%classert] span
-      (List.for_all
-         (fun ty ->
-           not (ty_has_nested_borrows (Some span) ctx.type_ctx.type_infos ty))
-         func.generics.types)
-      (lazy
-        ("Instantiating [Box::new] with nested borrows is not allowed for now ("
-       ^ fn_ptr_to_string ctx func ^ ")"))
-  else
-    [%classert] span
-      (List.for_all
-         (fun ty -> not (ty_has_mut_borrows ctx.type_ctx.type_infos ty))
-         func.generics.types)
-      (lazy
-        ("Instantiating the type parameters of a function with types \
-          containing mutable borrows is currently not allowed ("
-       ^ fn_ptr_to_string ctx func ^ ")"));
-
-  (* There shouldn't be any reference to Self *)
-  let tr_self = UnknownTrait __FUNCTION__ in
-  let call_info =
-    mk_symbolic_fun_call_inst span ctx ~call_kind:(FunId (FBuiltin fid))
-      ~call_generics:func.generics ~call_span:span ~inst_generics:func.generics
-      ~tr_self sg
-  in
-
-  (* Evaluate the function call *)
-  eval_function_call_symbolic_from_inst_sig config call_info args dest ctx
 
 (** Evaluate a statement seen as a function body *)
 and eval_function_body (config : config) (body : block) : stl_cm_fun =

--- a/src/interp/InterpStatements.ml
+++ b/src/interp/InterpStatements.ml
@@ -557,6 +557,28 @@ let create_push_abstractions_from_abs_region_groups
   in
   List.fold_left insert_abs ctx (List.combine rg_ids empty_absl)
 
+type symbolic_fun_call_inst = {
+  call_kind : fn_ptr_kind;
+  call_generics : generic_args;
+  call_span : Meta.span;
+  call_sig : bound_fun_sig;
+  call_inst_sig : inst_fun_sig;
+}
+
+let mk_symbolic_fun_call_inst (span : Meta.span) (ctx : eval_ctx)
+    ~(call_kind : fn_ptr_kind) ~(call_generics : generic_args)
+    ~(call_span : Meta.span) ~(inst_generics : generic_args)
+    ~(tr_self : trait_ref_kind) (signature : bound_fun_sig) :
+    symbolic_fun_call_inst =
+  {
+    call_kind;
+    call_generics;
+    call_span;
+    call_sig = signature;
+    call_inst_sig =
+      instantiate_fun_sig (Some span) ctx inst_generics tr_self signature;
+  }
+
 (** Auxiliary helper for [eval_non_builtin_function_call_symbolic] Instantiate
     the signature and introduce fresh abstractions and region ids while doing
     so.
@@ -617,19 +639,23 @@ let create_push_abstractions_from_abs_region_groups
         OptionHasValueImpl.has_value T x
     ]} *)
 let eval_non_builtin_function_call_symbolic_inst (span : Meta.span)
-    (call : call) (ctx : eval_ctx) :
-    fn_ptr_kind * generic_args * fun_decl * inst_fun_sig =
+    (call : call) (ctx : eval_ctx) : symbolic_fun_call_inst =
   match call.func with
   | FnOpDynamic _ ->
       (* Function pointer case: TODO *)
       [%craise] span "Function pointers are not supported yet"
   | FnOpRegular func ->
-      let fid, generics, tr_self =
+      let call_info =
         match func.kind with
         | FunId (FRegular fid) ->
             [%ltrace "Regular function"];
             let tr_self = UnknownTrait __FUNCTION__ in
-            (fid, func.generics, tr_self)
+            (* Lookup the declaration *)
+            let def = ctx_lookup_fun_decl span ctx fid in
+            let signature = bound_fun_sig_of_decl def in
+            mk_symbolic_fun_call_inst span ctx ~call_kind:func.kind
+              ~call_generics:func.generics ~call_span:def.item_meta.span
+              ~inst_generics:func.generics ~tr_self signature
         | FunId (FBuiltin _) ->
             (* Unreachable: must be a transparent function *)
             [%craise] span "Unreachable"
@@ -665,21 +691,19 @@ let eval_non_builtin_function_call_symbolic_inst (span : Meta.span)
             in
             (* *)
             let tr_self = trait_ref.kind in
-            (fn_ref.id, fn_ref.generics, tr_self)
+            (* Lookup the declaration *)
+            let def = ctx_lookup_fun_decl span ctx fn_ref.id in
+            let signature = bound_fun_sig_of_decl def in
+            mk_symbolic_fun_call_inst span ctx ~call_kind:func.kind
+              ~call_generics:func.generics ~call_span:def.item_meta.span
+              ~inst_generics:fn_ref.generics ~tr_self signature
       in
-      (* Lookup the declaration *)
-      let def = ctx_lookup_fun_decl span ctx fid in
-      let signature = bound_fun_sig_of_decl def in
       [%ltrace
         "- call: " ^ call_to_string ctx call ^ "\n- call.generics:\n"
-        ^ generic_args_to_string ctx generics
+        ^ generic_args_to_string ctx call_info.call_generics
         ^ "\n- def.signature:\n"
-        ^ fun_sig_to_string ctx signature];
-      (* Instantiate *)
-      let inst_sg =
-        instantiate_fun_sig (Some span) ctx generics tr_self signature
-      in
-      (func.kind, func.generics, def, inst_sg)
+        ^ fun_sig_to_string ctx call_info.call_sig];
+      call_info
 
 (** Helper to evaluate global references for lifetime static.
 
@@ -1462,34 +1486,34 @@ and eval_non_builtin_function_call_concrete (config : config) (span : Meta.span)
 and eval_non_builtin_function_call_symbolic (config : config) (span : Meta.span)
     (call : call) : stl_cm_fun =
  fun ctx ->
-  let func, generics, def, inst_sg =
-    eval_non_builtin_function_call_symbolic_inst span call ctx
-  in
-  (* Sanity check: same number of inputs *)
-  [%sanity_check] span (List.length call.args = List.length def.signature.inputs);
-  (* Sanity check: the class of borrows present in the type is supported *)
-  List.iter
-    ([%add_loc] check_ty_is_supported span ctx)
-    (inst_sg.output :: inst_sg.inputs);
+  let call_info = eval_non_builtin_function_call_symbolic_inst span call ctx in
   (* Evaluate the function call *)
-  eval_function_call_symbolic_from_inst_sig config def.item_meta.span func
-    def.signature inst_sg generics call.args call.dest ctx
+  eval_function_call_symbolic_from_inst_sig config call_info call.args call.dest
+    ctx
 
 (** Evaluate a function call in symbolic mode by using the function signature.
 
     This allows us to factorize the evaluation of local and non-local function
     calls in symbolic mode: only their signatures matter.
 
-    The [self_trait_ref] trait ref refers to [Self]. We use it when calling a
-    provided trait method, because those methods have a special treatment: we
-    dot not group them with the required trait methods, and forbid (for now)
-    overriding them. We treat them as regular method, which take an additional
-    trait ref as input. *)
+    The [call_info] contains the signature after instantiation together with the
+    original call information used by the symbolic AST. *)
 and eval_function_call_symbolic_from_inst_sig (config : config)
-    (span : Meta.span) (fid : fn_ptr_kind) (sg : fun_sig)
-    (inst_sg : inst_fun_sig) (generics : generic_args) (args : operand list)
-    (dest : place) : stl_cm_fun =
+    (call_info : symbolic_fun_call_inst) (args : operand list) (dest : place) :
+    stl_cm_fun =
  fun ctx ->
+  let span = call_info.call_span in
+  let fid = call_info.call_kind in
+  let sg = call_info.call_sig.item_binder_value in
+  let inst_sg = call_info.call_inst_sig in
+  let generics = call_info.call_generics in
+  (* Sanity check: same number of inputs *)
+  [%sanity_check] span
+    (List.length args = List.length call_info.call_sig.item_binder_value.inputs);
+  (* Sanity check: the class of borrows present in the type is supported *)
+  List.iter
+    ([%add_loc] check_ty_is_supported span ctx)
+    (call_info.call_inst_sig.output :: call_info.call_inst_sig.inputs);
   [%ltrace
     "- fid: "
     ^ fn_ptr_kind_to_string ctx fid
@@ -1695,11 +1719,14 @@ and eval_builtin_function_call_symbolic (config : config) (span : Meta.span)
 
   (* There shouldn't be any reference to Self *)
   let tr_self = UnknownTrait __FUNCTION__ in
-  let inst_sig = instantiate_fun_sig (Some span) ctx func.generics tr_self sg in
+  let call_info =
+    mk_symbolic_fun_call_inst span ctx ~call_kind:(FunId (FBuiltin fid))
+      ~call_generics:func.generics ~call_span:span ~inst_generics:func.generics
+      ~tr_self sg
+  in
 
   (* Evaluate the function call *)
-  eval_function_call_symbolic_from_inst_sig config span (FunId (FBuiltin fid))
-    sg.item_binder_value inst_sig func.generics args dest ctx
+  eval_function_call_symbolic_from_inst_sig config call_info args dest ctx
 
 (** Evaluate a statement seen as a function body *)
 and eval_function_body (config : config) (body : block) : stl_cm_fun =

--- a/src/llbc/Contexts.ml
+++ b/src/llbc/Contexts.ml
@@ -46,7 +46,7 @@ type type_ctx = {
 type fun_ctx = {
   fun_decls : fun_decl FunDeclId.Map.t;
       (** Copy of the declarations in the crate *)
-  fun_infos : FunsAnalysis.fun_info FunDeclId.Map.t;
+  fun_infos : FunsAnalysis.modules_funs_info;
   to_extract : fun_decl FunDeclId.Map.t;
       (** The fun declarations that should be extracted.
 

--- a/src/llbc/FunsAnalysis.ml
+++ b/src/llbc/FunsAnalysis.ml
@@ -32,16 +32,71 @@ type fun_info = {
 }
 [@@deriving show]
 
-(** Various information about a module's functions *)
-type modules_funs_info = fun_info FunDeclId.Map.t
+(** Various information about a module's functions and trait methods.
+
+    The [fun_decl_id_map] field records the canonical id for every function
+    declaration. The fun_decl backing a trait method definition is refered to
+    using [FunOrMethodId.Method] instead of its fun_decl_id. *)
+type modules_funs_info = {
+  fun_decl_id_map : FunOrMethodId.id FunDeclId.Map.t;
+  infos : fun_info FunOrMethodId.Map.t;
+}
+[@@deriving show]
+
+let lookup_fun_info (infos : modules_funs_info) (id : FunOrMethodId.id) :
+    fun_info option =
+  FunOrMethodId.Map.find_opt id infos.infos
+
+let fun_or_method_id_of_fun_decl_id (infos : modules_funs_info)
+    (id : FunDeclId.id) : FunOrMethodId.id =
+  [%silent_unwrap_opt_span] None
+    (FunDeclId.Map.find_opt id infos.fun_decl_id_map)
+
+let fun_or_method_id_of_fn_ptr (infos : modules_funs_info) (kind : fn_ptr_kind)
+    : FunOrMethodId.id option =
+  match kind with
+  | FunId (FRegular id) -> Some (fun_or_method_id_of_fun_decl_id infos id)
+  | TraitMethod (trait_ref, method_id, _) ->
+      Some (FunOrMethodId.of_trait_method trait_ref method_id)
+  | FunId (FBuiltin _) -> None
+
+let lookup_fun_decl_info (infos : modules_funs_info) (id : FunDeclId.id) :
+    fun_info option =
+  lookup_fun_info infos (fun_or_method_id_of_fun_decl_id infos id)
+
+let lookup_fn_ptr_info (infos : modules_funs_info) (kind : fn_ptr_kind) :
+    fun_info option =
+  Option.bind (fun_or_method_id_of_fn_ptr infos kind) (lookup_fun_info infos)
+
+let compute_fun_decl_id_map (m : crate) (funs_map : fun_decl FunDeclId.Map.t) :
+    FunOrMethodId.id FunDeclId.Map.t =
+  let ids = ref FunDeclId.Map.empty in
+  FunDeclId.Map.iter
+    (fun id _ ->
+      ids := FunDeclId.Map.add id (FunOrMethodId.of_regular_fun_decl_id id) !ids)
+    funs_map;
+  TraitDeclId.Map.iter
+    (fun trait_decl_id (trait_decl : trait_decl) ->
+      Types.TraitMethodId.Map.iter
+        (fun method_id (method_ : trait_method Types.binder) ->
+          let id = method_.binder_value.item.id in
+          let canonical_id = FunOrMethodId.Method (trait_decl_id, method_id) in
+          ids := FunDeclId.Map.add id canonical_id !ids)
+        trait_decl.methods)
+    m.trait_decls;
+  !ids
 
 let analyze_module (m : crate) (funs_map : fun_decl FunDeclId.Map.t) :
     modules_funs_info =
   let fmt_env = Charon.Print.crate_to_fmt_env m in
-  let infos = ref FunDeclId.Map.empty in
-  let register_info (id : FunDeclId.id) (info : fun_info) : unit =
-    assert (not (FunDeclId.Map.mem id !infos));
-    infos := FunDeclId.Map.add id info !infos
+  let fun_decl_id_map = compute_fun_decl_id_map m funs_map in
+  let infos = ref { fun_decl_id_map; infos = FunOrMethodId.Map.empty } in
+  let register_info (id : FunOrMethodId.id) (info : fun_info) : unit =
+    assert (not (FunOrMethodId.Map.mem id !infos.infos));
+    infos := { !infos with infos = FunOrMethodId.Map.add id info !infos.infos }
+  in
+  let register_fun_decl_info (id : FunDeclId.id) (info : fun_info) : unit =
+    register_info (fun_or_method_id_of_fun_decl_id !infos id) info
   in
 
   (* Analyze a group of mutually recursive functions.
@@ -87,12 +142,13 @@ let analyze_module (m : crate) (funs_map : fun_decl FunDeclId.Map.t) :
           method maybe_stateful b = stateful := !stateful || b
           method! visit_statement _ st = super#visit_statement st.span st
 
+          (* Custom function called by hand, this isn't visit_fun_decl_id! *)
           method visit_fid span id =
             if FunDeclId.Set.mem id fun_ids then (
               can_diverge := true;
               is_rec := true)
             else
-              let info = FunDeclId.Map.find_opt id !infos in
+              let info = lookup_fun_decl_info !infos id in
               let info =
                 [%unwrap_opt_span] (Some span) info
                   "The function called here is missing from the crate \
@@ -236,7 +292,7 @@ let analyze_module (m : crate) (funs_map : fun_decl FunDeclId.Map.t) :
     let fun_ids = List.map (fun (d : fun_decl) -> d.def_id) funs in
     let fun_ids = FunDeclId.Set.of_list fun_ids in
     let info = analyze_fun_decls fun_ids funs in
-    List.iter (fun (f : fun_decl) -> register_info f.def_id info) funs
+    List.iter (fun (f : fun_decl) -> register_fun_decl_info f.def_id info) funs
   in
 
   let rec analyze_decl_groups (decls : declaration_group list) : unit =

--- a/src/llbc/LlbcAst.ml
+++ b/src/llbc/LlbcAst.ml
@@ -2,6 +2,35 @@ open Types
 open Values
 include Charon.LlbcAst
 
+module FunOrMethodId = struct
+  type id = Fun of FunDeclId.id | Method of TraitDeclId.id * TraitMethodId.id
+  [@@deriving show, ord]
+
+  type t = id
+
+  let compare = compare_id
+  let to_string = show_id
+  let pp_t = pp_id
+  let show_t = show_id
+  let of_regular_fun_decl_id (id : FunDeclId.id) : id = Fun id
+
+  let of_trait_method (trait_ref : trait_ref) (method_id : TraitMethodId.id) :
+      id =
+    Method (trait_ref.trait_decl_ref.binder_value.id, method_id)
+
+  module Ord : Collections.OrderedType with type t = id = struct
+    type t = id
+
+    let compare = compare_id
+    let to_string = show_id
+    let pp_t = pp_id
+    let show_t = show_id
+  end
+
+  module Map = Collections.MakeMap (Ord)
+  module Set = Collections.MakeSet (Ord)
+end
+
 type bound_fun_sig = Charon.TypesUtils.bound_fun_sig
 type abs_region_group = (RegionId.id, AbsId.id) g_region_group [@@deriving show]
 type abs_region_groups = abs_region_group list [@@deriving show]

--- a/src/pure/Pure.ml
+++ b/src/pure/Pure.ml
@@ -1870,6 +1870,13 @@ type global_decl = {
 }
 [@@deriving show]
 
+type trait_method = {
+  method_id : trait_method_id;
+  item_name : trait_item_name;
+  fun_ref : fun_decl_ref binder;
+}
+[@@deriving show]
+
 type trait_decl = {
   def_id : trait_decl_id;
   name : string;
@@ -1889,7 +1896,7 @@ type trait_decl = {
   llbc_parent_clauses : Types.trait_param list;
   consts : (assoc_const_id * trait_item_name * ty) list;
   types : (assoc_type_id * trait_item_name) list;
-  methods : (trait_method_id * trait_item_name * fun_decl_ref binder) list;
+  methods : trait_method list;
 }
 [@@deriving show]
 

--- a/src/pure/PureMicroPassesAnnots.ml
+++ b/src/pure/PureMicroPassesAnnots.ml
@@ -213,7 +213,7 @@ let add_type_annotations_to_fun_decl (trans_ctx : trans_ctx)
                 in
                 [%ldebug "function name: " ^ trans_fun.name];
                 trans_fun.signature
-            | TraitMethod (tref, method_id, method_decl_id) ->
+            | TraitMethod (tref, method_id, _) ->
                 [%ldebug
                   "method name: "
                   ^ Charon.GAstUtils.get_method_name trans_ctx.crate
@@ -228,8 +228,7 @@ let add_type_annotations_to_fun_decl (trans_ctx : trans_ctx)
                 in
                 (* TODO: we shouldn't call `SymbolicToPure` here, there should
                    be a way to translate these signatures earlier. *)
-                SymbolicToPureTypes.translate_fun_sig trans_ctx
-                  (FRegular method_decl_id) method_sig
+                SymbolicToPureTypes.translate_fun_sig trans_ctx fid method_sig
                   (List.map (fun _ -> None) method_sig.item_binder_value.inputs)
             | FunId (FBuiltin aid) ->
                 Builtin.BuiltinFunIdMap.find aid builtin_sigs

--- a/src/symbolic/SymbolicToPure.ml
+++ b/src/symbolic/SymbolicToPure.ml
@@ -345,9 +345,7 @@ let translate_trait_impl (ctx : Contexts.decls_ctx) (trait_impl : A.trait_impl)
 
 let translate_global (ctx : Contexts.decls_ctx) (decl : A.global_decl) :
     global_decl =
-  let { A.item_meta; def_id; generics = llbc_generics; ty; src; value = _; _ } =
-    decl
-  in
+  let { A.item_meta; def_id; generics = llbc_generics; ty; src; _ } = decl in
   let body_id = Option.get (Charon.GAstUtils.init_fun_id_of_global decl) in
   let name =
     Print.name_to_string
@@ -367,7 +365,9 @@ let translate_global (ctx : Contexts.decls_ctx) (decl : A.global_decl) :
     match builtin_info with
     | Some info -> info.can_fail
     | None -> (
-        match FunDeclId.Map.find_opt body_id ctx.fun_ctx.fun_infos with
+        match
+          FunsAnalysis.lookup_fun_decl_info ctx.fun_ctx.fun_infos body_id
+        with
         | None -> (* Don't know: true by default *) true
         | Some info -> info.can_fail)
   in

--- a/src/symbolic/SymbolicToPure.ml
+++ b/src/symbolic/SymbolicToPure.ml
@@ -166,11 +166,18 @@ let translate_binder (span : span option) (translate_inside : 'a -> 'b)
   }
 
 let translate_trait_method (span : span option) (translate_ty : T.ty -> ty)
-    (bound_method : A.trait_method T.binder) : fun_decl_ref binder =
-  translate_binder span
-    (fun (m : A.trait_method) ->
-      translate_fun_decl_ref span translate_ty m.item)
-    bound_method
+    (method_id : TraitMethodId.id) (bound_method : A.trait_method T.binder) :
+    trait_method =
+  let method_ = bound_method.binder_value in
+  {
+    method_id;
+    item_name = method_.name;
+    fun_ref =
+      translate_binder span
+        (fun (m : A.trait_method) ->
+          translate_fun_decl_ref span translate_ty m.item)
+        bound_method;
+  }
 
 let translate_trait_decl (ctx : Contexts.decls_ctx) (trait_decl : A.trait_decl)
     : trait_decl =
@@ -236,9 +243,7 @@ let translate_trait_decl (ctx : Contexts.decls_ctx) (trait_decl : A.trait_decl)
   let methods =
     List.map
       (fun ((method_id, m) : TraitMethodId.id * A.trait_method T.binder) ->
-        ( method_id,
-          m.binder_value.name,
-          translate_trait_method opt_span translate_ty m ))
+        translate_trait_method opt_span translate_ty method_id m)
       (TraitMethodId.Map.to_list methods)
   in
   {

--- a/src/symbolic/SymbolicToPureCore.ml
+++ b/src/symbolic/SymbolicToPureCore.ml
@@ -42,7 +42,7 @@ type fun_sig_named_outputs = {
 
 type fun_ctx = {
   llbc_fun_decls : A.fun_decl A.FunDeclId.Map.t;
-  fun_infos : fun_info A.FunDeclId.Map.t;
+  fun_infos : modules_funs_info;
 }
 [@@deriving show]
 
@@ -149,7 +149,7 @@ type bs_ctx = {
   trans_global_decls : global_decl GlobalDeclId.Map.t;
   type_ctx : type_ctx;  (** TODO: remove: this is already in decls_ctx *)
   fun_ctx : fun_ctx;
-  fun_sigs : fun_sigs FunDeclId.Map.t;
+  fun_sigs : fun_sigs A.FunOrMethodId.Map.t;
   fun_decl : A.fun_decl;
   bid : RegionGroupId.id option;
       (** TODO: rename
@@ -330,6 +330,10 @@ let bs_ctx_to_pure_fmt_env (ctx : bs_ctx) : PrintPure.fmt_env =
     pbvars = None;
     pbvars_counter = BVarId.zero;
   }
+
+let lookup_fn_ptr_sig (ctx : bs_ctx) (kind : A.fn_ptr_kind) : fun_sigs option =
+  Option.bind (fun_or_method_id_of_fn_ptr ctx.fun_ctx.fun_infos kind) (fun id ->
+      A.FunOrMethodId.Map.find_opt id ctx.fun_sigs)
 
 let ctx_generic_args_to_string (ctx : bs_ctx) (args : T.generic_args) : string =
   let env = bs_ctx_to_fmt_env ctx in

--- a/src/symbolic/SymbolicToPureCore.ml
+++ b/src/symbolic/SymbolicToPureCore.ml
@@ -335,6 +335,27 @@ let lookup_fn_ptr_sig (ctx : bs_ctx) (kind : A.fn_ptr_kind) : fun_sigs option =
   Option.bind (fun_or_method_id_of_fn_ptr ctx.fun_ctx.fun_infos kind) (fun id ->
       A.FunOrMethodId.Map.find_opt id ctx.fun_sigs)
 
+let fun_or_method_id_of_pure_fn_ptr (infos : modules_funs_info)
+    (kind : fn_ptr_kind) : A.FunOrMethodId.id option =
+  match kind with
+  | FunId (FRegular id) -> Some (fun_or_method_id_of_fun_decl_id infos id)
+  | TraitMethod (trait_ref, method_id, _) ->
+      Some
+        (A.FunOrMethodId.Method
+           (trait_ref.trait_decl_ref.trait_decl_id, method_id))
+  | FunId (FBuiltin _) -> None
+
+let lookup_pure_fn_ptr_sig (ctx : bs_ctx) (kind : fn_ptr_kind) : fun_sigs option
+    =
+  Option.bind (fun_or_method_id_of_pure_fn_ptr ctx.fun_ctx.fun_infos kind)
+    (fun id -> A.FunOrMethodId.Map.find_opt id ctx.fun_sigs)
+
+let lookup_pure_fn_ptr_info (infos : modules_funs_info) (kind : fn_ptr_kind) :
+    fun_info option =
+  Option.bind
+    (fun_or_method_id_of_pure_fn_ptr infos kind)
+    (lookup_fun_info infos)
+
 let ctx_generic_args_to_string (ctx : bs_ctx) (args : T.generic_args) : string =
   let env = bs_ctx_to_fmt_env ctx in
   Print.generic_args_to_string env args

--- a/src/symbolic/SymbolicToPureExpressions.ml
+++ b/src/symbolic/SymbolicToPureExpressions.ml
@@ -1593,10 +1593,10 @@ and translate_intro_symbolic (ectx : C.eval_ctx) (p : S.mplace option)
         let ty =
           match kind with
           | T.FunId (FBuiltin _) -> [%craise] ctx.span "Unimplemented"
-          | T.FunId (FRegular fid) ->
+          | T.FunId (FRegular _) ->
               let sg =
                 [%unwrap_with_span] ctx.span
-                  (FunDeclId.Map.find_opt fid ctx.fun_sigs)
+                  (lookup_fn_ptr_sig ctx kind)
                   "Internal error, please file an issue"
               in
               (* Check that the function lives in the expected effect - otherwise we

--- a/src/symbolic/SymbolicToPureExpressions.ml
+++ b/src/symbolic/SymbolicToPureExpressions.ml
@@ -374,7 +374,7 @@ and translate_function_call_aux (call : S.call) (e : S.expr) (ctx : bs_ctx) :
         let func = Fun (FromLlbc (fid_t, None)) in
         (* Retrieve the effect information about this function (can fail,
          * takes a state as input, etc.) *)
-        let effect_info = get_fun_effect_info ctx fid None in
+        let effect_info = get_fun_effect_info ctx fid_t None in
         (* Generate the variables for the backward functions returned by the forward
            function. *)
         let ctx, ignore_fwd_output, back_funs =
@@ -384,7 +384,7 @@ and translate_function_call_aux (call : S.call) (e : S.expr) (ctx : bs_ctx) :
           let decls_ctx = ctx.decls_ctx in
           let dsg =
             translate_inst_fun_sig_to_decomposed_fun_type (Some ctx.span)
-              decls_ctx fid inst_sg
+              decls_ctx fid_t inst_sg
               (List.map (fun _ -> None) sg.inputs)
           in
           let back_tys = compute_back_tys_with_info dsg in

--- a/src/symbolic/SymbolicToPureExpressions.ml
+++ b/src/symbolic/SymbolicToPureExpressions.ml
@@ -417,7 +417,7 @@ and translate_function_call_aux (call : S.call) (e : S.expr) (ctx : bs_ctx) :
                   | PtrFromParts RMut -> "ptr_from_parts_mut"
                   | PtrFromParts RShared -> "ptr_from_parts_shared"
                 end
-              | FunId (FRegular fid) | TraitMethod (_, _, fid) -> (
+              | FunId (FRegular fid) -> (
                   let decl =
                     FunDeclId.Map.find fid ctx.fun_ctx.llbc_fun_decls
                   in
@@ -431,6 +431,9 @@ and translate_function_call_aux (call : S.call) (e : S.expr) (ctx : bs_ctx) :
                   | _ ->
                       (* We shouldn't get there *)
                       [%craise] decl.item_meta.span "Unexpected")
+              | TraitMethod (trait_ref, method_id, _) ->
+                  Charon.GAstUtils.get_method_name ctx.decls_ctx.crate
+                    trait_ref.trait_decl_ref.binder_value.id method_id
             in
             name ^ "_back"
           in

--- a/src/symbolic/SymbolicToPureTypes.ml
+++ b/src/symbolic/SymbolicToPureTypes.ml
@@ -723,12 +723,13 @@ and translate_back_input_ty (span : Meta.span option) (decls_ctx : C.decls_ctx)
 
 (** Small utility. *)
 and compute_raw_fun_effect_info (span : Meta.span option)
-    (fun_infos : fun_info A.FunDeclId.Map.t) (fun_id : A.fn_ptr_kind)
+    (fun_infos : FunsAnalysis.modules_funs_info) (fun_id : A.fn_ptr_kind)
     (gid : T.RegionGroupId.id option) : fun_effect_info =
   match fun_id with
-  | TraitMethod (_, _, fid) | FunId (FRegular fid) ->
+  | TraitMethod _ | FunId (FRegular _) ->
       let info =
-        [%silent_unwrap_opt_span] span (A.FunDeclId.Map.find_opt fid fun_infos)
+        [%silent_unwrap_opt_span] span
+          (FunsAnalysis.lookup_fn_ptr_info fun_infos fun_id)
       in
       {
         (* Note that backward functions can't fail *)
@@ -1186,8 +1187,10 @@ and translate_fun_sig (decls_ctx : C.decls_ctx) (fun_id : A.fun_id)
 and get_fun_effect_info (ctx : bs_ctx) (fun_id : A.fn_ptr_kind)
     (gid : T.RegionGroupId.id option) : fun_effect_info =
   match fun_id with
-  | TraitMethod (_, _, fid) | FunId (FRegular fid) ->
-      let sg = A.FunDeclId.Map.find fid ctx.fun_sigs in
+  | TraitMethod _ | FunId (FRegular _) ->
+      let sg =
+        [%silent_unwrap_opt_span] (Some ctx.span) (lookup_fn_ptr_sig ctx fun_id)
+      in
       let sg = sg.dsg in
       let info =
         match gid with

--- a/src/symbolic/SymbolicToPureTypes.ml
+++ b/src/symbolic/SymbolicToPureTypes.ml
@@ -723,13 +723,13 @@ and translate_back_input_ty (span : Meta.span option) (decls_ctx : C.decls_ctx)
 
 (** Small utility. *)
 and compute_raw_fun_effect_info (span : Meta.span option)
-    (fun_infos : FunsAnalysis.modules_funs_info) (fun_id : A.fn_ptr_kind)
+    (fun_infos : FunsAnalysis.modules_funs_info) (fun_id : fn_ptr_kind)
     (gid : T.RegionGroupId.id option) : fun_effect_info =
   match fun_id with
   | TraitMethod _ | FunId (FRegular _) ->
       let info =
         [%silent_unwrap_opt_span] span
-          (FunsAnalysis.lookup_fn_ptr_info fun_infos fun_id)
+          (lookup_pure_fn_ptr_info fun_infos fun_id)
       in
       {
         (* Note that backward functions can't fail *)
@@ -760,7 +760,7 @@ and compute_raw_fun_effect_info (span : Meta.span option)
     - [generic_args]: the generic arguments with which the uninstantiated
       signature was instantiated, leading to the current [sg] *)
 and translate_inst_fun_sig_to_decomposed_fun_type (span : Meta.span option)
-    (decls_ctx : C.decls_ctx) (fun_id : A.fn_ptr_kind) (sg : A.inst_fun_sig)
+    (decls_ctx : C.decls_ctx) (fun_id : fn_ptr_kind) (sg : A.inst_fun_sig)
     (input_names : string option list) : decomposed_fun_type =
   [%ltrace
     let ctx = Print.Contexts.decls_ctx_to_fmt_env decls_ctx in
@@ -885,7 +885,7 @@ and translate_inst_fun_sig_to_decomposed_fun_type (span : Meta.span option)
           inputs
       in
       "translate_back_inputs_for_gid:" ^ "\n- function:"
-      ^ Charon.Print.fn_ptr_kind_to_string ctx fun_id
+      ^ PrintPure.regular_fun_id_to_string pctx (FromLlbc (fun_id, None))
       ^ "\n- gid: "
       ^ RegionGroupId.to_string gid
       ^ "\n- output: " ^ output ^ "\n- back inputs: " ^ inputs];
@@ -919,7 +919,7 @@ and translate_inst_fun_sig_to_decomposed_fun_type (span : Meta.span option)
           outputs
       in
       "compute_back_outputs_for_gid:" ^ "\n- function:"
-      ^ Charon.Print.fn_ptr_kind_to_string ctx fun_id
+      ^ PrintPure.regular_fun_id_to_string pctx (FromLlbc (fun_id, None))
       ^ "\n- gid: "
       ^ RegionGroupId.to_string gid
       ^ "\n- inputs: " ^ inputs ^ "\n- back outputs: " ^ outputs];
@@ -986,7 +986,7 @@ and translate_inst_fun_sig_to_decomposed_fun_type (span : Meta.span option)
   { fwd_inputs; fwd_output; back_sg; fwd_info }
 
 and translate_fun_sig_with_regions_hierarchy_to_decomposed (span : span option)
-    (decls_ctx : C.decls_ctx) (fun_id : A.fn_ptr_kind)
+    (decls_ctx : C.decls_ctx) (fun_id : fn_ptr_kind)
     (regions_hierarchy : T.region_var_groups) (sg : A.bound_fun_sig)
     (input_names : string option list) : decomposed_fun_sig =
   let inst_sg : LlbcAst.inst_fun_sig =
@@ -1169,7 +1169,7 @@ and translate_fun_sig_from_decomposed (dsg : Pure.decomposed_fun_sig) : fun_sig
     back_effect_info;
   }
 
-and translate_fun_sig (decls_ctx : C.decls_ctx) (fun_id : A.fun_id)
+and translate_fun_sig (decls_ctx : C.decls_ctx) (fun_id : fn_ptr_kind)
     (sg : A.bound_fun_sig) (input_names : string option list) : Pure.fun_sig =
   (* Compute the regions hierarchy *)
   let regions_hierarchy =
@@ -1177,19 +1177,20 @@ and translate_fun_sig (decls_ctx : C.decls_ctx) (fun_id : A.fun_id)
   in
   (* Compute the decomposed fun signature *)
   let sg =
-    translate_fun_sig_with_regions_hierarchy_to_decomposed None decls_ctx
-      (FunId fun_id) regions_hierarchy sg input_names
+    translate_fun_sig_with_regions_hierarchy_to_decomposed None decls_ctx fun_id
+      regions_hierarchy sg input_names
   in
   (* Finish the translation *)
   translate_fun_sig_from_decomposed sg
 
 (** TODO: not very clean. *)
-and get_fun_effect_info (ctx : bs_ctx) (fun_id : A.fn_ptr_kind)
+and get_fun_effect_info (ctx : bs_ctx) (fun_id : fn_ptr_kind)
     (gid : T.RegionGroupId.id option) : fun_effect_info =
   match fun_id with
   | TraitMethod _ | FunId (FRegular _) ->
       let sg =
-        [%silent_unwrap_opt_span] (Some ctx.span) (lookup_fn_ptr_sig ctx fun_id)
+        [%silent_unwrap_opt_span] (Some ctx.span)
+          (lookup_pure_fn_ptr_sig ctx fun_id)
       in
       let sg = sg.dsg in
       let info =

--- a/tests/src/mutually-recursive-traits.lean.out
+++ b/tests/src/mutually-recursive-traits.lean.out
@@ -3,5 +3,5 @@
 Trait declaration: mutually_recursive_traits::Trait1
 Source: Source: 'tests/src/mutually-recursive-traits.rs', lines 5:0-7:1
 Source: 'tests/src/mutually-recursive-traits.rs', lines 5:0-7:1
-Compiler source: symbolic/SymbolicToPure.ml, line 209
+Compiler source: symbolic/SymbolicToPure.ml, line 216
 


### PR DESCRIPTION
This PR prepares Aeneas for the removal in Charon of the fake `FunDecl`s we add for each method declaration (https://github.com/AeneasVerif/charon/issues/1148). They are misleading because methods are more often an abstraction boundary than a concrete item, and in particular it's useful to distinguish "the method declaration" from "the method default implementation" (when there is one). Using the same function item for both creates confusion.

The main change is that a couple of maps that used `FunDeclId`s as keys now use `FunOrMethodId`.