### PR TITLE
Distinguish trait method declarations from default method bodies

### DIFF
--- a/charon-pin
+++ b/charon-pin
@@ -1,2 +1,2 @@
 # This is the commit from https://github.com/AeneasVerif/charon that should be used with this version of aeneas.
-9dd7f23c8458b2366ce0b5ca7529c5ad4c5fb350
+ed9427f4b13577ec3e80314439e35a95fbfefaf7

--- a/flake.lock
+++ b/flake.lock
@@ -9,11 +9,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1780674781,
-        "narHash": "sha256-sn/efedcaOhewtH4aSBvzmHH2bhOngokZ/x9jJ/ptTY=",
+        "lastModified": 1781532637,
+        "narHash": "sha256-nKsV5jK/pLO11m/JZMZAm5O8PI0EWSU/L2evqCIl8Sk=",
         "owner": "aeneasverif",
         "repo": "charon",
-        "rev": "9dd7f23c8458b2366ce0b5ca7529c5ad4c5fb350",
+        "rev": "ed9427f4b13577ec3e80314439e35a95fbfefaf7",
         "type": "github"
       },
       "original": {

--- a/src/Translate.ml
+++ b/src/Translate.ml
@@ -182,7 +182,13 @@ let translate_function_to_pure_aux (trans_ctx : trans_ctx)
   in
 
   let sg =
-    SymbolicToPureTypes.translate_fun_sig_from_decl_to_decomposed trans_ctx fdef
+    let id =
+      FunsAnalysis.fun_or_method_id_of_fun_decl_id trans_ctx.fun_ctx.fun_infos
+        fdef.def_id
+    in
+    ([%silent_unwrap] fdef.item_meta.span
+       (FunOrMethodId.Map.find_opt id fun_sigs))
+      .dsg
   in
 
   let _, fresh_fvar_id = Pure.FVarId.fresh_stateful_generator () in

--- a/src/Translate.ml
+++ b/src/Translate.ml
@@ -402,14 +402,14 @@ let translate_crate_to_pure (crate : crate) (marked_ids : marked_ids) :
         (FunOrMethodId.Method (trait_decl.def_id, method_id), sg)
       in
       let translate_trait_methods (trait_decl : LlbcAst.trait_decl) =
+        let methods =
+          TraitDeclId.Map.find trait_decl.def_id
+            trans_ctx.trait_methods_to_extract
+        in
         List.map
           (fun (method_id, bound_method) ->
             translate_method_sig trait_decl method_id bound_method)
-          (List.filter
-             (fun ((_, bound_method) : _ * LlbcAst.trait_method Types.binder) ->
-               let method_ = bound_method.binder_value in
-               FunDeclId.Map.mem method_.item.id trans_ctx.fun_ctx.to_extract)
-             (TraitMethodId.Map.to_list trait_decl.methods))
+          (TraitMethodId.Map.to_list methods)
       in
       let entries =
         List.concat

--- a/src/Translate.ml
+++ b/src/Translate.ml
@@ -373,14 +373,8 @@ let translate_crate_to_pure (crate : crate) (marked_ids : marked_ids) :
             [%ltrace
               "Translating the signature of: "
               ^ name_to_string trans_ctx fdef.item_meta.name];
-            let open SymbolicToPureCore in
             let open SymbolicToPureTypes in
-            let dsg =
-              translate_fun_sig_from_decl_to_decomposed trans_ctx fdef
-            in
-            let sg = translate_fun_sig_from_decomposed dsg in
-            let ty = PureUtils.mk_arrows sg.inputs sg.output in
-            let sg : fun_sigs = { dsg; sg; ty } in
+            let sg = translate_fun_sigs_from_decl trans_ctx fdef in
             let id =
               FunsAnalysis.fun_or_method_id_of_fun_decl_id
                 trans_ctx.fun_ctx.fun_infos fdef.def_id

--- a/src/Translate.ml
+++ b/src/Translate.ml
@@ -789,12 +789,8 @@ let export_global (fmt : Format.formatter) (config : gen_config) (ctx : gen_ctx)
     Option.get (Charon.GAstUtils.init_fun_id_of_global global)
   in
   let trans =
-    let id =
-      FunsAnalysis.fun_or_method_id_of_fun_decl_id
-        ctx.trans_ctx.fun_ctx.fun_infos global_init
-    in
     [%silent_unwrap_opt_span] None
-      (FunOrMethodId.Map.find_opt id ctx.trans_funs)
+      (ExtractBase.ctx_lookup_fun_decl_info ctx global_init)
   in
   [%sanity_check] global.item_meta.span (trans.loops = [] && trans.bodies = []);
   let body = trans.f in
@@ -1097,13 +1093,7 @@ let extract_definitions (fmt : Format.formatter) (config : gen_config)
     | FunGroup (NonRecGroup id) -> (
         (* Lookup - the translated function may not be in the map if we had
            to ignore it because of errors *)
-        let pure_fun =
-          let id =
-            FunsAnalysis.fun_or_method_id_of_fun_decl_id
-              ctx.trans_ctx.fun_ctx.fun_infos id
-          in
-          FunOrMethodId.Map.find_opt id ctx.trans_funs
-        in
+        let pure_fun = ExtractBase.ctx_lookup_fun_decl_info ctx id in
         (* Special case: we skip trait method *declarations* (we will
            extract their type directly in the records we generate for
            the trait declarations themselves, there is no point in having
@@ -1123,12 +1113,7 @@ let extract_definitions (fmt : Format.formatter) (config : gen_config)
         (* Lookup *)
         let pure_funs =
           List.filter_map
-            (fun id ->
-              let id =
-                FunsAnalysis.fun_or_method_id_of_fun_decl_id
-                  ctx.trans_ctx.fun_ctx.fun_infos id
-              in
-              FunOrMethodId.Map.find_opt id ctx.trans_funs)
+            (fun id -> ExtractBase.ctx_lookup_fun_decl_info ctx id)
             ids
         in
         if List.exists (fun pf -> pf.f.is_global_decl_body) pure_funs then

--- a/src/Translate.ml
+++ b/src/Translate.ml
@@ -182,12 +182,8 @@ let translate_function_to_pure_aux (trans_ctx : trans_ctx)
   in
 
   let sg =
-    let id =
-      FunsAnalysis.fun_or_method_id_of_fun_decl_id trans_ctx.fun_ctx.fun_infos
-        fdef.def_id
-    in
     ([%silent_unwrap] fdef.item_meta.span
-       (FunOrMethodId.Map.find_opt id fun_sigs))
+       (FunOrMethodId.Map.find_opt (FunOrMethodId.Fun fdef.def_id) fun_sigs))
       .dsg
   in
 
@@ -364,9 +360,9 @@ let translate_crate_to_pure (crate : crate) (marked_ids : marked_ids) :
       (List.map (fun (d : Pure.global_decl) -> (d.def_id, d)) global_decls)
   in
 
-  (* Compute the fun sigs for the whole crate *)
+  (* Compute the function signatures for the whole crate *)
   let fun_sigs =
-    let fun_sig_entries =
+    let fun_decl_sigs =
       List.filter_map
         (fun (fdef : LlbcAst.fun_decl) ->
           try
@@ -375,11 +371,7 @@ let translate_crate_to_pure (crate : crate) (marked_ids : marked_ids) :
               ^ name_to_string trans_ctx fdef.item_meta.name];
             let open SymbolicToPureTypes in
             let sg = translate_fun_sigs_from_decl trans_ctx fdef in
-            let id =
-              FunsAnalysis.fun_or_method_id_of_fun_decl_id
-                trans_ctx.fun_ctx.fun_infos fdef.def_id
-            in
-            Some (id, sg)
+            Some (FunOrMethodId.Fun fdef.def_id, sg)
           with CFailure error ->
             let name = name_to_string trans_ctx fdef.item_meta.name in
             let name_pattern =
@@ -398,7 +390,37 @@ let translate_crate_to_pure (crate : crate) (marked_ids : marked_ids) :
             None)
         (FunDeclId.Map.values trans_ctx.fun_ctx.to_extract)
     in
-    FunOrMethodId.Map.of_list fun_sig_entries
+
+    let method_sigs =
+      let translate_method_sig (trait_decl : LlbcAst.trait_decl)
+          (method_id : TraitMethodId.id)
+          (bound_method : LlbcAst.trait_method Types.binder) =
+        let sg =
+          SymbolicToPureTypes.translate_flat_trait_method_sigs trans_ctx
+            trait_decl method_id bound_method
+        in
+        (FunOrMethodId.Method (trait_decl.def_id, method_id), sg)
+      in
+      let translate_trait_methods (trait_decl : LlbcAst.trait_decl) =
+        List.map
+          (fun (method_id, bound_method) ->
+            translate_method_sig trait_decl method_id bound_method)
+          (List.filter
+             (fun ((_, bound_method) : _ * LlbcAst.trait_method Types.binder) ->
+               let method_ = bound_method.binder_value in
+               FunDeclId.Map.mem method_.item.id trans_ctx.fun_ctx.to_extract)
+             (TraitMethodId.Map.to_list trait_decl.methods))
+      in
+      let entries =
+        List.concat
+          (List.map translate_trait_methods
+             (TraitDeclId.Map.values trans_ctx.trait_decls_to_extract))
+      in
+      FunOrMethodId.Map.of_list entries
+    in
+
+    FunOrMethodId.Map.of_list
+      (FunOrMethodId.Map.bindings method_sigs @ fun_decl_sigs)
   in
 
   (* Translate the signatures of the builtin functions *)
@@ -1444,15 +1466,10 @@ let extract_translated_crate (filename : string) (dest_dir : string)
     Pure.TypeDeclId.Map.of_list
       (List.map (fun (d : Pure.type_decl) -> (d.def_id, d)) trans_types)
   in
-  let trans_funs : pure_fun_translation FunOrMethodId.Map.t =
-    FunOrMethodId.Map.of_list
+  let trans_funs : pure_fun_translation FunDeclId.Map.t =
+    FunDeclId.Map.of_list
       (List.map
-         (fun (trans : pure_fun_translation) ->
-           let id =
-             FunsAnalysis.fun_or_method_id_of_fun_decl_id
-               trans_ctx.fun_ctx.fun_infos trans.f.def_id
-           in
-           (id, trans))
+         (fun (trans : pure_fun_translation) -> (trans.f.def_id, trans))
          trans_funs)
   in
 
@@ -1574,7 +1591,7 @@ let extract_translated_crate (filename : string) (dest_dir : string)
             );
           ctx)
       ctx
