### PR TITLE
CI: do not use self-hosted runner on forks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
   workflow_dispatch:
 
 jobs:
+  select-runner:
+    uses: ./.github/workflows/select-runner.yml
+
   prepare:
     name: Prepare Release
     runs-on: ubuntu-latest
@@ -39,7 +42,7 @@ jobs:
 
   build:
     name: Build (${{ matrix.artifact_name }})
-    needs: prepare
+    needs: [prepare, select-runner]
     runs-on: ${{ matrix.os }}
     permissions:
       contents: write
@@ -48,10 +51,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: [self-hosted, linux, nix]
+          - os: ${{ fromJSON(needs.select-runner.outputs.runs_on) }}
             artifact_name: aeneas-linux-x86_64
             nix_attr: aeneas-static-release
-            nix_machine: true
+            nix_machine: ${{ contains(fromJSON(needs.select-runner.outputs.runs_on), 'nix') }}
           - os: ubuntu-24.04-arm
             artifact_name: aeneas-linux-aarch64
             nix_attr: aeneas-static-release
@@ -69,7 +72,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install nix
-        if: ${{ ! matrix.nix_machine }}
+        if: ${{ !matrix.nix_machine }}
         uses: nixbuild/nix-quick-install-action@v30
         with:
           nix_conf: |
@@ -79,7 +82,7 @@ jobs:
             extra-trusted-public-keys = hacl.cachix.org-1:FzsZ2xsByOwKwIWNPII7yMOelJNDZ12mDAj3d1eGX0c=
 
       - name: Restore Nix Cache
-        if: ${{ ! matrix.nix_machine }}
+        if: ${{ !matrix.nix_machine }}
         id: restore-nix-cache
         uses: nix-community/cache-nix-action/restore@v6
         with:
@@ -102,7 +105,7 @@ jobs:
           chmod -R +w dist_staging
 
       - name: Install elan (Lean toolchain manager)
-        if: ${{ ! matrix.nix_machine }}
+        if: ${{ !matrix.nix_machine }}
         run: |
           set -eo pipefail
 
@@ -171,7 +174,7 @@ jobs:
           files: ${{ matrix.artifact_name }}.tar.gz
 
       - name: Save Nix Cache
-        if: ${{ always() && ! matrix.nix_machine }}
+        if: ${{ always() && !matrix.nix_machine }}
         uses: nix-community/cache-nix-action/save@v6
         with:
           primary-key: ${{ steps.restore-nix-cache.outputs.primary-key }}
@@ -181,8 +184,8 @@ jobs:
 
   notify:
     name: Notify Zulip
-    needs: [prepare, build]
-    runs-on: ubuntu-latest
+    needs: [prepare, build, select-runner]
+    runs-on: ${{ fromJSON(needs.select-runner.outputs.runs_on) }}
     if: ${{ success() || failure() }}
     permissions:
       actions: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -186,7 +186,7 @@ jobs:
     name: Notify Zulip
     needs: [prepare, build, select-runner]
     runs-on: ${{ fromJSON(needs.select-runner.outputs.runs_on) }}
-    if: ${{ success() || failure() }}
+    if: ${{ github.repository == 'AeneasVerif/aeneas' && (success() || failure()) }}
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/select-runner.yml
+++ b/.github/workflows/select-runner.yml
@@ -16,13 +16,23 @@ jobs:
       runs_on: ${{ steps.select.outputs.runs_on }}
     steps:
       - id: select
+        env:
+          current_repository: ${{ github.repository }}
         run: |
           set -euo pipefail
 
-          heartbeat_repository="aeneasverif/charon"
+          heartbeat_repository="AeneasVerif/charon"
           self_hosted='["self-hosted","linux","nix"]'
           github_hosted='["ubuntu-latest"]'
           max_age_seconds=$((3 * 60 * 60))
+
+          # The self-hosted runner is only available on the main Aeneas repo.
+          # On forks (and any other repo), always fall back to GitHub-hosted.
+          if [ "$current_repository" != "AeneasVerif/aeneas" ]; then
+            echo "::notice title=Not on AeneasVerif/aeneas::Selecting GitHub-hosted runner; current repository is ${current_repository}."
+            echo "runs_on=$github_hosted" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
 
           query_error="$(mktemp)"
           if default_branch=$(curl -fsSL "https://api.github.com/repos/${heartbeat_repository}" 2>"$query_error" | jq -r .default_branch); then


### PR DESCRIPTION
On our fork cryspen/aeneas, we don't have self-hosted runners any more, so we need to turn them off. The changes made here affect only forks, but might be useful for other forks, too. It would be great to upstream this, since it would be one less commit that we need to rebase regularly.

This PR is entirely Claude generated, but has been carefully reviewed and tested on our fork.