### PR TITLE
Document limitation instantiating generic types with mutable references

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,10 @@ one by one:
   are not supported yet (e.g., `'a : loop { loop { break 'a; } } `). This is a
   technical limitation, not a fundamental issue, that we plan to address in the
   near future and that we can prioritize depending on our users' needs.
+- **mutable references and generic types**: Instantiating a generic type (including `Self` through a
+  trait implementation) with a mutable reference is not supported yet (e.g., calling `id(&mut x)`
+  where `fn id<T>(x: T) -> T { x }`). This is a technical limitation, not a fundamental issue, that
+  we plan to address in the near future and that we can prioritize depending on our users' needs.
 
 The following limitations will be lifted by the ongoing work on separation logic:
 - **unsafe code**

--- a/README.md
+++ b/README.md
@@ -133,8 +133,8 @@ one by one:
   near future and that we can prioritize depending on our users' needs.
 - **mutable references and generic types**: Instantiating a generic type (including `Self` through a
   trait implementation) with a mutable reference is not supported yet (e.g., calling `id(&mut x)`
-  where `fn id<T>(x: T) -> T { x }`). This is a technical limitation, not a fundamental issue, that
-  we plan to address in the near future and that we can prioritize depending on our users' needs.
+  where `fn id<T>(x: T) -> T { x }`). We're working on addressing it and can prioritize it depending
+  on our users' needs.
 
 The following limitations will be lifted by the ongoing work on separation logic:
 - **unsafe code**


### PR DESCRIPTION
Fixes #1215 (unless we need a tracking issue).

Gemini was used to check the repository contribution guidelines (resulting in this disclaimer). I am the author of the change, PR title, and PR description (including this line).
