### PR TITLE
Update the OCaml dependencies in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,9 @@ opam switch create 5.3.0
 
 You can then install the dependencies with the following command:
 ```
-opam install ppx_deriving visitors easy_logging zarith yojson core_unix odoc \
-  ocamlgraph menhir ocamlformat.0.27.0 unionFind zarith progress domainslib
+opam install calendar core_unix domainslib easy_logging menhir \
+  ocamlformat.0.27.0 ocamlgraph odoc ppx_deriving ppx_deriving_yojson \
+  progress unionFind visitors yojson zarith
 ```
 
 Moreover, Aeneas uses the [Charon](https://github.com/AeneasVerif/charon) project and library.


### PR DESCRIPTION
The `opam` command line was missing package `ppx_deriving_yojson` and listed `zarith` twice. Update the list of packages and sort it.

Fixes: https://github.com/AeneasVerif/aeneas/issues/1171

(I did not use AI to work on this PR)