### PR TITLE
Fix translation of nested shared borrow used in loop

### DIFF
--- a/src/interp/InterpMatchCtxs.ml
+++ b/src/interp/InterpMatchCtxs.ml
@@ -215,10 +215,18 @@ let compute_abs_borrows_loans_maps (span : Meta.span) (explore : abs -> bool)
         | ASharedBorrow (npm, bid, sid) ->
             (* Add the current marker when visiting the borrow id *)
             register_borrow_id abs npm bid (Some sid)
-        | AProjSharedBorrow _ ->
+        | AProjSharedBorrow asb ->
             [%sanity_check] span (pm = PNone);
-            (* Process those normally *)
-            super#visit_aborrow_content (abs, pm) bc
+            (* Register the concrete shared borrows nested inside the projection.
+               We can't call super here because it would trigger visit_borrow_id
+               (which raises an internal error) for the AsbBorrow entries. *)
+            List.iter
+              (fun ab ->
+                match ab with
+                | AsbBorrow (bid, sid) ->
+                    register_borrow_id abs PNone bid (Some sid)
+                | AsbProjReborrows _ -> ())
+              asb
         | AIgnoredMutBorrow (_, child)
         | AEndedIgnoredMutBorrow { child; given_back = _; given_back_meta = _ }
           ->
@@ -226,6 +234,13 @@ let compute_abs_borrows_loans_maps (span : Meta.span) (explore : abs -> bool)
             (* Ignore the id of the borrow, if there is *)
             self#visit_tavalue (abs, pm) child
         | AEndedMutBorrow _ | AEndedSharedBorrow -> [%craise] span "Unreachable"
+
+      (** Ignore concrete borrows inside shared loan values (e.g., the shared
+          value [sv] of [ASharedLoan (_, _, sv, _)] can contain concrete borrows
+          when the type has nested references). These borrows are already
+          tracked via [ASharedBorrow] entries in the corresponding borrow
+          abstractions. *)
+      method! visit_borrow_content _ _ = ()
 
       method! visit_borrow_id _ _ = [%internal_error] span
       method! visit_loan_id (abs, pm) lid = register_loan_id abs pm lid
@@ -469,12 +484,15 @@ module MakeMatcher (M : PrimMatcher) : Matcher = struct
       ^ tavalue_to_string ~span:(Some M.span) ctx1 v1
       ^ "\n- ty1: " ^ ty_to_string ctx1 v1.ty];
 
