### PR TITLE
fix: Run release build with `CI` variable unset

### DIFF
--- a/scripts/ci-precompile-lean.sh
+++ b/scripts/ci-precompile-lean.sh
@@ -3,15 +3,17 @@ set -eo pipefail
 
 elan default "$(cat lean-toolchain)"
 
+# Unset CI to force precompilation of modules, which is disabled by default in
+# CI in lakefile.lean. This ensures releases contain the shared libraries
+# required for plugin loading.
+unset CI
+
 # Fetch pre-compiled Mathlib binaries.
 if ! lake exe cache get; then
   echo "::warning::Mathlib cache extraction failed; continuing with source build"
 fi
 
-# Unset CI to force precompilation of modules, which is disabled by default in
-# CI in lakefile.lean. This ensures releases contain the shared libraries
-# required for plugin loading.
-CI="" lake build
+lake build
 
 # Pack prebuilt oleans into an archive for Lake's automatic olean download.
 # Users who pin to a release tag get these instead of compiling from source.


### PR DESCRIPTION
The line `CI="" lake build` did not truly disable the CI environment variable because the lakefile considers the empty string to mean true.

AI disclaimer: I used Claude for debugging the issue.