-      (FunOrMethodId.Map.values trans_funs)
+      (FunDeclId.Map.values trans_funs)
   in
 
   let ctx =

--- a/src/Translate.ml
+++ b/src/Translate.ml
@@ -360,44 +360,45 @@ let translate_crate_to_pure (crate : crate) (marked_ids : marked_ids) :
 
   (* Compute the fun sigs for the whole crate *)
   let fun_sigs =
-    FunOrMethodId.Map.of_list
-      (List.filter_map
-         (fun (fdef : LlbcAst.fun_decl) ->
-           try
-             [%ltrace
-               "Translating the signature of: "
-               ^ name_to_string trans_ctx fdef.item_meta.name];
-             let open SymbolicToPureCore in
-             let open SymbolicToPureTypes in
-             let dsg =
-               translate_fun_sig_from_decl_to_decomposed trans_ctx fdef
-             in
-             let sg = translate_fun_sig_from_decomposed dsg in
-             let ty = PureUtils.mk_arrows sg.inputs sg.output in
-             let sg : fun_sigs = { dsg; sg; ty } in
-             let id =
-               FunsAnalysis.fun_or_method_id_of_fun_decl_id
-                 trans_ctx.fun_ctx.fun_infos fdef.def_id
-             in
-             Some (id, sg)
-           with CFailure error ->
-             let name = name_to_string trans_ctx fdef.item_meta.name in
-             let name_pattern =
-               try
-                 name_to_pattern_string (Some fdef.item_meta.span) trans_ctx
-                   fdef.item_meta.name
-               with CFailure _ ->
-                 "(could not compute the name pattern due to a different error)"
-             in
-             [%warn_opt_span] error.span
-               ("Could not translate the function signature of '" ^ name
-              ^ " because of previous error\nName pattern: '" ^ name_pattern
-              ^ "'" ^ "\nDefinition span: "
-               ^ Errors.raw_span_to_string fdef.item_meta.span
-               ^ compute_local_uses_error_message trans_ctx (IdFun fdef.def_id)
-               );
-             None)
-         (FunDeclId.Map.values trans_ctx.fun_ctx.to_extract))
+    let fun_sig_entries =
+      List.filter_map
+        (fun (fdef : LlbcAst.fun_decl) ->
+          try
+            [%ltrace
+              "Translating the signature of: "
+              ^ name_to_string trans_ctx fdef.item_meta.name];
+            let open SymbolicToPureCore in
+            let open SymbolicToPureTypes in
+            let dsg =
+              translate_fun_sig_from_decl_to_decomposed trans_ctx fdef
+            in
+            let sg = translate_fun_sig_from_decomposed dsg in
+            let ty = PureUtils.mk_arrows sg.inputs sg.output in
+            let sg : fun_sigs = { dsg; sg; ty } in
+            let id =
+              FunsAnalysis.fun_or_method_id_of_fun_decl_id
+                trans_ctx.fun_ctx.fun_infos fdef.def_id
+            in
+            Some (id, sg)
+          with CFailure error ->
+            let name = name_to_string trans_ctx fdef.item_meta.name in
+            let name_pattern =
+              try
+                name_to_pattern_string (Some fdef.item_meta.span) trans_ctx
+                  fdef.item_meta.name
+              with CFailure _ ->
+                "(could not compute the name pattern due to a different error)"
+            in
+            [%warn_opt_span] error.span
+              ("Could not translate the function signature of '" ^ name
+             ^ " because of previous error\nName pattern: '" ^ name_pattern
+             ^ "'" ^ "\nDefinition span: "
+              ^ Errors.raw_span_to_string fdef.item_meta.span
+              ^ compute_local_uses_error_message trans_ctx (IdFun fdef.def_id));
+            None)
+        (FunDeclId.Map.values trans_ctx.fun_ctx.to_extract)
+    in
+    FunOrMethodId.Map.of_list fun_sig_entries
   in
 
   (* Translate the signatures of the builtin functions *)

--- a/src/extract/Extract.ml
+++ b/src/extract/Extract.ml
@@ -999,67 +999,71 @@ and extract_function_call (span : Meta.span) (ctx : extraction_ctx)
       [%sanity_check] span (generics.const_generics = [] || backend () <> HOL4);
       (* Compute the information about the explicit/implicit input type parameters *)
       let explicit =
