### PR TITLE
Feat/range iterator next step spec

### DIFF
--- a/backends/lean/Aeneas/Std/Core.lean
+++ b/backends/lean/Aeneas/Std/Core.lean
@@ -10,6 +10,7 @@ import Aeneas.Std.Core.Fmt
 import Aeneas.Std.Core.FmtWithSlice
 import Aeneas.Std.Core.Hash
 import Aeneas.Std.Core.Iter
+import Aeneas.Std.Core.IterSpec
 import Aeneas.Std.Core.Marker
 import Aeneas.Std.Core.Ops
 import Aeneas.Std.Core.Panic

--- a/backends/lean/Aeneas/Std/Core/IterSpec.lean
+++ b/backends/lean/Aeneas/Std/Core/IterSpec.lean
@@ -1,0 +1,64 @@
+/- Specs for the `core::iter` iterators.
+
+   The iterator `next` functions (Core/Iter.lean) are extracted as plain `def`s
+   with no reasoning lemmas, so `progress` / `let*` cannot step through a
+   `for i in a..b` loop: every downstream project re-derives a `next` lemma by
+   hand. This file provides the missing `@[step]` spec for the `usize` range
+   iterator, the overwhelmingly common case. -/
+import Aeneas.Std.Core.Iter
+import Aeneas.Tactic.Step.Init
+
+namespace Aeneas.Std
+
+open Result Error WP
+
+/-- **Spec for the `usize` range iterator's `next`** (the engine of
+    `for i in a..b`): while `start < end` it yields `start` and advances the range
+    by one; otherwise it reports exhaustion, leaving the range unchanged.
+
+    Registered `@[step]` so `progress` / `let*` step straight through range-`for`
+    loops. The result is deterministic, so a single spec with an `if` postcondition
+    suffices; callers `split` on `start < end`. -/
+@[step]
+theorem core.iter.range.IteratorRange.next_StepUsize_spec
+    (r : core.ops.range.Range Usize) :
+    core.iter.range.IteratorRange.next core.iter.range.StepUsize r
+      ⦃ res =>
+        if r.start.val < r.«end».val then
+          res.1 = some r.start ∧ res.2.start.val = r.start.val + 1 ∧ res.2.«end» = r.«end»
+        else res.1 = none ∧ res.2 = r ⦄ := by
+  by_cases h : r.start.val < r.«end».val
+  · have hcmp : core.iter.range.StepUsize.partialOrdInst.lt r.start r.«end» = ok true := by
+      show liftFun2 core.cmp.impls.PartialOrdUsize.lt r.start r.«end» = ok true
+      simp [liftFun2, core.cmp.impls.PartialOrdUsize.lt, h]
+    have hck := core.num.checked_add_UScalar_bv_spec r.start 1#usize
+    have h1 : (1#usize).val = 1 := rfl
+    cases hopt : core.num.checked_add_UScalar r.start 1#usize
+    · -- overflow ⇒ impossible: `r.start < r.end ≤ usize::MAX`
+      rw [hopt] at hck
+      exfalso
+      rw [h1] at hck
+      scalar_tac
+    · -- `r.start + 1` is in range
+      rename_i w
+      rw [hopt] at hck
+      have heval : core.iter.range.IteratorRange.next core.iter.range.StepUsize r
+          = ok (some r.start, { r with start := w }) := by
+        unfold core.iter.range.IteratorRange.next
+        rw [hcmp]
+        simp only [bind_tc_ok, reduceIte, liftFun1, core.clone.impls.CloneUsize.clone]
+        unfold core.iter.range.StepUsize.forward_checked
+        simp only [Usize.checked_add, hopt, bind_tc_ok]
+      rw [heval, WP.spec_ok, if_pos h]
+      exact ⟨rfl, by rw [hck.2.1, h1], rfl⟩
+  · have hcmp : core.iter.range.StepUsize.partialOrdInst.lt r.start r.«end» = ok false := by
+      show liftFun2 core.cmp.impls.PartialOrdUsize.lt r.start r.«end» = ok false
+      simp [liftFun2, core.cmp.impls.PartialOrdUsize.lt, h]
+    have heval : core.iter.range.IteratorRange.next core.iter.range.StepUsize r = ok (none, r) := by
+      unfold core.iter.range.IteratorRange.next
+      rw [hcmp]
+      simp only [bind_tc_ok, Bool.false_eq_true, reduceIte]
+    rw [heval, WP.spec_ok, if_neg h]
+    exact ⟨rfl, rfl⟩
+
+end Aeneas.Std

--- a/backends/lean/Aeneas/Tactic/Step/Tests/RangeLoop.lean
+++ b/backends/lean/Aeneas/Tactic/Step/Tests/RangeLoop.lean
@@ -1,0 +1,30 @@
+import Aeneas.Std
+import Aeneas.Tactic.Step
+
+open Aeneas Aeneas.Std Result ControlFlow WP
+
+namespace range_loop_test
+
+/-- Regression for `IteratorRange.next_StepUsize_spec`: a range-`for` loop
+    (`for _ in r {}`, the `loop` + `next` shape Aeneas extracts) is total, proven
+    by `step` auto-applying the `@[step]` `next` spec — no hand-written `next`
+    lemma. Aeneas extracts range loops but the suite otherwise proves none. -/
+example (r : core.ops.range.Range Usize) :
+    loop (fun iter => do
+      let (o, iter') ← core.iter.range.IteratorRange.next core.iter.range.StepUsize iter
+      match o with
+      | none => ok (ControlFlow.done ())
+      | some _ => ok (ControlFlow.cont iter')) r
+    ⦃ (_ : Unit) => True ⦄ := by
+  apply loop.spec_decr_nat (measure := fun s => s.«end».val - s.start.val) (inv := fun _ => True)
+  · intro s _
+    step as ⟨o, iter2, hpost⟩
+    by_cases h : s.start.val < s.«end».val
+    · obtain ⟨ho, hstart, hend⟩ := by simpa only [h, if_true] using hpost
+      simp only [ho, WP.spec_ok, hstart, hend]
+      scalar_tac
+    · obtain ⟨ho, -⟩ := by simpa only [h, if_false] using hpost
+      simp only [ho, WP.spec_ok]
+  · trivial
+
+end range_loop_test


### PR DESCRIPTION
Closes #1132.

The `usize` range iterator's `next` ships with no reasoning lemma, so `step`
can't drive a `for i in a..b` loop. This adds a deterministic `@[step]` WP spec
for it (`Std/Core/IterSpec.lean`, wired into `Std/Core`), plus a regression test
proving a range-`for` loop total via the spec (`Tactic/Step/Tests/RangeLoop.lean`).
Full lib and `tests/lean` build green; `#print axioms` is the three standard ones.

I specced `StepUsize` only, the one `Step` instance today. Happy to generalize
over `Step` if you'd prefer.