### PR TITLE
Upload precompiled oleans for release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,6 +129,12 @@ jobs:
             "$script"
           fi
 
+      - name: Upload Lean oleans
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ needs.prepare.outputs.tag_name }}
+          files: dist_staging/backends/lean/.lake/aeneas-*.tar.gz
+
       - name: Re-package Tarball
         run: |
           set -eo pipefail

--- a/backends/lean/lakefile.lean
+++ b/backends/lean/lakefile.lean
@@ -5,7 +5,8 @@ open Lake DSL
 require mathlib from git
   "https://github.com/leanprover-community/mathlib4.git" @ "v4.30.0-rc2"
 
-package «aeneas» {}
+package «aeneas» where
+  preferReleaseBuild := true
 
 @[default_target] lean_lib «Aeneas» {}
 

--- a/scripts/ci-precompile-lean.sh
+++ b/scripts/ci-precompile-lean.sh
@@ -13,5 +13,9 @@ fi
 # required for plugin loading.
 CI="" lake build
 
+# Pack prebuilt oleans into an archive for Lake's automatic olean download.
+# Users who pin to a release tag get these instead of compiling from source.
+lake pack
+
 # Delete heavy dependency sources to keep the release archive small.
 rm -rf .lake/packages


### PR DESCRIPTION
Building the Aeneas Lean lib takes a long time. This PR solves that problem for downstream users by offering prebuilt olean files on GitHub that lake will pick up automatically.

To enable this Lake feature, we need to run `lake pack` and upload the resulting files when we make a release. Also, we enable the `preferReleaseBuild` option in our `lakefile`, so that `lake` will look for the oleans on GitHub when a user runs `lake build` on a project depending on aeneas.

Disclaimer: I haven't been able to test this yet.