### PR TITLE
Improve the WP elaborator to support grouped binders

### DIFF
--- a/backends/lean/Aeneas/Std/WP.lean
+++ b/backends/lean/Aeneas/Std/WP.lean
@@ -303,15 +303,6 @@ partial def mkBinderFun (depth : Nat) (binder : Term) (body : Term) : MacroM Ter
     buildUncurryLam leafIdents wrappedBody
   | _ => `(fun $binder => $body)
 
-/-- Macro expansion for a single element -/
-macro_rules
-  | `($e ⦃ $x => $p ⦄) => do
-    let post ← mkBinderFun 0 x p
-    `(Aeneas.Std.WP.spec $e $post)
-  | `($e ⦃ $x => $p ⦄div) => do
-    let post ← mkBinderFun 0 x p
-    `(Aeneas.Std.WP.dspec $e $post)
-
 def mk_function_syntax (p : TSyntax `term) (depth : Nat) (xs : List Term) : MacroM Term := do
   match xs with
   | [] => `($p)
@@ -321,15 +312,60 @@ def mk_function_syntax (p : TSyntax `term) (depth : Nat) (xs : List Term) : Macr
     let inner ← mkBinderFun depth x xs
     `(uncurry' $inner)
 
+/-- If `stx` is a bare identifier or a juxtaposition (application) of bare
+identifiers — i.e. a binder group like `a b c` — return the identifiers in
+order.  Otherwise return `none`, so anonymous constructors `⟨a, b⟩`, tuple
+patterns, and other structured terms are left untouched. -/
+private partial def binderGroupIdents? (stx : Syntax) : Option (Array Term) :=
+  if stx.isIdent then some #[⟨stx⟩]
+  else if stx.getKind == ``Lean.Parser.Term.app || stx.getKind == Lean.nullKind then
+    stx.getArgs.foldlM (init := (#[] : Array Term)) fun acc s =>
+      (binderGroupIdents? s).map (acc ++ ·)
+  else none
+
+/-- Expand a binder that shares one type ascription across several names —
+`(a b c : T)` — into the list of single binders `[(a : T), (b : T), (c : T)]`,
+so each name becomes its own product component (exactly as if written
+separately).  Tuple/pattern binders `(a, b)`, `(⟨a, b⟩ : T)`, single binders
+`(a : T)`, and bare identifiers are returned unchanged. -/
+private def expandGroupedBinder (binder : Term) : MacroM (List Term) := do
+  match binder with
+  | `(($e : $t)) =>
+    match binderGroupIdents? e.raw with
+    | some ids =>
+      if ids.size ≤ 1 then pure [binder]
+      else ids.toList.mapM fun id => `(($id : $t))
+    | none => pure [binder]
+  | _ => pure [binder]
+
+/-- Flatten grouped binders across the whole binder list. -/
+private def expandBinders (xs : List Term) : MacroM (List Term) := do
+  let mut out : Array Term := #[]
+  for x in xs do
+    out := out ++ (← expandGroupedBinder x).toArray
+  pure out.toList
+
+/-- Build the postcondition term for `⦃ xs => p ⦄`, expanding grouped binders
+into one component per name first. -/
+private def mkPost (p : Term) (xs : List Term) : MacroM Term := do
+  mk_function_syntax p 0 (← expandBinders xs)
+
+/-- Macro expansion for a single element (may expand to several via a grouped binder) -/
+macro_rules
+  | `($e ⦃ $x => $p ⦄) => do
+    let post ← mkPost p [x]
+    `(Aeneas.Std.WP.spec $e $post)
+  | `($e ⦃ $x => $p ⦄div) => do
+    let post ← mkPost p [x]
+    `(Aeneas.Std.WP.dspec $e $post)
+
 /-- Macro expansion for multiple elements -/
 macro_rules
   | `($e ⦃ $x $xs:term* => $p ⦄) => do
-    let xs := x :: xs.toList
-    let post ← mk_function_syntax p 0 xs
+    let post ← mkPost p (x :: xs.toList)
     `(Aeneas.Std.WP.spec $e $post)
   | `($e ⦃ $x $xs:term* => $p ⦄div) => do
