### PR TITLE
Add a prepass to normalize the type of `Box::new`

### DIFF
--- a/src/PrePasses.ml
+++ b/src/PrePasses.ml
@@ -2242,9 +2242,35 @@ let fix_closure_lifetimes (crate : crate) (f : fun_decl) : fun_decl =
           f
       | _, _ -> f)
 
+(** Normalize the generics of the calls to [Box::new].
+
+    [Box::new] has two generic arguments, the type of the allocated element and
+    the type of the allocator itself. Charon generally filters the second one
+    but not always: this pass addresses this issue. *)
+let normalize_box_new (crate : crate) : crate =
+  let visitor =
+    object
+      inherit [_] map_crate_with_span as super
+
+      method! visit_fn_ptr env fn_ptr =
+        match fn_ptr.kind with
+        | FunId (FBuiltin BoxNew) ->
+            (* Keep only the first one and drop the others (the allocator). *)
+            let generics =
+              match fn_ptr.generics.types with
+              | ty :: _ :: _ -> { fn_ptr.generics with types = [ ty ] }
+              | _ -> fn_ptr.generics
+            in
+            super#visit_fn_ptr env { fn_ptr with generics }
+        | _ -> super#visit_fn_ptr env fn_ptr
+    end
+  in
+  visitor#visit_crate None crate
+
 let apply_passes (crate : crate) : crate =
   (* Passes that apply to the whole crate *)
   let crate = update_array_default crate in
+  let crate = normalize_box_new crate in
   (* Passes that apply to individual function bodies *)
   let function_passes =
     [

--- a/tests/lean/Vec.lean
+++ b/tests/lean/Vec.lean
@@ -38,4 +38,11 @@ def from_elem
   := do
   alloc.vec.from_elem corecloneCloneInst x n
 
+/-- [vec::singleton]:
+    Source: 'tests/src/vec.rs', lines 17:0-19:1 -/
+def singleton {T : Type} (x : T) : Result (alloc.vec.Vec T) := do
+  let y ←
+    lift (Std.Array.to_slice (Array.make 1#usize [ x ] : Array T 1#usize))
+  ok (alloc.slice.Slice.into_vec y)
+
 end vec

--- a/tests/src/vec.rs
+++ b/tests/src/vec.rs
@@ -13,3 +13,7 @@ fn use_alloc_with_capacity<T>(n: usize) -> Vec<T> {
 fn from_elem<T: Clone>(x: T, n: usize) -> Vec<T> {
     std::vec::from_elem(x, n)
 }
+
+fn singleton<T>(x: T) -> Vec<T> {
+    vec![x]
+}


### PR DESCRIPTION
This PR adds a prepass that drops the allocator type from `Box::new` when it is present.
This is a workaround for https://github.com/AeneasVerif/charon/issues/1297