### PR TITLE
test: minimal repro for GAT crash (issue #1195)

### DIFF
--- a/tests/src/gat_crash_repro.rs
+++ b/tests/src/gat_crash_repro.rs
@@ -1,0 +1,35 @@
+//! Minimal reproduction of issue #1195: aeneas hard crash related to certain GATs.
+//!
+//! This test case isolates the simplest pattern that triggers the crash so
+//! maintainers can reproduce and fix the underlying cause without needing
+//! the full original codebase.
+
+/// A GAT (generic associated type) with a lifetime parameter.
+pub trait Container {
+    type Item<'a>
+    where
+        Self: 'a;
+
+    fn get<'a>(&'a self) -> Self::Item<'a>;
+}
+
+/// Simple concrete implementation using a reference.
+pub struct Wrapper<T>(T);
+
+impl<T> Container for Wrapper<T> {
+    type Item<'a> = &'a T where Self: 'a;
+
+    fn get<'a>(&'a self) -> &'a T {
+        &self.0
+    }
+}
+
+/// Using the GAT through a generic bound — this pattern triggers the crash.
+pub fn use_container<C: Container>(c: &C) -> C::Item<'_> {
+    c.get()
+}
+
+pub fn main() {
+    let w = Wrapper(42u32);
+    let _val = use_container(&w);
+}


### PR DESCRIPTION
Adds tests/src/gat_crash_repro.rs — the smallest Rust program that triggers the hard crash reported in #1195.

The pattern: a trait with a lifetime-parameterized GAT, a concrete impl, and a generic function using the GAT through a bound. This isolates the crash from the original codebase so it can be reproduced and fixed independently.

Follows the style of existing test files (header comments, public items, minimal dependencies).