### PR TITLE
Fix a minor issue in step

### DIFF
--- a/backends/lean/Aeneas/Tactic/Step/Step.lean
+++ b/backends/lean/Aeneas/Tactic/Step/Step.lean
@@ -716,7 +716,7 @@ def introOutputs (args : Args) (fExpr : Expr) (stepState : StepState) :
                 #[``Std.uncurry_apply_pair,
                   ``Std.uncurry_eq_prop, ``Std.uncurry_eq_prop_arrow,
                   ``Std.WP.uncurry'_pair, ``Std.WP.uncurry'_eq,
-                  ``and_imp, ``forall_unit, ``true_imp_iff] ++ scalar_eqs }
+                  ``and_imp, ``exists_imp, ``forall_unit, ``true_imp_iff] ++ scalar_eqs }
             (.targets #[] true)
   if (← getUnsolvedGoals).isEmpty then trace[Step] "Main goal solved by cleanup simp!"; return none
 

--- a/backends/lean/Aeneas/Tactic/Step/Tests/IntroOutputs.lean
+++ b/backends/lean/Aeneas/Tactic/Step/Tests/IntroOutputs.lean
@@ -445,6 +445,41 @@ h : y = z + 1
 example : (do let (x, y) ← existentialProg; ok (x + y)) ⦃ res => res > 2 ⦄ := by
   step with existentialProg_spec as ⟨ x, y, hx, z, hz, h ⟩
 
+/- A *nested*-tuple result combined with a *leading* existential in the post.
+   The post's `∃` only becomes visible after the output is destructured, so it
+   must be split by the post-destructure cleanup pass. -/
+def nestedExistentialProg : Result ((Nat × Nat) × Nat) := ok ((1, 2), 3)
+
+@[step]
+theorem nestedExistentialProg_spec :
+    nestedExistentialProg ⦃ (a, b) c => ∃ (_ : a = 1), b = 2 ∧ c = 3 ⦄ := by
+  unfold nestedExistentialProg; exact ⟨rfl, rfl, rfl⟩
+
+/--
+info: Try this:
+
+  [apply]     let* ⟨ a, b, c, a_post1, a_post2, a_post3 ⟩ ← nestedExistentialProg_spec
+    agrind
+-/
+#guard_msgs in
+example :
+    (do let ((a, b), c) ← nestedExistentialProg; ok (a + b + c)) ⦃ x => x = 6 ⦄ := by
+  step*?
+
+/--
+error: unsolved goals
+case a
+c a b : ℕ
+ha : a = 1
+hb : b = 2
+hc : c = 3
+⊢ a + b + c = 6
+-/
+#guard_msgs in
+example :
+    (do let ((a, b), c) ← nestedExistentialProg; ok (a + b + c)) ⦃ x => x = 6 ⦄ := by
+  step with nestedExistentialProg_spec as ⟨ a, b, c, ha, hb, hc ⟩
+
 -- Testing that we don't destructure too far when we don't have to
 
 section


### PR DESCRIPTION
`step` would not properly destructure some existentials appearing in post-conditions after https://github.com/AeneasVerif/aeneas/pull/1047