-    let xs := x :: xs.toList
-    let post ← mk_function_syntax p 0 xs
+    let post ← mkPost p (x :: xs.toList)
     `(Aeneas.Std.WP.dspec $e $post)
 
 /-- Macro expansion for predicate with no arrow -/

--- a/backends/lean/Aeneas/Tactic/Step/Tests/TupleDestruct.lean
+++ b/backends/lean/Aeneas/Tactic/Step/Tests/TupleDestruct.lean
@@ -4,32 +4,32 @@ import Aeneas.Tactic.Step
 
 open Aeneas Aeneas.Std Result
 
-namespace step_tuple_destruct
+namespace Aeneas.Tactic.Step.Tests.TupleDestruct
 
-def twoNats : Result (Nat × Nat) :=
+private def twoNats : Result (Nat × Nat) :=
   ok (1, 2)
 
-def threeNats : Result (Nat × Nat × Nat) :=
+private def threeNats : Result (Nat × Nat × Nat) :=
   ok (1, 2, 3)
 
-@[step]
-theorem twoNats_spec : twoNats ⦃ a b => a = 1 ∧ b = 2⦄ := by unfold twoNats; step*
+@[local step]
+private theorem twoNats_spec : twoNats ⦃ a b => a = 1 ∧ b = 2⦄ := by unfold twoNats; step*
 
-@[step]
-def threeNats_spec : threeNats ⦃ a b c => a = 1 ∧ b = 2 ∧ c = 3⦄ := by unfold threeNats; step*
+@[local step]
+private def threeNats_spec : threeNats ⦃ a b c => a = 1 ∧ b = 2 ∧ c = 3⦄ := by unfold threeNats; step*
 
-def fourNats : Result ((Nat × Nat) × (Nat × Nat)) :=
+private def fourNats : Result ((Nat × Nat) × (Nat × Nat)) :=
   ok ((3, 4), (5, 6))
 
-@[step]
-theorem fourNats_spec : fourNats ⦃ (a, b) (c,d) => a = 3 ∧ b = 4 ∧ c = 5 ∧ d = 6⦄ := by
+@[local step]
+private theorem fourNats_spec : fourNats ⦃ (a, b) (c,d) => a = 3 ∧ b = 4 ∧ c = 5 ∧ d = 6⦄ := by
   unfold fourNats; step*
 
-def sixNats : Result (((Nat × Nat) × Nat) × ((Nat × Nat) × Nat)) :=
+private def sixNats : Result (((Nat × Nat) × Nat) × ((Nat × Nat) × Nat)) :=
   ok (((3, 4), 5), ((6, 7), 8))
 
-@[step]
-theorem sixNats_spec : sixNats ⦃ ((a, b), c) ((d, e), f) => a = 3 ∧ b = 4 ∧ c = 5 ∧ d = 6 ∧ e = 7 ∧ f = 8⦄ := by
+@[local step]
+private theorem sixNats_spec : sixNats ⦃ ((a, b), c) ((d, e), f) => a = 3 ∧ b = 4 ∧ c = 5 ∧ d = 6 ∧ e = 7 ∧ f = 8⦄ := by
   unfold sixNats; step*
 
 /--
@@ -82,7 +82,7 @@ The binding can be removed (if unused) or named `_` (if used implicitly).
 Note: This linter can be disabled with `set_option linter.unusedVariables false`
 -/
 #guard_msgs in
-def testTuples : Result Nat := do
+private def testTuples : Result Nat := do
   let (a, b) ← twoNats
   let (c, d) ← twoNats
   let ((a, b), (c, d)) ← fourNats
@@ -103,7 +103,7 @@ example : testTuples ⦃ res => res = 18⦄ := by
   unfold testTuples
   step*?
 
-def testTuples1 : Result Nat := do
+private def testTuples1 : Result Nat := do
   let (a, b, c) ← threeNats
   let (e, f, g) ← threeNats
   ok (a + b + c + e + f + g)
@@ -120,7 +120,7 @@ example : testTuples1 ⦃ res => res = 12⦄ := by
   unfold testTuples1
   step*?
 
-def testTuples2 : Result Nat := do
+private def testTuples2 : Result Nat := do
   let (((a, b), c), ((d, e), f)) ← sixNats
   ok (a + b + c + d + e + f)
 
@@ -135,4 +135,44 @@ example : testTuples2 ⦃ res => res = 33⦄ := by
   unfold testTuples2
   step*?
 
-end step_tuple_destruct
+/-! ## Grouped binders in postconditions
+
+Several names sharing one type ascription — `(a b c : Nat)` — expand to one
+product component per name, exactly as if the binders were written separately.
+Arity is irrelevant, and tuple *pattern* binders `(⟨…⟩ : T)` are unaffected. -/
+
+private def fiveNats : Result (Nat × Nat × Nat × Nat × Nat) :=
+  ok (1, 2, 3, 4, 5)
+
+/-- A single grouped binder covering every component. -/
+example :
+    fiveNats ⦃ (a b c d e : Nat) => a = 1 ∧ b = 2 ∧ c = 3 ∧ d = 4 ∧ e = 5 ⦄ := by
+  unfold fiveNats; step*
+
+/-- A grouped binder mixed with a bare binder and a smaller group. -/
+example :
+    fiveNats ⦃ a (b c : Nat) d e => a = 1 ∧ b = 2 ∧ c = 3 ∧ d = 4 ∧ e = 5 ⦄ := by
+  unfold fiveNats; step*
+
+/-- Grouping is independent of arity. -/
+example :
+    threeNats ⦃ (a b c : Nat) => a = 1 ∧ b = 2 ∧ c = 3 ⦄ := by
+  unfold threeNats; step*
+
+/-- Regression guard: a tuple *pattern* binder `(⟨…⟩ : T)` is NOT a grouped
+binder — its names destructure a single component, not one component each. -/
+example :
+    fiveNats ⦃ (⟨a, b, c, d, e⟩ : Nat × Nat × Nat × Nat × Nat) =>
+      a = 1 ∧ b = 2 ∧ c = 3 ∧ d = 4 ∧ e = 5 ⦄ := by
+  unfold fiveNats; step*
+
+private def natsAndBools : Result (Nat × Nat × Bool × Bool) :=
+  ok (1, 2, true, false)
+
+/-- A single grouped binder covering every component. -/
+@[local step]
+example :
+    natsAndBools ⦃ (a b : Nat) (c d : Bool) => a = 1 ∧ b = 2 ∧ c = true ∧ d = false ⦄ := by
+  unfold natsAndBools; step*
+
+end Aeneas.Tactic.Step.Tests.TupleDestruct


### PR DESCRIPTION
The following syntax was not supported: `⦃ (a b c : Nat) => ... ⦄`. It required doing `⦃ (a : Nat) (b : Nat) (c : Nat) => ... ⦄` instead.