### PR TITLE
ci: better name for the lean build archive

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,7 +133,7 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ needs.prepare.outputs.tag_name }}
-          files: dist_staging/backends/lean/.lake/aeneas-*.tar.gz
+          files: dist_staging/backends/lean/.lake/lean-build-aeneas-*.tar.gz
 
       - name: Re-package Tarball
         run: |

--- a/backends/lean/lakefile.lean
+++ b/backends/lean/lakefile.lean
@@ -7,6 +7,7 @@ require mathlib from git
 
 package «aeneas» where
   preferReleaseBuild := true
+  buildArchive := s!"lean-build-aeneas-{System.Platform.target}.tar.gz"
 
 @[default_target] lean_lib «Aeneas» {}
 


### PR DESCRIPTION
We should use a better name for the lean archive to distinguish it from the binary release.

According to `lake pack --help`, it respects the `buildArchive` setting:
```
$ lake pack --help
Pack build artifacts into an archive for distribution

USAGE:
  lake pack [<file.tgz>]

Packs the root package's `buildDir` into a gzip tar archive using `tar`.
If a path for the archive is not specified, creates an archive in the package's
Lake directory (`.lake`) named according to its `buildArchive` setting.

Does NOT build any artifacts. It just packs the existing ones.
```