### PR TITLE
Fix `i128` bounds in Rocq backend

### DIFF
--- a/backends/coq/Primitives.v
+++ b/backends/coq/Primitives.v
@@ -501,7 +501,7 @@ Definition core_num_I8_MIN    := i8_min %i32.
 Definition core_num_I16_MIN   := i16_min %i32.
 Definition core_num_I32_MIN   := i32_min %i32.
 Definition core_num_I64_MIN   := i64_min %i64.
-Definition core_num_I128_MIN  := i64_min %i128.
+Definition core_num_I128_MIN  := i128_min %i128.
 Axiom core_num_Isize_MIN : isize. (** TODO *)
 
 Definition core_num_U8_MAX    := u8_max %u32.
@@ -514,7 +514,7 @@ Definition core_num_I8_MAX    := i8_max %i32.
 Definition core_num_I16_MAX   := i16_max %i32.
 Definition core_num_I32_MAX   := i32_max %i32.
 Definition core_num_I64_MAX   := i64_max %i64.
-Definition core_num_I128_MAX  := i64_max %i128.
+Definition core_num_I128_MAX  := i128_max %i128.
 Axiom core_num_Isize_MAX : isize. (** TODO *)
 
 (*** core *)

--- a/tests/coq/arrays/Primitives.v
+++ b/tests/coq/arrays/Primitives.v
@@ -501,7 +501,7 @@ Definition core_num_I8_MIN    := i8_min %i32.
 Definition core_num_I16_MIN   := i16_min %i32.
 Definition core_num_I32_MIN   := i32_min %i32.
 Definition core_num_I64_MIN   := i64_min %i64.
-Definition core_num_I128_MIN  := i64_min %i128.
+Definition core_num_I128_MIN  := i128_min %i128.
 Axiom core_num_Isize_MIN : isize. (** TODO *)
 
 Definition core_num_U8_MAX    := u8_max %u32.
@@ -514,7 +514,7 @@ Definition core_num_I8_MAX    := i8_max %i32.
 Definition core_num_I16_MAX   := i16_max %i32.
 Definition core_num_I32_MAX   := i32_max %i32.
 Definition core_num_I64_MAX   := i64_max %i64.
-Definition core_num_I128_MAX  := i64_max %i128.
+Definition core_num_I128_MAX  := i128_max %i128.
 Axiom core_num_Isize_MAX : isize. (** TODO *)
 
 (*** core *)

--- a/tests/coq/demo/Primitives.v
+++ b/tests/coq/demo/Primitives.v
@@ -501,7 +501,7 @@ Definition core_num_I8_MIN    := i8_min %i32.
 Definition core_num_I16_MIN   := i16_min %i32.
 Definition core_num_I32_MIN   := i32_min %i32.
 Definition core_num_I64_MIN   := i64_min %i64.
-Definition core_num_I128_MIN  := i64_min %i128.
+Definition core_num_I128_MIN  := i128_min %i128.
 Axiom core_num_Isize_MIN : isize. (** TODO *)
 
 Definition core_num_U8_MAX    := u8_max %u32.
@@ -514,7 +514,7 @@ Definition core_num_I8_MAX    := i8_max %i32.
 Definition core_num_I16_MAX   := i16_max %i32.
 Definition core_num_I32_MAX   := i32_max %i32.
 Definition core_num_I64_MAX   := i64_max %i64.
-Definition core_num_I128_MAX  := i64_max %i128.
+Definition core_num_I128_MAX  := i128_max %i128.
 Axiom core_num_Isize_MAX : isize. (** TODO *)
 
 (*** core *)

--- a/tests/coq/hashmap/Primitives.v
+++ b/tests/coq/hashmap/Primitives.v
@@ -501,7 +501,7 @@ Definition core_num_I8_MIN    := i8_min %i32.
 Definition core_num_I16_MIN   := i16_min %i32.
 Definition core_num_I32_MIN   := i32_min %i32.
 Definition core_num_I64_MIN   := i64_min %i64.
-Definition core_num_I128_MIN  := i64_min %i128.
+Definition core_num_I128_MIN  := i128_min %i128.
 Axiom core_num_Isize_MIN : isize. (** TODO *)
 
 Definition core_num_U8_MAX    := u8_max %u32.
@@ -514,7 +514,7 @@ Definition core_num_I8_MAX    := i8_max %i32.
 Definition core_num_I16_MAX   := i16_max %i32.
 Definition core_num_I32_MAX   := i32_max %i32.
 Definition core_num_I64_MAX   := i64_max %i64.
-Definition core_num_I128_MAX  := i64_max %i128.
+Definition core_num_I128_MAX  := i128_max %i128.
 Axiom core_num_Isize_MAX : isize. (** TODO *)
 
 (*** core *)

--- a/tests/coq/misc/Primitives.v
+++ b/tests/coq/misc/Primitives.v
@@ -501,7 +501,7 @@ Definition core_num_I8_MIN    := i8_min %i32.
 Definition core_num_I16_MIN   := i16_min %i32.
 Definition core_num_I32_MIN   := i32_min %i32.
 Definition core_num_I64_MIN   := i64_min %i64.
-Definition core_num_I128_MIN  := i64_min %i128.
+Definition core_num_I128_MIN  := i128_min %i128.
 Axiom core_num_Isize_MIN : isize. (** TODO *)
 
 Definition core_num_U8_MAX    := u8_max %u32.
@@ -514,7 +514,7 @@ Definition core_num_I8_MAX    := i8_max %i32.
 Definition core_num_I16_MAX   := i16_max %i32.
 Definition core_num_I32_MAX   := i32_max %i32.
 Definition core_num_I64_MAX   := i64_max %i64.
-Definition core_num_I128_MAX  := i64_max %i128.
+Definition core_num_I128_MAX  := i128_max %i128.
 Axiom core_num_Isize_MAX : isize. (** TODO *)
 
 (*** core *)


### PR DESCRIPTION
Hello,

Definitions `core_num_I128_MIN` and `core_num_I128_MAX` were wrongly using `i64_min` and `i128_max`.

This very simple Pull Request modifies all copies of `Primitives.v`, please let me know if you prefer another approach.

(No AI was used to do this PR)