### PR TITLE
Fix Usize inequality lifting in bvify

### DIFF
--- a/backends/lean/Aeneas/Tactic/Conv/Bvify/Bvify.lean
+++ b/backends/lean/Aeneas/Tactic/Conv/Bvify/Bvify.lean
@@ -277,12 +277,14 @@ theorem UScalar.le_equiv_bv_le {ty : UScalarTy} (x y : UScalar ty) : x ≤ y ↔
 @[bvify] theorem U32.lt_bv (x y : U32) : x < y ↔ x.bv < y.bv := by rfl
 @[bvify] theorem U64.lt_bv (x y : U64) : x < y ↔ x.bv < y.bv := by rfl
 @[bvify] theorem U128.lt_bv (x y : U128) : x < y ↔ x.bv < y.bv := by rfl
+@[bvify] theorem Usize.lt_bv (x y : Usize) : x < y ↔ x.bv < y.bv := by rfl
 
 @[bvify] theorem U8.le_bv  (x y : U8)  : x ≤ y ↔ x.bv ≤ y.bv := by rfl
 @[bvify] theorem U16.le_bv (x y : U16) : x ≤ y ↔ x.bv ≤ y.bv := by rfl
 @[bvify] theorem U32.le_bv (x y : U32) : x ≤ y ↔ x.bv ≤ y.bv := by rfl
 @[bvify] theorem U64.le_bv (x y : U64) : x ≤ y ↔ x.bv ≤ y.bv := by rfl
 @[bvify] theorem U128.le_bv (x y : U128) : x ≤ y ↔ x.bv ≤ y.bv := by rfl
+@[bvify] theorem Usize.le_bv (x y : Usize) : x ≤ y ↔ x.bv ≤ y.bv := by rfl
 
 def bvifyAddSimpThms (n : Expr) : TacticM (Array FVarId) := do
   let addThm (thName : Name) : TacticM FVarId := do

--- a/backends/lean/Aeneas/Tactic/Conv/Bvify/Tests.lean
+++ b/backends/lean/Aeneas/Tactic/Conv/Bvify/Tests.lean
@@ -45,3 +45,13 @@ example (a : U32) (ha : a.val < 2 * 3329)
     (i : U32) (hi2 : i.bv = res.bv >>> 16) :
     i = 0#u32 ∨ i = 65535#u32 := by
   bvify 32 at *
+
+/--
+error: unsolved goals
+a b : Usize
+h : a.bv < b.bv
+⊢ a.bv ≤ b.bv
+-/
+#guard_msgs in
+example (a b : Usize) (h : a < b) : a ≤ b := by
+  bvify System.Platform.numBits at *


### PR DESCRIPTION
This PR fixes a regression introduced by #1000 by adding the missing `Usize.lt_bv` and `Usize.le_bv` theorems for `bvify`.

Example proof hitting the regression: https://github.com/AeneasVerif/jxl-proofs/blob/f365cc22b372396949021d36c321f9033d0f326b/lean/JxlProofs/Proofs.lean#L86

Gemini was used to debug the issue and author the fix. I have reviewed the fix, confirmed that it fixes the issue, authored the commit, and created the PR.