-    (* Using ValuesUtils.value_has_borrows on purpose here: we want
+    (* Using ValuesUtils.value_has_mut_borrows on purpose here: we want
        to make explicit the fact that, though we have to pick
-       one of the two contexts (ctx0 here) to call value_has_borrows,
-       it doesn't matter here. *)
-    let value_has_borrows =
-      ValuesUtils.value_has_borrows (Some span) ctx0.type_ctx.type_infos
+       one of the two contexts (ctx0 here) to call value_has_mut_borrows,
+       it doesn't matter here.
+       Note: we use value_has_mut_borrows (not value_has_borrows) because
+       since PR #1187, shared values inside ASharedLoan can contain nested
+       VSharedBorrow entries. *)
+    let value_has_mut_borrows =
+      ValuesUtils.value_has_mut_borrows (Some span) ctx0.type_ctx.type_infos
     in
 
     let match_rec = match_tvalues ctx0 ctx1 in
@@ -549,7 +567,7 @@ module MakeMatcher (M : PrimMatcher) : Matcher = struct
             let sv = match_rec sv0 sv1 in
             let av = match_arec av0 av1 in
             [%sanity_check_recover] M.recover M.span
-              (not (value_has_borrows sv.value));
+              (not (value_has_mut_borrows sv.value));
             M.match_ashared_loans match_rec ctx0 ctx1 v0.ty pm0 id0 sv0 av0
               v1.ty pm1 id1 sv1 av1 ty sv av
         | AMutLoan (pm0, id0, av0), AMutLoan (pm1, id1, av1) ->

--- a/tests/lean/NestedSharedBorrows.lean
+++ b/tests/lean/NestedSharedBorrows.lean
@@ -17,6 +17,15 @@ noncomputable section
 
 namespace nested_shared_borrows
 
+/-- [core::ops::bit::{impl core::ops::bit::BitXorAssign<&'_0 u8> for u8}::bitxor_assign]:
+    Source: '/rustc/library/core/src/internal_macros.rs', lines 64:12-64:45
+    Name pattern: [core::ops::bit::{core::ops::bit::BitXorAssign<u8, &'0 u8>}::bitxor_assign]
+    Visibility: public -/
+@[rust_fun
+  "core::ops::bit::{core::ops::bit::BitXorAssign<u8, &'0 u8>}::bitxor_assign"]
+axiom U8.Insts.CoreOpsBitBitXorAssignShared0U8.bitxor_assign
+  : Std.U8 → Std.U8 → Result Std.U8
+
 /-- [core::option::{impl core::ops::try_trait::Try for core::option::Option<T>}::branch]:
     Source: '/rustc/library/core/src/option.rs', lines 2779:4-2779:64
     Name pattern: [core::option::{core::ops::try_trait::Try<core::option::Option<@T>>}::branch]
@@ -98,5 +107,46 @@ def S.method_try
   | core.ops.control_flow.ControlFlow.Break residual =>
     core.result.Result.Insts.CoreOpsTryTraitFromResidualResultInfallible.from_residual
       Std.U8 (core.convert.FromSame Unit) residual
+
+/-- [nested_shared_borrows::RefSlice]
+    Source: 'tests/src/nested-shared-borrows.rs', lines 54:0-56:1
+    Visibility: public -/
+structure RefSlice where
+  s : Slice Std.U8
+
+/-- [nested_shared_borrows::xor_slice]: loop body 0:
+    Source: 'tests/src/nested-shared-borrows.rs', lines 60:4-62:5
+    Visibility: public -/
+@[rust_loop_body]
+def xor_slice_loop.body
+  (iter : core.slice.iter.Iter Std.U8) (result : Std.U8) :
+  Result (ControlFlow ((core.slice.iter.Iter Std.U8) × Std.U8) Std.U8)
+  := do
+  let (o, iter1) ← core.slice.iter.IteratorSliceIter.next iter
+  match o with
+  | none => ok (done result)
+  | some x =>
+    let result1 ←
+      U8.Insts.CoreOpsBitBitXorAssignShared0U8.bitxor_assign result x
+    ok (cont (iter1, result1))
+
+/-- [nested_shared_borrows::xor_slice]: loop 0:
+    Source: 'tests/src/nested-shared-borrows.rs', lines 60:4-62:5
+    Visibility: public -/
+@[rust_loop]
+def xor_slice_loop
+  (iter : core.slice.iter.Iter Std.U8) (result : Std.U8) : Result Std.U8 := do
+  loop
+    (fun (iter1, result1) => xor_slice_loop.body iter1 result1)
+    (iter, result)
+
+/-- [nested_shared_borrows::xor_slice]:
+    Source: 'tests/src/nested-shared-borrows.rs', lines 58:0-64:1
+    Visibility: public -/
+def xor_slice (rs : RefSlice) : Result Std.U8 := do
+  let iter ←
+    SharedSlice.Insts.CoreIterTraitsCollectIntoIteratorSharedIter.into_iter
+      rs.s
+  xor_slice_loop iter 0#u8
 
 end nested_shared_borrows

--- a/tests/src/nested-shared-borrows.rs
+++ b/tests/src/nested-shared-borrows.rs
@@ -49,3 +49,16 @@ impl<'a> S<'a> {
         Ok(y)
     }
 }
+
+// Loop on a structure holding a reference to a slice
+pub struct RefSlice<'a> {
+    pub s: &'a [u8],
+}
+
+pub fn xor_slice(rs: &RefSlice<'_>) -> u8 {
+    let mut result = 0;
+    for x in rs.s {
+        result ^= x;
+    }
+    result
+}


### PR DESCRIPTION
Hello,

After Pull Request #1187 fixed the simple reproducer from #1099, I tried to use Aeneas again on [some simple Rust code using nested shared borrow](https://github.com/LedgerHQ/app-sui/blob/e4176c8e0412da8417f4315799679246b87db7c2/rust-app/src/crypto_helpers/common.rs#L17-L28) and it failed. A minimal reproducer is:

```rust
pub struct RefSlice<'a> {
    pub s: &'a [u8],
}

pub fn xor_slice(rs: &RefSlice<'_>)  {
    for _ in rs.s {
    }
}
```

```text
$ aeneas -backend=lean -print-error-emitters mytest.llbc 
...
[Error] Internal error, please file an issue
Source: 'src/lib.rs', lines 6:4-7:5
Compiler source: interp/InterpMatchCtxs.ml, line 230
[Warn ] Could not translate the body of function 'mytest::xor_slice because of previous error
Name pattern: 'mytest::xor_slice'
Definition span: 'src/lib.rs', lines 5:0-8:1
Source: 'src/lib.rs', lines 6:4-7:5
Compiler source: interp/Interp.ml, line 609
```

The error occurs in https://github.com/AeneasVerif/aeneas/blob/bd30f6076f5d9a7f6c1db1b067e5aa43e7af4691/src/interp/InterpMatchCtxs.ml#L230

I wrote a test (in `tests/src/nested-shared-borrows.rs`) and let Claude Code with Sonnet 4.6 tell me what was going on and suggest me what was failing. It wrote a patch and explained:

> Root cause: PR #1187 introduced nested `VSharedBorrow` entries inside `ASharedLoan` shared values. This broke four code paths that assumed shared values had no borrows.
>
> Fix 1 — `explore_abs` visitor, `AProjSharedBorrow` case:
> Explicitly iterate `AsbBorrow` entries and call `register_borrow_id`, instead of calling `super` which triggered the `visit_borrow_id` internal error guard.
>
> Fix 2 — `explore_abs` visitor, `visit_borrow_content`:
> Added `method! visit_borrow_content _ _ = ()` to silence concrete borrows inside abstract values. The `ASharedLoan` shared value (which now contains `VSharedBorrow`) was triggering the `visit_borrow_id` `[%internal_error]` guard.
>
> Fix 3 — [I am removing this "fix" as it was actually some misunderstanding about what `phys_eq` does: the AI wanted to replace it with `not (equal_tvalue ...)`]
>
> Fix 4 — `ASharedLoan` matching sanity check:
> Changed `value_has_borrows sv.value` → `value_has_mut_borrows sv.value` in the `[%sanity_check_recover]` after matching a shared loan's concrete value. Shared values can now contain nested shared borrows (`VSharedBorrow`) by design, but still cannot contain mutable borrows.

I edited the changes to be comfortable with them (and I verified the test suite passes). Could you please review?