-        let lookup is_trait_method id lp_id =
-          try
-            (* Lookup the function to retrieve the signature information *)
-            let trans_fun =
-              [%silent_unwrap] span
-                (A.FunOrMethodId.Map.find_opt id ctx.trans_funs)
-            in
-            let trans_fun =
-              match lp_id with
-              | None -> trans_fun.f
-              | Some (lp_id, true) -> Pure.LoopId.nth trans_fun.bodies lp_id
-              | Some (lp_id, false) -> Pure.LoopId.nth trans_fun.loops lp_id
-            in
-            let explicit = trans_fun.signature.explicit_info in
-            (* If it is a trait method, we need to remove the prefix
-               which accounts for the generics of the impl. *)
-            let explicit =
-              adjust_explicit_info explicit is_trait_method generics
-            in
-            (* *)
-            Some explicit
-          with CFailure _ ->
-            (* Fallback if, for instance, we could not lookup the declaration *)
-            [%save_error] span "Internal error";
-            None
-        in
-        match fun_id with
-        | FromLlbc (FunId (FRegular fun_decl_id), lp_id) ->
-            let id =
-              FunsAnalysis.fun_or_method_id_of_fun_decl_id
-                ctx.trans_ctx.fun_ctx.fun_infos fun_decl_id
-            in
-            lookup false id lp_id
-        | FromLlbc (TraitMethod (trait_ref, method_id, _), lp_id) ->
-            let id =
-              A.FunOrMethodId.Method
-                (trait_ref.trait_decl_ref.trait_decl_id, method_id)
-            in
-            lookup true id lp_id
-        | FromLlbc (FunId (FBuiltin aid), _) ->
-            Some
-              (Builtin.BuiltinFunIdMap.find aid ctx.builtin_sigs).explicit_info
-        | Pure (UpdateAtIndex Array) ->
-            Some
-              {
-                explicit_types = [ Implicit ];
-                explicit_const_generics = [ Implicit ];
-              }
-        | Pure (UpdateAtIndex Slice) ->
-            Some { explicit_types = [ Implicit ]; explicit_const_generics = [] }
-        | Pure Discriminant ->
-            Some { explicit_types = [ Implicit ]; explicit_const_generics = [] }
-        | Pure ToResult ->
-            Some { explicit_types = [ Implicit ]; explicit_const_generics = [] }
-        | Pure ResultUnwrapMut ->
-            Some
-              {
-                explicit_types = [ Implicit; Implicit ];
-                explicit_const_generics = [];
-              }
-        | Pure _ -> None
+        try
+          match fun_id with
+          | FromLlbc (FunId (FRegular fun_decl_id), lp_id) -> begin
+              (* Lookup the function to retrieve the signature information *)
+              let trans_fun =
+                [%silent_unwrap] span (ctx_lookup_fun_decl_info ctx fun_decl_id)
+              in
+              let trans_fun =
+                match lp_id with
+                | None -> trans_fun.f
+                | Some (lp_id, true) -> Pure.LoopId.nth trans_fun.bodies lp_id
+                | Some (lp_id, false) -> Pure.LoopId.nth trans_fun.loops lp_id
+              in
+              let explicit = trans_fun.signature.explicit_info in
+              Some (adjust_explicit_info explicit false generics)
+            end
+          | FromLlbc (TraitMethod (trait_ref, method_id, _), lp_id) -> begin
+              (* Lookup the function to retrieve the signature information *)
+              let id =
+                A.FunOrMethodId.Method
+                  (trait_ref.trait_decl_ref.trait_decl_id, method_id)
+              in
+              let trans_fun =
+                [%silent_unwrap] span
+                  (A.FunOrMethodId.Map.find_opt id ctx.trans_funs)
+              in
+              let trans_fun =
+                match lp_id with
+                | None -> trans_fun.f
+                | Some (lp_id, true) -> Pure.LoopId.nth trans_fun.bodies lp_id
+                | Some (lp_id, false) -> Pure.LoopId.nth trans_fun.loops lp_id
+              in
+              let explicit = trans_fun.signature.explicit_info in
+              Some (adjust_explicit_info explicit true generics)
+            end
+          | FromLlbc (FunId (FBuiltin aid), _) ->
+              Some
+                (Builtin.BuiltinFunIdMap.find aid ctx.builtin_sigs)
+                  .explicit_info
+          | Pure (UpdateAtIndex Array) ->
+              Some
+                {
+                  explicit_types = [ Implicit ];
+                  explicit_const_generics = [ Implicit ];
+                }
+          | Pure (UpdateAtIndex Slice) ->
+              Some
+                { explicit_types = [ Implicit ]; explicit_const_generics = [] }
+          | Pure Discriminant ->
+              Some
+                { explicit_types = [ Implicit ]; explicit_const_generics = [] }
+          | Pure ToResult ->
+              Some
+                { explicit_types = [ Implicit ]; explicit_const_generics = [] }
+          | Pure ResultUnwrapMut ->
+              Some
+                {
+                  explicit_types = [ Implicit; Implicit ];
+                  explicit_const_generics = [];
+                }
+          | Pure _ -> None
+        with CFailure _ ->
+          (* Fallback if, for instance, we could not lookup the declaration *)
+          [%save_error] span "Internal error";
+          None
       in
       (* Filter the generics.
 

--- a/src/extract/Extract.ml
+++ b/src/extract/Extract.ml
@@ -974,7 +974,7 @@ and extract_function_call (span : Meta.span) (ctx : extraction_ctx)
          ]}
       *)
       (match fun_id with
-      | FromLlbc (TraitMethod (trait_ref, method_name, _fun_decl_id), lp_id) ->
+      | FromLlbc (TraitMethod (trait_ref, method_name, _), lp_id) ->
           let trait_decl_id = trait_ref.trait_decl_ref.trait_decl_id in
           let trait_decl =
             TraitDeclId.Map.find trait_decl_id ctx.trans_trait_decls
@@ -1016,22 +1016,17 @@ and extract_function_call (span : Meta.span) (ctx : extraction_ctx)
               Some (adjust_explicit_info explicit false generics)
             end
           | FromLlbc (TraitMethod (trait_ref, method_id, _), lp_id) -> begin
-              (* Lookup the function to retrieve the signature information *)
-              let id =
-                A.FunOrMethodId.Method
-                  (trait_ref.trait_decl_ref.trait_decl_id, method_id)
+              [%sanity_check] span (lp_id = None);
+              let trait_decl =
+                TraitDeclId.Map.find trait_ref.trait_decl_ref.trait_decl_id
+                  ctx.trans_trait_decls
               in
-              let trans_fun =
-                [%silent_unwrap] span
-                  (A.FunOrMethodId.Map.find_opt id ctx.trans_funs)
+              let meth =
+                List.find
+                  (fun (meth : trait_method) -> meth.method_id = method_id)
+                  trait_decl.methods
               in
-              let trans_fun =
-                match lp_id with
-                | None -> trans_fun.f
-                | Some (lp_id, true) -> Pure.LoopId.nth trans_fun.bodies lp_id
-                | Some (lp_id, false) -> Pure.LoopId.nth trans_fun.loops lp_id
-              in
-              let explicit = trans_fun.signature.explicit_info in
+              let explicit = meth.signature.explicit_info in
               Some (adjust_explicit_info explicit true generics)
             end
           | FromLlbc (FunId (FBuiltin aid), _) ->

--- a/src/extract/Extract.ml
+++ b/src/extract/Extract.ml
@@ -2822,31 +2822,22 @@ let extract_trait_decl_method_names (ctx : extraction_ctx)
   [%ltrace trait_decl.name];
   let methods = trait_decl.methods in
   (* Small helper *)
-  let compute_item_name (method_id : trait_method_id) (item_name : string) :
-      FunDeclId.id option * string =
+  let compute_item_name (meth : trait_method) : FunDeclId.id option * string =
+    let item_name = meth.item_name in
     [%ldebug "(" ^ trait_decl.name ^ "): compute_item_name: " ^ item_name];
-    let trans : pure_fun_translation =
-      let id = A.FunOrMethodId.Method (trait_decl.def_id, method_id) in
-      match A.FunOrMethodId.Map.find_opt id ctx.trans_funs with
-      | Some decl -> decl
-      | None ->
-          [%craise] trait_decl.item_meta.span
-            ("Unexpected error: could not find the declaration for method '"
-           ^ item_name ^ "' for trait declaration '"
-            ^ name_to_string ctx trait_decl.item_meta.name
-            ^ "'")
-    in
 
-    let f = trans.f in
     (* We do something special to reuse the [ctx_compute_fun_decl]
        function. TODO: make it cleaner. *)
     let llbc_name : Types.name =
       [ Types.PeIdent (item_name, Disambiguator.zero) ]
     in
-    let f = { f with item_meta = { f.item_meta with name = llbc_name } } in
+    let item_meta = { meth.item_meta with name = llbc_name } in
     [%ldebug
-      "compute_item_name: llbc_name=" ^ name_to_string ctx f.item_meta.name];
-    let name = ctx_compute_fun_name f true ctx in
+      "compute_item_name: llbc_name=" ^ name_to_string ctx item_meta.name];
+    let name =
+      ctx_compute_fun_global_name_no_suffix item_meta TopLevelItem
+        ~is_trait_decl_field:true ctx
+    in
     (* Add a prefix if necessary *)
     let name =
       if !record_fields_short_names then name
@@ -2861,9 +2852,7 @@ let extract_trait_decl_method_names (ctx : extraction_ctx)
         (* Not a builtin function *)
         List.map
           (fun meth ->
-            let default_id, fun_name =
-              compute_item_name meth.method_id meth.item_name
-            in
+            let default_id, fun_name = compute_item_name meth in
             (meth.method_id, default_id, fun_name))
           methods
     | Some info ->
@@ -2881,9 +2870,7 @@ let extract_trait_decl_method_names (ctx : extraction_ctx)
                  ^ Config.backend_name ()
                  ^ " library seems to be missing the corresponding field.");
                 (* Use the LLBC definition to compute the name *)
-                let default_id, fun_name =
-                  compute_item_name meth.method_id meth.item_name
-                in
+                let default_id, fun_name = compute_item_name meth in
                 (meth.method_id, default_id, fun_name)
             | Some info ->
                 let fun_name = info.extract_name in

