### PR TITLE
fix: pass commit sha into nix container when running release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,14 @@ jobs:
         run: |
           set -eo pipefail
 
-          TAG_NAME="nightly-$(date +'%Y.%m.%d')"
+          SHORT_SHA="$(git rev-parse --short HEAD)"
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            # Manual run
+            TAG_NAME="build-${SHORT_SHA}"
+          else
+            # Scheduled run
+            TAG_NAME="nightly-$(date +'%Y.%m.%d')-${SHORT_SHA}"
+          fi
           echo "tag_name=${TAG_NAME}" >> "$GITHUB_OUTPUT"
 
       - name: Create Release
@@ -81,10 +88,14 @@ jobs:
           restore-prefixes-first-match: ${{ matrix.os }}-release
 
       - name: Package
+        env:
+          # The release tag reported by `aeneas -version`.
+          # `--impure` is required for nix to read the env var.
+          AENEAS_RELEASE_VERSION: ${{ needs.prepare.outputs.tag_name }}
         run: |
           set -eo pipefail
 
-          nix build -L .#${{ matrix.nix_attr }}
+          nix build -L --impure .#${{ matrix.nix_attr }}
           mkdir dist_staging
           cp -R result/. dist_staging/
           # Nix preserves read-only permissions from the store, so we must make files writable.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,11 +90,11 @@ jobs:
       - name: Package
         env:
           # The release tag reported by `aeneas -version`.
-          # `--impure` is required for nix to read the env var.
           AENEAS_RELEASE_VERSION: ${{ needs.prepare.outputs.tag_name }}
         run: |
           set -eo pipefail
 
+          # Pass `--impure` so that nix can read `AENEAS_RELEASE_VERSION`
           nix build -L --impure .#${{ matrix.nix_attr }}
           mkdir dist_staging
           cp -R result/. dist_staging/
@@ -140,6 +140,8 @@ jobs:
 
       # Verify the binary is functional.
       - name: Smoke Test
+        env:
+          AENEAS_RELEASE_VERSION: ${{ needs.prepare.outputs.tag_name }}
         run: |
           set -eo pipefail
 
@@ -147,6 +149,14 @@ jobs:
           cd staging
           tar xf ../${{ matrix.artifact_name }}.tar.gz
           ./aeneas --help > /dev/null
+
+          # Verify the reported version matches the release tag
+          version_output="$(./aeneas -version)"
+          expected="aeneas ${AENEAS_RELEASE_VERSION}"
+          if [[ "$version_output" != "$expected" ]]; then
+            echo "Version mismatch: expected '$expected', got '$version_output'" >&2
+            exit 1
+          fi
 
       - name: Upload Artifact
         uses: softprops/action-gh-release@v2

--- a/flake.nix
+++ b/flake.nix
@@ -80,6 +80,11 @@
         charon-release = inputs.charon.packages.${system}.charon-release;
         charon-ml = inputs.charon.packages.${system}.charon-ml.override { inherit ocamlPackages; };
 
+        # The version embedded into the `aeneas` binary (reported by `aeneas -version`).
+        commitSha = self.shortRev or self.dirtyShortRev or "unknown";
+        releaseVersion = builtins.getEnv "AENEAS_RELEASE_VERSION";
+        aeneasVersion = if releaseVersion != "" then releaseVersion else commitSha;
+
         easy_logging = pkgs.callPackage
           ({ fetchFromGitHub, ocamlPackages }:
             ocamlPackages.buildDunePackage rec {
@@ -110,6 +115,7 @@
               duneVersion = "3";
               src = ./src;
               OCAMLPARAM = "_,warn-error=+A"; # Turn all warnings into errors.
+              AENEAS_VERSION = aeneasVersion;
               propagatedBuildInputs = [
                 easy_logging
                 charon-ml

--- a/src/dune
+++ b/src/dune
@@ -126,9 +126,12 @@
   Values
   ValuesUtils))
 
-;; Embed the git commit into the binary so that `aeneas -version` can report it.
+;; Embed the version into the binary so that `aeneas -version` can report it.
 ;; Follows the same pattern as opam (see https://github.com/ocaml/opam/blob/master/src/client/dune).
-;; Step 1: capture the git description (commit hash, with -dirty suffix if needed).
+;; Step 1: capture the version string. If the `AENEAS_VERSION` environment
+;; variable is set (e.g. by the Nix release build, which has no access to the
+;; git history inside its sandbox) we use it directly; otherwise we fall back to
+;; the git description (commit hash, with -dirty suffix if needed).
 
 (rule
  (target git-sha)
@@ -137,7 +140,8 @@
   (ignore-stderr
    (with-stdout-to
     %{target}
-    (system "git describe --always --dirty 2>/dev/null || echo")))))
+    (system
+     "if [ -n \"$AENEAS_VERSION\" ]; then echo \"$AENEAS_VERSION\"; else git describe --always --dirty 2>/dev/null || echo; fi")))))
 
 ;; Step 2: generate GitVersion.ml from the captured hash.
 ;; Produces `let commit = Some "<hash>"` or `let commit = None` if git is unavailable.


### PR DESCRIPTION
This PR fixes the issue that all recent `aeneas` releases report `unknown` when running `aeneas -version`. This happens because the nix build happens in a sandbox without access to the git commit. To fix it, we pass the desired version string into nix via environment variables.

In addition, I made a switch to produce different GitHub tags and version strings depending on whether it was a scheduled nightly or a manually triggered build.

I tested the setup here: https://github.com/cryspen/aeneas/actions/runs/27696222469/job/81920104263
It resulted in this build that reports the version correctly: https://github.com/cryspen/aeneas/releases/tag/build-cc3aad2

AI disclaimer: Claude made the initial draft, but I tested and refined it.
