### PR TITLE
fix: replace `sorry`s with `noncomputable opaque`/`axiom`

### DIFF
--- a/backends/lean/Aeneas/Std/Slice.lean
+++ b/backends/lean/Aeneas/Std/Slice.lean
@@ -360,12 +360,11 @@ def core.slice.Slice.get
   inst.get i s
 
 @[rust_fun "core::slice::{[@T]}::get_unchecked"]
-def core.slice.Slice.get_unchecked
+noncomputable opaque core.slice.Slice.get_unchecked
   {T : Type} {I : Type} {Output : Type}
   (SliceIndexInst : core.slice.index.SliceIndex I (Slice T) Output)
-  (s : Slice T) (i : I) : Result Output :=
+  (s : Slice T) (i : I) : Result Output
   -- TODO: we should actually use the `SliceIndexInst.get_unchecked` method
-  sorry
 
 @[rust_fun "core::slice::{[@T]}::get_mut"]
 def core.slice.Slice.get_mut
@@ -583,11 +582,10 @@ def core.slice.index.SliceIndexUsizeSlice (T : Type) :
 }
 
 @[step]
-theorem core.slice.Slice.get_unchecked_SliceIndexUsizeSlice_spec {T s i} [Inhabited T]
+axiom core.slice.Slice.get_unchecked_SliceIndexUsizeSlice_spec {T s i} [Inhabited T]
   (h : i.val < s.length) :
   core.slice.Slice.get_unchecked  (core.slice.index.SliceIndexUsizeSlice T) s i
-  ⦃ x => x = s[i] ⦄ := by
-  sorry
+  ⦃ x => x = s[i] ⦄
 
 @[rust_fun "core::slice::{[@T]}::copy_from_slice"]
 def core.slice.Slice.copy_from_slice {T : Type} (_ : core.marker.Copy T)

--- a/backends/lean/Aeneas/Std/StringIter.lean
+++ b/backends/lean/Aeneas/Std/StringIter.lean
@@ -9,13 +9,15 @@ structure core.str.iter.Chars where
   iter : core.slice.iter.Iter U8
 
 @[rust_fun "core::str::iter::{core::iter::traits::iterator::Iterator<core::str::iter::Chars<'a>, char>}::next"]
-def core.str.iter.IteratorChars.next (_iter : core.str.iter.Chars) : Result ((Option Char) × core.str.iter.Chars) := sorry
+def core.str.iter.IteratorChars.next (it : core.str.iter.Chars) : Result ((Option Char) × core.str.iter.Chars) := do
+  let (r, iter) ← core.slice.iter.IteratorSliceIter.next it.iter
+  .ok (r.map Char.ofNat, ⟨iter⟩)
 
 @[rust_fun "core::str::iter::{core::iter::traits::iterator::Iterator<core::str::iter::Chars<'a>, char>}::collect"]
-def core.str.iter.IteratorChars.collect
+noncomputable opaque core.str.iter.IteratorChars.collect
   {B : Type} (itertraitscollectFromIteratorBCharInst :
   core.iter.traits.collect.FromIterator B Char) :
-  core.str.iter.Chars → Result B := sorry
+  core.str.iter.Chars → Result B
 
 @[reducible, rust_trait_impl
   "core::iter::traits::iterator::Iterator<core::str::iter::Chars<'a>, char>"]


### PR DESCRIPTION
This PR replaces all `sorry`s in the Lean backend library with `noncomputable opaque`/`axiom`. The advantage is that building the library no longer yields `declaration uses sorry`-warnings. Other than that, the library should work as before.

Only for `core.str.iter.IteratorChars.next`, giving a definition was straight-forward, so I defined it.


Fixes #18 