--- a/src/extract/Extract.ml
+++ b/src/extract/Extract.ml
@@ -288,11 +288,9 @@ let fun_builtin_filter_types_trait_clauses (ty_to_string : 'a -> string)
     | None -> Result.Ok clauses
     | Some filter ->
         if List.length filter <> List.length types then (
-          let id =
-            FunsAnalysis.fun_or_method_id_of_fun_decl_id
-              ctx.trans_ctx.fun_ctx.fun_infos id
+          let decl =
+            [%silent_unwrap_opt_span] None (ctx_lookup_fun_decl_info ctx id)
           in
-          let decl = A.FunOrMethodId.Map.find id ctx.trans_funs in
           let err =
             "Ill-formed builtin information for function "
             ^ name_to_string ctx decl.f.item_meta.name
@@ -313,11 +311,9 @@ let fun_builtin_filter_types_trait_clauses (ty_to_string : 'a -> string)
     | None -> Result.Ok (types, explicit)
     | Some filter ->
         if List.length filter <> List.length types then (
-          let id =
-            FunsAnalysis.fun_or_method_id_of_fun_decl_id
-              ctx.trans_ctx.fun_ctx.fun_infos id
+          let decl =
+            [%silent_unwrap_opt_span] None (ctx_lookup_fun_decl_info ctx id)
           in
-          let decl = A.FunOrMethodId.Map.find id ctx.trans_funs in
           let err =
             "Ill-formed builtin information for function "
             ^ name_to_string ctx decl.f.item_meta.name
@@ -3424,12 +3420,8 @@ let extract_trait_impl_method_items_aux (ctx : extraction_ctx)
   let method_decl_id = fn.binder_value.fun_id in
   (* Lookup the definition *)
   let trans =
-    let id =
-      FunsAnalysis.fun_or_method_id_of_fun_decl_id
-        ctx.trans_ctx.fun_ctx.fun_infos method_decl_id
-    in
     [%unwrap_with_span] span
-      (A.FunOrMethodId.Map.find_opt id ctx.trans_funs)
+      (ctx_lookup_fun_decl_info ctx method_decl_id)
       "Could not lookup the translated function, probably because of an error \
        which happened before"
   in

--- a/src/extract/Extract.ml
+++ b/src/extract/Extract.ml
@@ -3065,21 +3065,16 @@ let extract_trait_decl_method_items_aux (ctx : extraction_ctx)
     (fmt : F.formatter) (decl : trait_decl) (meth : trait_method) : unit =
   (* Lookup the definition *)
   let method_id = meth.method_id in
-  let fn = meth.fun_ref in
-  let trans =
-    let id = A.FunOrMethodId.Method (decl.def_id, method_id) in
-    [%silent_unwrap_opt_span] None
-      (A.FunOrMethodId.Map.find_opt id ctx.trans_funs)
-  in
-  let span = trans.f.item_meta.span in
+  let signature = meth.signature in
+  let span = meth.item_meta.span in
   (* Extract the items *)
   let fun_name = ctx_get_trait_method span decl.def_id method_id ctx in
   let ty () =
-    let method_llbc_generics = fn.binder_llbc_generics in
-    let method_generics = fn.binder_generics in
-    let method_explicit_info = fn.binder_explicit_info in
+    let method_llbc_generics = signature.llbc_generics in
+    let method_generics = signature.generics in
+    let method_explicit_info = signature.explicit_info in
     let ctx, type_params, cg_params, trait_clauses =
-      ctx_add_generic_params span trans.f.item_meta.name Method
+      ctx_add_generic_params span meth.item_meta.name Method
         method_llbc_generics method_generics ctx
     in
     let backend_uses_forall =
@@ -3098,15 +3093,7 @@ let extract_trait_decl_method_items_aux (ctx : extraction_ctx)
 
     (* Extract the inputs and output *)
     F.pp_print_space fmt ();
-    (* We substitute the function item generics in temrs of the trait + method
-       generics. *)
-    let signature = trans.f.signature in
-    let subst =
-      make_subst_from_generics signature.generics fn.binder_value.fun_generics
-    in
     let ({ inputs; output; _ } : fun_sig) = signature in
-    let inputs = List.map (ty_substitute subst) inputs in
-    let output = ty_substitute subst output in
     extract_fun_input_parameters_types span ctx fmt inputs;
     extract_ty span ctx fmt TypeDeclId.Set.empty ~inside:false output
   in

--- a/src/extract/ExtractBase.ml
+++ b/src/extract/ExtractBase.ml
@@ -596,7 +596,7 @@ type extraction_ctx = {
   trait_decl_id : trait_decl_id option;
       (** If we are extracting a trait declaration, identifies it *)
   trans_types : Pure.type_decl Pure.TypeDeclId.Map.t;
-  trans_funs : pure_fun_translation A.FunOrMethodId.Map.t;
+  trans_funs : pure_fun_translation A.FunDeclId.Map.t;
   trans_globals : Pure.global_decl Pure.GlobalDeclId.Map.t;
   builtin_sigs : Pure.fun_sig Builtin.BuiltinFunIdMap.t;
   functions_with_decreases_clause : PureUtils.FunLoopIdSet.t;
@@ -899,11 +899,7 @@ let ctx_get_termination_measure (span : Meta.span) (def_id : A.FunDeclId.id)
 
 let ctx_lookup_fun_decl_info (ctx : extraction_ctx) (id : A.FunDeclId.id) :
     pure_fun_translation option =
-  let id =
-    FunsAnalysis.fun_or_method_id_of_fun_decl_id ctx.trans_ctx.fun_ctx.fun_infos
-      id
-  in
-  A.FunOrMethodId.Map.find_opt id ctx.trans_funs
+  A.FunDeclId.Map.find_opt id ctx.trans_funs
 
 (** Small helper to compute the name of a unary operation *)
 let unop_name (unop : unop) : string =

--- a/src/extract/ExtractBase.ml
+++ b/src/extract/ExtractBase.ml
@@ -897,6 +897,14 @@ let ctx_get_termination_measure (span : Meta.span) (def_id : A.FunDeclId.id)
     (loop_id : (LoopId.id * bool) option) (ctx : extraction_ctx) : string =
   ctx_get (Some span) (TerminationMeasureId (FRegular def_id, loop_id)) ctx
 
+let ctx_lookup_fun_decl_info (ctx : extraction_ctx) (id : A.FunDeclId.id) :
+    pure_fun_translation option =
+  let id =
+    FunsAnalysis.fun_or_method_id_of_fun_decl_id ctx.trans_ctx.fun_ctx.fun_infos
+      id
+  in
+  A.FunOrMethodId.Map.find_opt id ctx.trans_funs
+
 (** Small helper to compute the name of a unary operation *)
 let unop_name (unop : unop) : string =
   match unop with

--- a/src/interp/Interp.ml
+++ b/src/interp/Interp.ml
@@ -177,13 +177,53 @@ let compute_contexts (crate : crate) : decls_ctx =
   in
 
   let trait_methods_to_extract =
+    let trait_method_ids = ref TraitDeclId.Map.empty in
+    let add_trait_method_id trait_decl_id method_id =
+      trait_method_ids :=
+        TraitDeclId.Map.update trait_decl_id
+          (fun opt_set ->
+            let set = Option.value opt_set ~default:TraitMethodId.Set.empty in
+            Some (TraitMethodId.Set.add method_id set))
+          !trait_method_ids
+    in
+    let visitor =
+      object
+        inherit [_] iter_crate as super
+
+        (* Include a method if an implementation of it is in the extracted functions. *)
+        method! visit_item_source env (src : item_source) =
+          (match src with
+          | TraitDeclItem (trait_ref, AssocIdMethod method_id, _)
+          | TraitImplItem (_, trait_ref, AssocIdMethod method_id, _) ->
+              add_trait_method_id trait_ref.id method_id
+          | _ -> ());
+          super#visit_item_source env src
+
+        (* Include a method if it is mentioned in the extracted functions. *)
+        method! visit_fn_ptr env fn_ptr =
+          (match fn_ptr.kind with
+          | TraitMethod (trait_ref, method_id, _) ->
+              let trait_decl_id = trait_ref.trait_decl_ref.binder_value.id in
+              add_trait_method_id trait_decl_id method_id
+          | _ -> ());
+          super#visit_fn_ptr env fn_ptr
+      end
+    in
+    List.iter
+      (visitor#visit_fun_decl ())
+      (FunDeclId.Map.values fun_ctx.to_extract);
+    List.iter
+      (visitor#visit_global_decl ())
+      (GlobalDeclId.Map.values global_decls_to_extract);
+
     TraitDeclId.Map.mapi
-      (fun _ (trait_decl : trait_decl) ->
-        TraitMethodId.Map.filter
-          (fun _ (bound_method : trait_method Types.binder) ->
-            let method_ = bound_method.binder_value in
-            FunDeclId.Set.mem method_.item.id !fun_decl_ids)
-          trait_decl.methods)
+      (fun trait_decl_id (trait_decl : trait_decl) ->
+        match TraitDeclId.Map.find_opt trait_decl_id !trait_method_ids with
+        | None -> TraitMethodId.Map.empty
+        | Some method_ids ->
+            TraitMethodId.Map.filter
+              (fun method_id _ -> TraitMethodId.Set.mem method_id method_ids)
+              trait_decl.methods)
       crate.trait_decls
   in
 

--- a/src/interp/Interp.ml
+++ b/src/interp/Interp.ml
@@ -176,6 +176,17 @@ let compute_contexts (crate : crate) : decls_ctx =
       crate.trait_impls
   in
 
+  let trait_methods_to_extract =
+    TraitDeclId.Map.mapi
+      (fun _ (trait_decl : trait_decl) ->
+        TraitMethodId.Map.filter
+          (fun _ (bound_method : trait_method Types.binder) ->
+            let method_ = bound_method.binder_value in
+            FunDeclId.Set.mem method_.item.id !fun_decl_ids)
+          trait_decl.methods)
+      crate.trait_decls
+  in
+
   {
     crate;
     graph_of_uses = crate_graph;
@@ -183,6 +194,7 @@ let compute_contexts (crate : crate) : decls_ctx =
     fun_ctx;
     global_decls_to_extract;
     trait_decls_to_extract;
+    trait_methods_to_extract;
     trait_impls_to_extract;
   }
 

--- a/src/llbc/Contexts.ml
+++ b/src/llbc/Contexts.ml
@@ -70,6 +70,11 @@ type decls_ctx = {
           extracted. *)
   trait_decls_to_extract : trait_decl TraitDeclId.Map.t;
       (** Similar to [global_decls_to_extract] *)
+  trait_methods_to_extract :
+    trait_method Types.binder TraitMethodId.Map.t TraitDeclId.Map.t;
+      (** The trait methods whose declaration should be extracted as fields of
+          their trait declaration. This map contains an entry for every
+          [TraitDeclId]. *)
   trait_impls_to_extract : trait_impl TraitImplId.Map.t;
       (** Similar to [global_decls_to_extract] *)
 }

--- a/src/llbc/FunsAnalysis.ml
+++ b/src/llbc/FunsAnalysis.ml
@@ -32,72 +32,53 @@ type fun_info = {
 }
 [@@deriving show]
 
-(** Various information about a module's functions and trait methods.
-
-    The [fun_decl_id_map] field records the canonical id for every function
-    declaration. The fun_decl backing a trait method definition is refered to
-    using [FunOrMethodId.Method] instead of its fun_decl_id. *)
-type modules_funs_info = {
-  fun_decl_id_map : FunOrMethodId.id FunDeclId.Map.t;
-  infos : fun_info FunOrMethodId.Map.t;
-}
+(** Various information about a module's functions and trait methods. *)
+type modules_funs_info = { infos : fun_info FunOrMethodId.Map.t }
 [@@deriving show]
 
 let lookup_fun_info (infos : modules_funs_info) (id : FunOrMethodId.id) :
     fun_info option =
   FunOrMethodId.Map.find_opt id infos.infos
 
-let fun_or_method_id_of_fun_decl_id (infos : modules_funs_info)
-    (id : FunDeclId.id) : FunOrMethodId.id =
-  [%silent_unwrap_opt_span] None
-    (FunDeclId.Map.find_opt id infos.fun_decl_id_map)
-
-let fun_or_method_id_of_fn_ptr (infos : modules_funs_info) (kind : fn_ptr_kind)
-    : FunOrMethodId.id option =
+let fun_or_method_id_of_fn_ptr (kind : fn_ptr_kind) : FunOrMethodId.id option =
   match kind with
-  | FunId (FRegular id) -> Some (fun_or_method_id_of_fun_decl_id infos id)
+  | FunId (FRegular id) -> Some (FunOrMethodId.Fun id)
   | TraitMethod (trait_ref, method_id, _) ->
       Some (FunOrMethodId.of_trait_method trait_ref method_id)
   | FunId (FBuiltin _) -> None
 
 let lookup_fun_decl_info (infos : modules_funs_info) (id : FunDeclId.id) :
     fun_info option =
-  lookup_fun_info infos (fun_or_method_id_of_fun_decl_id infos id)
+  lookup_fun_info infos (FunOrMethodId.Fun id)
 
 let lookup_fn_ptr_info (infos : modules_funs_info) (kind : fn_ptr_kind) :
     fun_info option =
-  Option.bind (fun_or_method_id_of_fn_ptr infos kind) (lookup_fun_info infos)
-
-let compute_fun_decl_id_map (m : crate) (funs_map : fun_decl FunDeclId.Map.t) :
-    FunOrMethodId.id FunDeclId.Map.t =
-  let ids = ref FunDeclId.Map.empty in
-  FunDeclId.Map.iter
-    (fun id _ ->
-      ids := FunDeclId.Map.add id (FunOrMethodId.of_regular_fun_decl_id id) !ids)
-    funs_map;
-  TraitDeclId.Map.iter
-    (fun trait_decl_id (trait_decl : trait_decl) ->
-      Types.TraitMethodId.Map.iter
-        (fun method_id (method_ : trait_method Types.binder) ->
-          let id = method_.binder_value.item.id in
-          let canonical_id = FunOrMethodId.Method (trait_decl_id, method_id) in
-          ids := FunDeclId.Map.add id canonical_id !ids)
-        trait_decl.methods)
-    m.trait_decls;
-  !ids
+  Option.bind (fun_or_method_id_of_fn_ptr kind) (lookup_fun_info infos)
 
 let analyze_module (m : crate) (funs_map : fun_decl FunDeclId.Map.t) :
     modules_funs_info =
   let fmt_env = Charon.Print.crate_to_fmt_env m in
-  let fun_decl_id_map = compute_fun_decl_id_map m funs_map in
-  let infos = ref { fun_decl_id_map; infos = FunOrMethodId.Map.empty } in
+  let infos = ref { infos = FunOrMethodId.Map.empty } in
   let register_info (id : FunOrMethodId.id) (info : fun_info) : unit =
     assert (not (FunOrMethodId.Map.mem id !infos.infos));
-    infos := { !infos with infos = FunOrMethodId.Map.add id info !infos.infos }
+    infos := { infos = FunOrMethodId.Map.add id info !infos.infos }
   in
   let register_fun_decl_info (id : FunDeclId.id) (info : fun_info) : unit =
-    register_info (fun_or_method_id_of_fun_decl_id !infos id) info
+    register_info (FunOrMethodId.Fun id) info
   in
+  let register_trait_method_info (trait_decl_id : TraitDeclId.id)
+      (method_id : Types.TraitMethodId.id) : unit =
+    register_info
+      (FunOrMethodId.Method (trait_decl_id, method_id))
+      { can_fail = true; stateful = false; can_diverge = false; is_rec = false }
+  in
+
+  TraitDeclId.Map.iter
+    (fun trait_decl_id (trait_decl : trait_decl) ->
+      Types.TraitMethodId.Map.iter
+        (fun method_id _ -> register_trait_method_info trait_decl_id method_id)
+        trait_decl.methods)
+    m.trait_decls;
 
   (* Analyze a group of mutually recursive functions.
    * As the functions can call each other, we compute the same information

--- a/src/pure/Pure.ml
+++ b/src/pure/Pure.ml
@@ -1873,6 +1873,10 @@ type global_decl = {
 type trait_method = {
   method_id : trait_method_id;
   item_name : trait_item_name;
+  item_meta : T.item_meta;
+  signature : fun_sig;
+  (* The signature of the method. Its [generic_params] contain the method
+     generics; the signature can refer to both trait and method generics. *)
   fun_ref : fun_decl_ref binder;
 }
 [@@deriving show]

--- a/src/pure/PureUtils.ml
+++ b/src/pure/PureUtils.ml
@@ -2408,26 +2408,36 @@ let filter_generic_params_used_in_texpr (generic : generic_params) (e : texpr) :
   let generics : generic_params = { types; const_generics; trait_clauses } in
   (generics, filter)
 
-let generic_args_of_params (generics : generic_params) : generic_args =
+type mk_var = { mk : 'a. 'a -> 'a de_bruijn_var }
+
+let mk_generic_args_of_params (mk_var : mk_var) (generics : generic_params) :
+    generic_args =
   let types =
-    List.map (fun (v : type_param) -> TVar (Free v.index)) generics.types
+    List.map (fun (v : type_param) -> TVar (mk_var.mk v.index)) generics.types
   in
   let const_generics =
     List.map
-      (fun (v : const_generic_param) -> CgVar (Free v.index))
+      (fun (v : const_generic_param) -> CgVar (mk_var.mk v.index))
       generics.const_generics
   in
   let trait_refs =
     List.map
       (fun (c : trait_param) ->
         {
-          trait_id = Clause (Free c.clause_id);
+          trait_id = Clause (mk_var.mk c.clause_id);
           trait_decl_ref =
             { trait_decl_id = c.trait_id; decl_generics = c.generics };
         })
       generics.trait_clauses
   in
   { types; const_generics; trait_refs }
+
+let generic_args_of_params (generics : generic_params) : generic_args =
+  mk_generic_args_of_params { mk = (fun x -> Free x) } generics
+
+(* Like `generic_args_of_params` but makes all the variables `Bound` instead of `Free`. *)
+let bound_generic_args_of_params (generics : generic_params) : generic_args =
+  mk_generic_args_of_params { mk = (fun x -> Bound (0, x)) } generics
 
 type decomposed_loop_result = {
   variant_id : variant_id;

--- a/src/pure/ReorderDecls.ml
+++ b/src/pure/ReorderDecls.ml
@@ -46,7 +46,8 @@ let compute_body_fun_deps (e : texpr) : FunIdSet.t =
             | FromLlbc (fid, lp_id) -> (
                 match fid with
                 | FunId (FBuiltin _) -> ()
-                | TraitMethod (_, _, fid) | FunId (FRegular fid) ->
+                | TraitMethod _ -> ()
+                | FunId (FRegular fid) ->
                     let id = { def_id = fid; lp_id } in
                     ids := FunIdSet.add id !ids))
     end

--- a/src/symbolic/SymbolicToPure.ml
+++ b/src/symbolic/SymbolicToPure.ml
@@ -194,7 +194,7 @@ let translate_trait_decl (ctx : Contexts.decls_ctx) (trait_decl : A.trait_decl)
     implied_clauses = llbc_parent_clauses;
     consts;
     types;
-    methods;
+    methods = _;
     vtable = _;
   } : A.trait_decl =
     trait_decl
@@ -246,16 +246,14 @@ let translate_trait_decl (ctx : Contexts.decls_ctx) (trait_decl : A.trait_decl)
         (const_id, c.name, translate_ty c.ty))
       (T.AssocConstId.Map.to_list consts)
   in
+  let methods_to_extract =
+    TraitDeclId.Map.find def_id ctx.trait_methods_to_extract
+  in
   let methods =
-    List.filter_map
+    List.map
       (fun ((method_id, m) : TraitMethodId.id * A.trait_method T.binder) ->
-        let method_ = m.binder_value in
-        if FunDeclId.Map.mem method_.item.id ctx.fun_ctx.to_extract then
-          Some
-            (translate_trait_method ctx opt_span translate_ty trait_decl
-               method_id m)
-        else None)
-      (TraitMethodId.Map.to_list methods)
+        translate_trait_method ctx opt_span translate_ty trait_decl method_id m)
+      (TraitMethodId.Map.to_list methods_to_extract)
   in
   {
     def_id;

--- a/src/symbolic/SymbolicToPure.ml
+++ b/src/symbolic/SymbolicToPure.ml
@@ -165,13 +165,19 @@ let translate_binder (span : span option) (translate_inside : 'a -> 'b)
     binder_llbc_generics;
   }
 
-let translate_trait_method (span : span option) (translate_ty : T.ty -> ty)
+let translate_trait_method (ctx : Contexts.decls_ctx) (span : span option)
+    (translate_ty : T.ty -> ty) (trait_decl : A.trait_decl)
     (method_id : TraitMethodId.id) (bound_method : A.trait_method T.binder) :
     trait_method =
   let method_ = bound_method.binder_value in
+  let signature =
+    translate_trait_method_sig ctx trait_decl method_id bound_method
+  in
   {
     method_id;
     item_name = method_.name;
+    item_meta = method_.item_meta;
+    signature;
     fun_ref =
       translate_binder span
         (fun (m : A.trait_method) ->
@@ -241,9 +247,14 @@ let translate_trait_decl (ctx : Contexts.decls_ctx) (trait_decl : A.trait_decl)
       (T.AssocConstId.Map.to_list consts)
   in
   let methods =
-    List.map
+    List.filter_map
       (fun ((method_id, m) : TraitMethodId.id * A.trait_method T.binder) ->
-        translate_trait_method opt_span translate_ty method_id m)
+        let method_ = m.binder_value in
+        if FunDeclId.Map.mem method_.item.id ctx.fun_ctx.to_extract then
+          Some
+            (translate_trait_method ctx opt_span translate_ty trait_decl
+               method_id m)
+        else None)
       (TraitMethodId.Map.to_list methods)
   in
   {

--- a/src/symbolic/SymbolicToPureCore.ml
+++ b/src/symbolic/SymbolicToPureCore.ml
@@ -332,13 +332,13 @@ let bs_ctx_to_pure_fmt_env (ctx : bs_ctx) : PrintPure.fmt_env =
   }
 
 let lookup_fn_ptr_sig (ctx : bs_ctx) (kind : A.fn_ptr_kind) : fun_sigs option =
-  Option.bind (fun_or_method_id_of_fn_ptr ctx.fun_ctx.fun_infos kind) (fun id ->
+  Option.bind (fun_or_method_id_of_fn_ptr kind) (fun id ->
       A.FunOrMethodId.Map.find_opt id ctx.fun_sigs)
 
-let fun_or_method_id_of_pure_fn_ptr (infos : modules_funs_info)
-    (kind : fn_ptr_kind) : A.FunOrMethodId.id option =
+let fun_or_method_id_of_pure_fn_ptr (kind : fn_ptr_kind) :
+    A.FunOrMethodId.id option =
   match kind with
-  | FunId (FRegular id) -> Some (fun_or_method_id_of_fun_decl_id infos id)
+  | FunId (FRegular id) -> Some (A.FunOrMethodId.Fun id)
   | TraitMethod (trait_ref, method_id, _) ->
       Some
         (A.FunOrMethodId.Method
@@ -347,14 +347,12 @@ let fun_or_method_id_of_pure_fn_ptr (infos : modules_funs_info)
 
 let lookup_pure_fn_ptr_sig (ctx : bs_ctx) (kind : fn_ptr_kind) : fun_sigs option
     =
-  Option.bind (fun_or_method_id_of_pure_fn_ptr ctx.fun_ctx.fun_infos kind)
-    (fun id -> A.FunOrMethodId.Map.find_opt id ctx.fun_sigs)
+  Option.bind (fun_or_method_id_of_pure_fn_ptr kind) (fun id ->
+      A.FunOrMethodId.Map.find_opt id ctx.fun_sigs)
 
 let lookup_pure_fn_ptr_info (infos : modules_funs_info) (kind : fn_ptr_kind) :
     fun_info option =
-  Option.bind
-    (fun_or_method_id_of_pure_fn_ptr infos kind)
-    (lookup_fun_info infos)
+  Option.bind (fun_or_method_id_of_pure_fn_ptr kind) (lookup_fun_info infos)
 
 let ctx_generic_args_to_string (ctx : bs_ctx) (args : T.generic_args) : string =
   let env = bs_ctx_to_fmt_env ctx in

--- a/src/symbolic/SymbolicToPureTypes.ml
+++ b/src/symbolic/SymbolicToPureTypes.ml
@@ -983,10 +983,14 @@ and translate_inst_fun_sig_to_decomposed_fun_type (span : Meta.span option)
   (* Return *)
   { fwd_inputs; fwd_output; back_sg; fwd_info }
 
-and translate_fun_sig_with_regions_hierarchy_to_decomposed (span : span option)
-    (decls_ctx : C.decls_ctx) (fun_id : fn_ptr_kind)
-    (regions_hierarchy : T.region_var_groups) (sg : A.bound_fun_sig)
-    (input_names : string option list) : decomposed_fun_sig =
+and translate_fun_sigs (span : span option) (decls_ctx : C.decls_ctx)
+    (fun_id : fn_ptr_kind) (sg : A.bound_fun_sig)
+    (input_names : string option list) : fun_sigs =
+  (* Retrieve the list of parent backward functions *)
+  let regions_hierarchy =
+    RegionsHierarchy.compute_regions_hierarchy_for_sig span decls_ctx.crate sg
+  in
+
   let inst_sg : LlbcAst.inst_fun_sig =
     let ({ T.inputs; output; _ } : T.fun_sig) = sg.item_binder_value in
     [%sanity_check_opt_span] span
@@ -1027,28 +1031,20 @@ and translate_fun_sig_with_regions_hierarchy_to_decomposed (span : span option)
     translate_inst_fun_sig_to_decomposed_fun_type span decls_ctx fun_id inst_sg
       input_names
   in
-  { generics; llbc_generics = sg.item_binder_params; preds; fun_ty }
-
-and translate_fun_sig_to_decomposed (decls_ctx : C.decls_ctx)
-    (fun_id : FunDeclId.id) (sg : A.bound_fun_sig)
-    (input_names : string option list) : decomposed_fun_sig =
-  let span =
-    ([%silent_unwrap_opt_span] None
-       (FunDeclId.Map.find_opt fun_id decls_ctx.fun_ctx.fun_decls))
-      .item_meta
-      .span
+  let dsg =
+    { generics; llbc_generics = sg.item_binder_params; preds; fun_ty }
   in
-  (* Retrieve the list of parent backward functions *)
-  let regions_hierarchy =
-    RegionsHierarchy.compute_regions_hierarchy_for_sig (Some span)
-      decls_ctx.crate sg
-  in
+  translate_fun_sigs_from_decomposed dsg
 
-  translate_fun_sig_with_regions_hierarchy_to_decomposed (Some span) decls_ctx
-    (FunId (FRegular fun_id)) regions_hierarchy sg input_names
+and translate_fun_sigs_from_decomposed (dsg : Pure.decomposed_fun_sig) :
+    fun_sigs =
+  let sg = translate_fun_sig_from_decomposed dsg in
+  let ty = mk_arrows sg.inputs sg.output in
+  { dsg; sg; ty }
 
-and translate_fun_sig_from_decl_to_decomposed (decls_ctx : C.decls_ctx)
-    (fdef : LlbcAst.fun_decl) : decomposed_fun_sig =
+and translate_fun_sigs_from_decl (decls_ctx : C.decls_ctx)
+    (fdef : LlbcAst.fun_decl) : fun_sigs =
+  let span = fdef.item_meta.span in
   let input_names =
     match fdef.body with
     | StructuredBody body ->
@@ -1057,26 +1053,9 @@ and translate_fun_sig_from_decl_to_decomposed (decls_ctx : C.decls_ctx)
           (LlbcAstUtils.fun_body_get_input_vars body)
     | _ -> List.map (fun _ -> None) fdef.signature.inputs
   in
-  let sg =
-    translate_fun_sig_to_decomposed decls_ctx fdef.def_id
-      (bound_fun_sig_of_decl fdef)
-      input_names
-  in
-  [%ltrace
-    "- name: "
-    ^ T.show_name fdef.item_meta.name
-    ^ "\n- sg:\n"
-    ^ PrintPure.decomposed_fun_sig_to_string
-        (PrintPure.decls_ctx_to_fmt_env decls_ctx)
-        sg];
-  sg
-
-and translate_fun_sigs_from_decl (decls_ctx : C.decls_ctx)
-    (fdef : LlbcAst.fun_decl) : fun_sigs =
-  let dsg = translate_fun_sig_from_decl_to_decomposed decls_ctx fdef in
-  let sg = translate_fun_sig_from_decomposed dsg in
-  let ty = mk_arrows sg.inputs sg.output in
-  { dsg; sg; ty }
+  translate_fun_sigs (Some span) decls_ctx (FunId (FRegular fdef.def_id))
+    (bound_fun_sig_of_decl fdef)
+    input_names
 
 and mk_output_ty_from_effect_info (effect_info : fun_effect_info) (ty : ty) : ty
     =
@@ -1176,17 +1155,8 @@ and translate_fun_sig_from_decomposed (dsg : Pure.decomposed_fun_sig) : fun_sig
 
 and translate_fun_sig (decls_ctx : C.decls_ctx) (fun_id : fn_ptr_kind)
     (sg : A.bound_fun_sig) (input_names : string option list) : Pure.fun_sig =
-  (* Compute the regions hierarchy *)
-  let regions_hierarchy =
-    RegionsHierarchy.compute_regions_hierarchy_for_sig None decls_ctx.crate sg
-  in
-  (* Compute the decomposed fun signature *)
-  let sg =
-    translate_fun_sig_with_regions_hierarchy_to_decomposed None decls_ctx fun_id
-      regions_hierarchy sg input_names
-  in
-  (* Finish the translation *)
-  translate_fun_sig_from_decomposed sg
+  let sigs = translate_fun_sigs None decls_ctx fun_id sg input_names in
+  sigs.sg
 
 (** TODO: not very clean. *)
 and get_fun_effect_info (ctx : bs_ctx) (fun_id : fn_ptr_kind)

--- a/src/symbolic/SymbolicToPureTypes.ml
+++ b/src/symbolic/SymbolicToPureTypes.ml
@@ -1042,6 +1042,74 @@ and translate_fun_sigs_from_decomposed (dsg : Pure.decomposed_fun_sig) :
   let ty = mk_arrows sg.inputs sg.output in
   { dsg; sg; ty }
 
+and translate_flat_trait_method_sigs (decls_ctx : C.decls_ctx)
+    (trait_decl : A.trait_decl) (method_id : TraitMethodId.id)
+    (bound_method : A.trait_method T.binder) : fun_sigs =
+  let span = trait_decl.item_meta.span in
+  let method_ = bound_method.binder_value in
+  let trait_decl_ref : T.trait_decl_ref T.region_binder =
+    let generics =
+      Charon.TypesUtils.generic_args_of_params (Some span) trait_decl.generics
+    in
+    {
+      binder_regions = [];
+      binder_value = ({ id = trait_decl.def_id; generics } : T.trait_decl_ref);
+    }
+  in
+  let trait_ref = ({ kind = T.Self; trait_decl_ref } : T.trait_ref) in
+  let trait_ref = translate_fwd_trait_ref (Some span) decls_ctx trait_ref in
+  let fun_id = TraitMethod (trait_ref, method_id, method_.item.id) in
+  let sg =
+    [%silent_unwrap_opt_span] (Some span)
+      (Substitute.lookup_flat_method_sig decls_ctx.crate trait_decl.def_id
+         method_id)
+  in
+  let input_names = List.map (fun _ -> None) sg.item_binder_value.inputs in
+  translate_fun_sigs (Some span) decls_ctx fun_id sg input_names
+
+and translate_trait_method_sig (decls_ctx : C.decls_ctx)
+    (trait_decl : A.trait_decl) (method_id : TraitMethodId.id)
+    (bound_method : A.trait_method T.binder) : Pure.fun_sig =
+  (* We do something somewhat silly here: we flatten the signature, translate
+     it, then unflatten it into two nested binders. This is needed because
+     [translate_fun_sig] doesn't handle nested binder levels. *)
+  let span = trait_decl.item_meta.span in
+  let flat_sig =
+    (translate_flat_trait_method_sigs decls_ctx trait_decl method_id
+       bound_method)
+      .sg
+  in
+  let trait_generics, _ =
+    translate_generic_params (Some span) trait_decl.generics
+  in
+  let method_llbc_generics = bound_method.binder_params in
+  let method_generics, preds =
+    translate_generic_params (Some span) method_llbc_generics
+  in
+  let generics =
+    append_generic_args
+      (generic_args_of_params trait_generics)
+      (bound_generic_args_of_params method_generics)
+  in
+  let subst = make_subst_from_generics flat_sig.generics generics in
+  let inputs = List.map (ty_substitute subst) flat_sig.inputs in
+  let output = ty_substitute subst flat_sig.output in
+
+  let explicit_info = compute_explicit_info method_generics inputs in
+  let known_from_trait_refs =
+    compute_known_info explicit_info method_generics
+  in
+  {
+    flat_sig with
+    generics = method_generics;
+    llbc_generics = method_llbc_generics;
+    explicit_info;
+    known_from_trait_refs;
+    preds;
+    inputs;
+    output;
+  }
+
 and translate_fun_sigs_from_decl (decls_ctx : C.decls_ctx)
     (fdef : LlbcAst.fun_decl) : fun_sigs =
   let span = fdef.item_meta.span in

--- a/src/symbolic/SymbolicToPureTypes.ml
+++ b/src/symbolic/SymbolicToPureTypes.ml
@@ -409,8 +409,8 @@ let rec translate_fwd_ty (span : Meta.span option) (decls_ctx : C.decls_ctx)
               (FunDeclId.Map.find_opt fid decls_ctx.fun_ctx.fun_decls)
               "Could not lookup a function declaration"
           in
-          let dsg = translate_fun_sig_from_decl_to_decomposed decls_ctx fdecl in
-          let sg = translate_fun_sig_from_decomposed dsg in
+          let sigs = translate_fun_sigs_from_decl decls_ctx fdecl in
+          let sg = sigs.sg in
           (* Check that the function lives in the expected effect - otherwise we
                  have to lift it *)
           [%cassert_opt_span] span sg.fwd_info.effect_info.can_fail
@@ -422,9 +422,7 @@ let rec translate_fwd_ty (span : Meta.span option) (decls_ctx : C.decls_ctx)
             "Unimplemented";
           (* Substitute *)
           let subst = make_subst_from_generics sg.generics generics in
-          let inputs = List.map (ty_substitute subst) sg.inputs in
-          let output = ty_substitute subst sg.output in
-          mk_arrows inputs output
+          ty_substitute subst sigs.ty
       | T.TraitMethod _ -> [%craise_opt_span] span "Unimplemented")
   | TFnPtr _ -> [%craise_opt_span] span "Arrow types are not supported yet"
   | TDynTrait { binder } ->
@@ -1072,6 +1070,13 @@ and translate_fun_sig_from_decl_to_decomposed (decls_ctx : C.decls_ctx)
         (PrintPure.decls_ctx_to_fmt_env decls_ctx)
         sg];
   sg
+
+and translate_fun_sigs_from_decl (decls_ctx : C.decls_ctx)
+    (fdef : LlbcAst.fun_decl) : fun_sigs =
+  let dsg = translate_fun_sig_from_decl_to_decomposed decls_ctx fdef in
+  let sg = translate_fun_sig_from_decomposed dsg in
+  let ty = mk_arrows sg.inputs sg.output in
+  { dsg; sg; ty }
 
 and mk_output_ty_from_effect_info (effect_info : fun_effect_info) (ty : ty) : ty
     =

--- a/tests/src/borrow-check-negative.borrow-check.out
+++ b/tests/src/borrow-check-negative.borrow-check.out
@@ -5,7 +5,7 @@ Compiler source: interp/InterpPaths.ml, line 231
 Name pattern: 'borrow_check_negative::choose_test'
 Definition span: 'tests/src/borrow-check-negative.rs', lines 16:0-26:1
 Source: 'tests/src/borrow-check-negative.rs', lines 25:12-25:14
-Compiler source: interp/Interp.ml, line 550
+Compiler source: interp/Interp.ml, line 562
 
 [[91mError[39m] Can't end abstraction 8 as it is set as non-endable
 Source: 'tests/src/borrow-check-negative.rs', lines 28:0-34:1
@@ -14,7 +14,7 @@ Compiler source: interp/InterpBorrows.ml, line 1203
 Name pattern: 'borrow_check_negative::choose_wrong'
 Definition span: 'tests/src/borrow-check-negative.rs', lines 28:0-34:1
 Source: 'tests/src/borrow-check-negative.rs', lines 28:0-34:1
-Compiler source: interp/Interp.ml, line 550
+Compiler source: interp/Interp.ml, line 562
 
 [[91mError[39m] Can not apply a projection to the ⊥ value
 Source: 'tests/src/borrow-check-negative.rs', lines 42:4-42:11
@@ -23,7 +23,7 @@ Compiler source: interp/InterpPaths.ml, line 231
 Name pattern: 'borrow_check_negative::test_mut1'
 Definition span: 'tests/src/borrow-check-negative.rs', lines 36:0-43:1
 Source: 'tests/src/borrow-check-negative.rs', lines 42:4-42:11
-Compiler source: interp/Interp.ml, line 550
+Compiler source: interp/Interp.ml, line 562
 
 [[91mError[39m] Can not apply a projection to the ⊥ value
 Source: 'tests/src/borrow-check-negative.rs', lines 51:12-51:14
@@ -32,7 +32,7 @@ Compiler source: interp/InterpPaths.ml, line 231
 Name pattern: 'borrow_check_negative::test_mut2'
 Definition span: 'tests/src/borrow-check-negative.rs', lines 46:0-52:1
 Source: 'tests/src/borrow-check-negative.rs', lines 51:12-51:14
-Compiler source: interp/Interp.ml, line 550
+Compiler source: interp/Interp.ml, line 562
 
 [[91mError[39m] Can not apply a projection to the ⊥ value
 Source: 'tests/src/borrow-check-negative.rs', lines 65:12-65:17
@@ -41,7 +41,7 @@ Compiler source: interp/InterpPaths.ml, line 231
 Name pattern: 'borrow_check_negative::refs_test1'
 Definition span: 'tests/src/borrow-check-negative.rs', lines 59:0-66:1
 Source: 'tests/src/borrow-check-negative.rs', lines 65:12-65:17
-Compiler source: interp/Interp.ml, line 550
+Compiler source: interp/Interp.ml, line 562
 
 [[91mError[39m] Can not apply a projection to the ⊥ value
 Source: 'tests/src/borrow-check-negative.rs', lines 80:12-80:17
@@ -50,7 +50,7 @@ Compiler source: interp/InterpPaths.ml, line 231
 Name pattern: 'borrow_check_negative::refs_test2'
 Definition span: 'tests/src/borrow-check-negative.rs', lines 68:0-81:1
 Source: 'tests/src/borrow-check-negative.rs', lines 80:12-80:17
-Compiler source: interp/Interp.ml, line 550
+Compiler source: interp/Interp.ml, line 562
 
 [[91mError[39m] Can not apply a projection to the ⊥ value
 Source: 'tests/src/borrow-check-negative.rs', lines 91:12-91:15
@@ -59,5 +59,5 @@ Compiler source: interp/InterpPaths.ml, line 231
 Name pattern: 'borrow_check_negative::test_box1'
 Definition span: 'tests/src/borrow-check-negative.rs', lines 83:0-92:1
 Source: 'tests/src/borrow-check-negative.rs', lines 91:12-91:15
-Compiler source: interp/Interp.ml, line 550
+Compiler source: interp/Interp.ml, line 562
 

--- a/tests/src/borrow-check-negative.borrow-check.out
+++ b/tests/src/borrow-check-negative.borrow-check.out
@@ -5,7 +5,7 @@ Compiler source: interp/InterpPaths.ml, line 231
 Name pattern: 'borrow_check_negative::choose_test'
 Definition span: 'tests/src/borrow-check-negative.rs', lines 16:0-26:1
 Source: 'tests/src/borrow-check-negative.rs', lines 25:12-25:14
-Compiler source: interp/Interp.ml, line 562
+Compiler source: interp/Interp.ml, line 602
 
 [[91mError[39m] Can't end abstraction 8 as it is set as non-endable
 Source: 'tests/src/borrow-check-negative.rs', lines 28:0-34:1
@@ -14,7 +14,7 @@ Compiler source: interp/InterpBorrows.ml, line 1203
 Name pattern: 'borrow_check_negative::choose_wrong'
 Definition span: 'tests/src/borrow-check-negative.rs', lines 28:0-34:1
 Source: 'tests/src/borrow-check-negative.rs', lines 28:0-34:1
-Compiler source: interp/Interp.ml, line 562
+Compiler source: interp/Interp.ml, line 602
 
 [[91mError[39m] Can not apply a projection to the ⊥ value
 Source: 'tests/src/borrow-check-negative.rs', lines 42:4-42:11
@@ -23,7 +23,7 @@ Compiler source: interp/InterpPaths.ml, line 231
 Name pattern: 'borrow_check_negative::test_mut1'
 Definition span: 'tests/src/borrow-check-negative.rs', lines 36:0-43:1
 Source: 'tests/src/borrow-check-negative.rs', lines 42:4-42:11
-Compiler source: interp/Interp.ml, line 562
+Compiler source: interp/Interp.ml, line 602
 
 [[91mError[39m] Can not apply a projection to the ⊥ value
 Source: 'tests/src/borrow-check-negative.rs', lines 51:12-51:14
@@ -32,7 +32,7 @@ Compiler source: interp/InterpPaths.ml, line 231
 Name pattern: 'borrow_check_negative::test_mut2'
 Definition span: 'tests/src/borrow-check-negative.rs', lines 46:0-52:1
 Source: 'tests/src/borrow-check-negative.rs', lines 51:12-51:14
-Compiler source: interp/Interp.ml, line 562
+Compiler source: interp/Interp.ml, line 602
 
 [[91mError[39m] Can not apply a projection to the ⊥ value
 Source: 'tests/src/borrow-check-negative.rs', lines 65:12-65:17
@@ -41,7 +41,7 @@ Compiler source: interp/InterpPaths.ml, line 231
 Name pattern: 'borrow_check_negative::refs_test1'
 Definition span: 'tests/src/borrow-check-negative.rs', lines 59:0-66:1
 Source: 'tests/src/borrow-check-negative.rs', lines 65:12-65:17
-Compiler source: interp/Interp.ml, line 562
+Compiler source: interp/Interp.ml, line 602
 
 [[91mError[39m] Can not apply a projection to the ⊥ value
 Source: 'tests/src/borrow-check-negative.rs', lines 80:12-80:17
@@ -50,7 +50,7 @@ Compiler source: interp/InterpPaths.ml, line 231
 Name pattern: 'borrow_check_negative::refs_test2'
 Definition span: 'tests/src/borrow-check-negative.rs', lines 68:0-81:1
 Source: 'tests/src/borrow-check-negative.rs', lines 80:12-80:17
-Compiler source: interp/Interp.ml, line 562
+Compiler source: interp/Interp.ml, line 602
 
 [[91mError[39m] Can not apply a projection to the ⊥ value
 Source: 'tests/src/borrow-check-negative.rs', lines 91:12-91:15
@@ -59,5 +59,5 @@ Compiler source: interp/InterpPaths.ml, line 231
 Name pattern: 'borrow_check_negative::test_box1'
 Definition span: 'tests/src/borrow-check-negative.rs', lines 83:0-92:1
 Source: 'tests/src/borrow-check-negative.rs', lines 91:12-91:15
-Compiler source: interp/Interp.ml, line 562
+Compiler source: interp/Interp.ml, line 602
 

--- a/tests/src/loops-borrow-check-negative.borrow-check.out
+++ b/tests/src/loops-borrow-check-negative.borrow-check.out
@@ -5,5 +5,5 @@ Compiler source: interp/InterpBorrows.ml, line 1203
 Name pattern: 'loops_borrow_check_negative::loop_a_b'
 Definition span: 'tests/src/loops-borrow-check-negative.rs', lines 20:0-30:1
 Source: 'tests/src/loops-borrow-check-negative.rs', lines 20:0-30:1
-Compiler source: interp/Interp.ml, line 562
+Compiler source: interp/Interp.ml, line 602
 

--- a/tests/src/loops-borrow-check-negative.borrow-check.out
+++ b/tests/src/loops-borrow-check-negative.borrow-check.out
@@ -5,5 +5,5 @@ Compiler source: interp/InterpBorrows.ml, line 1203
 Name pattern: 'loops_borrow_check_negative::loop_a_b'
 Definition span: 'tests/src/loops-borrow-check-negative.rs', lines 20:0-30:1
 Source: 'tests/src/loops-borrow-check-negative.rs', lines 20:0-30:1
-Compiler source: interp/Interp.ml, line 550
+Compiler source: interp/Interp.ml, line 562
 

--- a/tests/src/mutually-recursive-traits.lean.out
+++ b/tests/src/mutually-recursive-traits.lean.out
@@ -3,5 +3,5 @@
 Trait declaration: mutually_recursive_traits::Trait1
 Source: Source: 'tests/src/mutually-recursive-traits.rs', lines 5:0-7:1
 Source: 'tests/src/mutually-recursive-traits.rs', lines 5:0-7:1
-Compiler source: symbolic/SymbolicToPure.ml, line 216
+Compiler source: symbolic/SymbolicToPure.ml, line 222
 


### PR DESCRIPTION
More preparation for https://github.com/AeneasVerif/charon/issues/1148: this PR clears up the distinction between actual function items (keyed by `FunDeclId`) and abstract trait methods (keyed by `(TraitDeclId, TraitMethodId)`).