### PR TITLE
Fix sort order in tests/lean/script.sh

### DIFF
--- a/tests/lean/lakefile.lean
+++ b/tests/lean/lakefile.lean
@@ -5,6 +5,8 @@ require aeneas from "../../backends/lean"
 
 package «tests» {}
 
+/- File created by tests/lean/script.sh. -/
+
 @[default_target] lean_lib Adt
 @[default_target] lean_lib AdtBorrows
 @[default_target] lean_lib Arrays

--- a/tests/lean/lakefile.lean
+++ b/tests/lean/lakefile.lean
@@ -5,7 +5,7 @@ require aeneas from "../../backends/lean"
 
 package «tests» {}
 
-/- File created by tests/lean/script.sh. -/
+/- File created by `tests/lean/script.sh`. -/
 
 @[default_target] lean_lib Adt
 @[default_target] lean_lib AdtBorrows

--- a/tests/lean/script.sh
+++ b/tests/lean/script.sh
@@ -1,8 +1,12 @@
 #!/bin/bash
 
+# Generate `lakefile.lean` from `lakefile.lean-template` plus one `lean_lib` target per test file.
+
 cp lakefile.lean-template lakefile.lean
 
-for entry in *.lean
+printf "/- File created by tests/lean/script.sh. -/\n\n" >> lakefile.lean
+
+for entry in $(printf '%s\n' *.lean | LC_ALL=C sort -f)
 do
   suffix=".lean"
   entry=${entry%"$suffix"}

--- a/tests/lean/script.sh
+++ b/tests/lean/script.sh
@@ -4,7 +4,7 @@
 
 cp lakefile.lean-template lakefile.lean
 
-printf "/- File created by tests/lean/script.sh. -/\n\n" >> lakefile.lean
+printf "/- File created by \`tests/lean/script.sh\`. -/\n\n" >> lakefile.lean
 
 for entry in $(printf '%s\n' *.lean | LC_ALL=C sort -f)
 do


### PR DESCRIPTION
Previously the order of the entries added by tests/lean/script.sh to the lakefile would depend on the locale where it is run. This modification fixes the order, indepenedent of locale and also add a comment to the generated file noting which script generated it. 