### PR TITLE
Fix release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -184,8 +184,8 @@ jobs:
 
   notify:
     name: Notify Zulip
-    needs: [prepare, build, select-runner]
-    runs-on: ${{ fromJSON(needs.select-runner.outputs.runs_on) }}
+    needs: [prepare, build]
+    runs-on: ubuntu-latest
     if: ${{ github.repository == 'AeneasVerif/aeneas' && (success() || failure()) }}
     permissions:
       actions: read


### PR DESCRIPTION
The "send Zulip message" job was not prepared to run on the nix machine; restoring unconditional use of github-hosted actions.