### PR TITLE
feat: reduce Errors to only panic and undef

### DIFF
--- a/backends/lean/Aeneas/Std/Array/Array.lean
+++ b/backends/lean/Aeneas/Std/Array/Array.lean
@@ -104,7 +104,7 @@ abbrev Array.slice {α : Type u} {n : Usize} [Inhabited α] (v : Array α n) (i 
 
 def Array.index_usize {α : Type u} {n : Usize} (v: Array α n) (i: Usize) : Result α :=
   match v[i]? with
-  | none => fail .arrayOutOfBounds
+  | none => fail .panic
   | some x => ok x
 
 -- For initialization
@@ -210,7 +210,7 @@ theorem Array.set_length {α : Type u} {n : Usize} (v: Array α n) (i: Usize) (x
 
 def Array.update {α : Type u} {n : Usize} (v: Array α n) (i: Usize) (x: α) : Result (Array α n) :=
   match v[i]? with
-  | none => fail .arrayOutOfBounds
+  | none => fail .panic
   | some _ =>
     ok ⟨ v.val.set i.val x, by have := v.property; simp [*] ⟩
 

--- a/backends/lean/Aeneas/Std/Core/Discriminant.lean
+++ b/backends/lean/Aeneas/Std/Core/Discriminant.lean
@@ -26,6 +26,6 @@ it as builtin so that it doesn't generate any axiom for it (this is a way of ign
 @[rust_fun "core::intrinsics::discriminant_value"]
 def core.intrinsics.discriminant_value
   {T : Type} (DiscrInst : DiscriminantKind T) (_ : T) :
-  Result (DiscrInst.Discriminant) := .fail .undef -- TODO: we need
+  Result (DiscrInst.Discriminant) := .fail .ub -- TODO: we need
 
 end Aeneas.Std

--- a/backends/lean/Aeneas/Std/Primitives.lean
+++ b/backends/lean/Aeneas/Std/Primitives.lean
@@ -49,11 +49,6 @@ def elabImpl : CommandElab := fun (stx: Syntax) => do
 -/
 
 inductive Error where
-   | assertionFailure: Error
-   | integerOverflow: Error
-   | divisionByZero: Error
-   | arrayOutOfBounds: Error
-   | maximumSizeExceeded: Error
    | panic: Error
    | undef: Error
 deriving Repr, BEq
@@ -90,7 +85,7 @@ def div? {α: Type u} (r: Result α): Bool :=
   | ok _ | fail _ => false
 
 def massert (b : Prop) [Decidable b] : Result Unit :=
-  if b then ok () else fail assertionFailure
+  if b then ok () else fail undef
 
 macro "prove_eval_global" : tactic => `(tactic| simp (failIfUnchanged := false) only [global_simps] <;> first | apply Eq.refl | decide)
 

--- a/backends/lean/Aeneas/Std/Primitives.lean
+++ b/backends/lean/Aeneas/Std/Primitives.lean
@@ -50,7 +50,7 @@ def elabImpl : CommandElab := fun (stx: Syntax) => do
 
 inductive Error where
    | panic: Error
-   | undef: Error
+   | ub: Error
 deriving Repr, BEq
 
 open Error
@@ -85,7 +85,7 @@ def div? {α: Type u} (r: Result α): Bool :=
   | ok _ | fail _ => false
 
 def massert (b : Prop) [Decidable b] : Result Unit :=
-  if b then ok () else fail undef
+  if b then ok () else fail ub
 
 macro "prove_eval_global" : tactic => `(tactic| simp (failIfUnchanged := false) only [global_simps] <;> first | apply Eq.refl | decide)
 

--- a/backends/lean/Aeneas/Std/PrimitivesLemmas.lean
+++ b/backends/lean/Aeneas/Std/PrimitivesLemmas.lean
@@ -20,6 +20,6 @@ theorem spec_massert (b : Prop) [Decidable b] : Std.WP.spec (massert b) P ↔ (b
   split <;> simp <;> grind
 
 @[simp, global_simps] theorem massert_True : massert True = ok () := by simp [massert]
-@[simp, global_simps] theorem massert_False : massert False = fail .assertionFailure := by simp [massert]
+@[simp, global_simps] theorem massert_False : massert False = fail .undef := by simp [massert]
 
 end Aeneas.Std

--- a/backends/lean/Aeneas/Std/PrimitivesLemmas.lean
+++ b/backends/lean/Aeneas/Std/PrimitivesLemmas.lean
@@ -20,6 +20,6 @@ theorem spec_massert (b : Prop) [Decidable b] : Std.WP.spec (massert b) P ↔ (b
   split <;> simp <;> grind
 
 @[simp, global_simps] theorem massert_True : massert True = ok () := by simp [massert]
-@[simp, global_simps] theorem massert_False : massert False = fail .undef := by simp [massert]
+@[simp, global_simps] theorem massert_False : massert False = fail .ub := by simp [massert]
 
 end Aeneas.Std

--- a/backends/lean/Aeneas/Std/RawPtr.lean
+++ b/backends/lean/Aeneas/Std/RawPtr.lean
@@ -28,6 +28,6 @@ instance {ty} : IsScalar (IScalar ty) where
 -- TODO: we can properly define this once we have separation logic
 def RawPtr.cast_scalar {T} {M} (T' : Type) (M' : Mutability) [IsScalar T] [IsScalar T'] (_ : RawPtr T M) :
   Result (RawPtr T' M') :=
-  .fail .undef
+  .fail .ub
 
 end Aeneas.Std

--- a/backends/lean/Aeneas/Std/Scalar/Bitwise.lean
+++ b/backends/lean/Aeneas/Std/Scalar/Bitwise.lean
@@ -18,13 +18,13 @@ def UScalar.shiftLeft {ty : UScalarTy} (x : UScalar ty) (s : Nat) :
   Result (UScalar ty) :=
   if s < ty.numBits then
     ok ⟨ x.bv.shiftLeft s ⟩
-  else fail .undef
+  else fail .ub
 
 def UScalar.shiftRight {ty : UScalarTy} (x : UScalar ty) (s : Nat) :
   Result (UScalar ty) :=
   if s < ty.numBits then
     ok ⟨ x.bv.ushiftRight s ⟩
-  else fail .undef
+  else fail .ub
 
 def UScalar.shiftLeft_UScalar {ty tys} (x : UScalar ty) (s : UScalar tys) :
   Result (UScalar ty) :=
@@ -38,25 +38,25 @@ def UScalar.shiftLeft_IScalar {ty tys} (x : UScalar ty) (s : IScalar tys) :
   Result (UScalar ty) :=
   if s.val ≥ 0 then
     x.shiftLeft s.toNat
-  else fail .undef
+  else fail .ub
 
 def UScalar.shiftRight_IScalar {ty tys} (x : UScalar ty) (s : IScalar tys) :
   Result (UScalar ty) :=
   if s.val ≥ 0 then
     x.shiftRight s.toNat
-  else fail .undef
+  else fail .ub
 
 def IScalar.shiftLeft {ty : IScalarTy} (x : IScalar ty) (s : Nat) :
   Result (IScalar ty) :=
   if s < ty.numBits then
     ok ⟨ x.bv.shiftLeft s ⟩
-  else fail .undef
+  else fail .ub
 
 def IScalar.shiftRight {ty : IScalarTy} (x : IScalar ty) (s : Nat) :
   Result (IScalar ty) :=
   if s < ty.numBits then
     ok ⟨ x.bv.sshiftRight s ⟩
-  else fail .undef
+  else fail .ub
 
 def IScalar.shiftLeft_UScalar {ty tys} (x : IScalar ty) (s : UScalar tys) :
   Result (IScalar ty) :=
@@ -70,13 +70,13 @@ def IScalar.shiftLeft_IScalar {ty tys} (x : IScalar ty) (s : IScalar tys) :
   Result (IScalar ty) :=
   if s.val ≥ 0 then
     x.shiftLeft s.toNat
-  else fail .undef
+  else fail .ub
 
 def IScalar.shiftRight_IScalar {ty tys} (x : IScalar ty) (s : IScalar tys) :
   Result (IScalar ty) :=
   if s.val ≥ 0 then
     x.shiftRight s.toNat
-  else fail .undef
+  else fail .ub
 
 instance {ty0 ty1} : HShiftLeft (UScalar ty0) (UScalar ty1) (Result (UScalar ty0)) where
   hShiftLeft x y := UScalar.shiftLeft_UScalar x y

--- a/backends/lean/Aeneas/Std/Scalar/Bitwise.lean
+++ b/backends/lean/Aeneas/Std/Scalar/Bitwise.lean
@@ -18,13 +18,13 @@ def UScalar.shiftLeft {ty : UScalarTy} (x : UScalar ty) (s : Nat) :
   Result (UScalar ty) :=
   if s < ty.numBits then
     ok ⟨ x.bv.shiftLeft s ⟩
-  else fail .integerOverflow
+  else fail .undef
 
 def UScalar.shiftRight {ty : UScalarTy} (x : UScalar ty) (s : Nat) :
   Result (UScalar ty) :=
   if s < ty.numBits then
     ok ⟨ x.bv.ushiftRight s ⟩
-  else fail .integerOverflow
+  else fail .undef
 
 def UScalar.shiftLeft_UScalar {ty tys} (x : UScalar ty) (s : UScalar tys) :
   Result (UScalar ty) :=
@@ -38,25 +38,25 @@ def UScalar.shiftLeft_IScalar {ty tys} (x : UScalar ty) (s : IScalar tys) :
   Result (UScalar ty) :=
   if s.val ≥ 0 then
     x.shiftLeft s.toNat
-  else fail .integerOverflow
+  else fail .undef
 
 def UScalar.shiftRight_IScalar {ty tys} (x : UScalar ty) (s : IScalar tys) :
   Result (UScalar ty) :=
   if s.val ≥ 0 then
     x.shiftRight s.toNat
-  else fail .integerOverflow
+  else fail .undef
 
 def IScalar.shiftLeft {ty : IScalarTy} (x : IScalar ty) (s : Nat) :
   Result (IScalar ty) :=
   if s < ty.numBits then
     ok ⟨ x.bv.shiftLeft s ⟩
-  else fail .integerOverflow
+  else fail .undef
 
 def IScalar.shiftRight {ty : IScalarTy} (x : IScalar ty) (s : Nat) :
   Result (IScalar ty) :=
   if s < ty.numBits then
     ok ⟨ x.bv.sshiftRight s ⟩
-  else fail .integerOverflow
+  else fail .undef
 
 def IScalar.shiftLeft_UScalar {ty tys} (x : IScalar ty) (s : UScalar tys) :
   Result (IScalar ty) :=
@@ -70,13 +70,13 @@ def IScalar.shiftLeft_IScalar {ty tys} (x : IScalar ty) (s : IScalar tys) :
   Result (IScalar ty) :=
   if s.val ≥ 0 then
     x.shiftLeft s.toNat
-  else fail .integerOverflow
+  else fail .undef
 
 def IScalar.shiftRight_IScalar {ty tys} (x : IScalar ty) (s : IScalar tys) :
   Result (IScalar ty) :=
   if s.val ≥ 0 then
     x.shiftRight s.toNat
-  else fail .integerOverflow
+  else fail .undef
 
 instance {ty0 ty1} : HShiftLeft (UScalar ty0) (UScalar ty1) (Result (UScalar ty0)) where
   hShiftLeft x y := UScalar.shiftLeft_UScalar x y

--- a/backends/lean/Aeneas/Std/Scalar/Core.lean
+++ b/backends/lean/Aeneas/Std/Scalar/Core.lean
@@ -593,7 +593,7 @@ def UScalar.tryMkOpt (ty : UScalarTy) (x : Nat) : Option (UScalar ty) :=
   else none
 
 def UScalar.tryMk (ty : UScalarTy) (x : Nat) : Result (UScalar ty) :=
-  Result.ofOption (tryMkOpt ty x) integerOverflow
+  Result.ofOption (tryMkOpt ty x) undef
 
 def IScalar.tryMkOpt (ty : IScalarTy) (x : Int) : Option (IScalar ty) :=
   if h:IScalar.check_bounds ty x then
@@ -601,7 +601,7 @@ def IScalar.tryMkOpt (ty : IScalarTy) (x : Int) : Option (IScalar ty) :=
   else none
 
 def IScalar.tryMk (ty : IScalarTy) (x : Int) : Result (IScalar ty) :=
-  Result.ofOption (tryMkOpt ty x) integerOverflow
+  Result.ofOption (tryMkOpt ty x) undef
 
 theorem UScalar.tryMkOpt_eq (ty : UScalarTy) (x : Nat) :
   match tryMkOpt ty x with

--- a/backends/lean/Aeneas/Std/Scalar/Core.lean
+++ b/backends/lean/Aeneas/Std/Scalar/Core.lean
@@ -593,7 +593,7 @@ def UScalar.tryMkOpt (ty : UScalarTy) (x : Nat) : Option (UScalar ty) :=
   else none
 
 def UScalar.tryMk (ty : UScalarTy) (x : Nat) : Result (UScalar ty) :=
-  Result.ofOption (tryMkOpt ty x) undef
+  Result.ofOption (tryMkOpt ty x) ub
 
 def IScalar.tryMkOpt (ty : IScalarTy) (x : Int) : Option (IScalar ty) :=
   if h:IScalar.check_bounds ty x then
@@ -601,7 +601,7 @@ def IScalar.tryMkOpt (ty : IScalarTy) (x : Int) : Option (IScalar ty) :=
   else none
 
 def IScalar.tryMk (ty : IScalarTy) (x : Int) : Result (IScalar ty) :=
-  Result.ofOption (tryMkOpt ty x) undef
+  Result.ofOption (tryMkOpt ty x) ub
 
 theorem UScalar.tryMkOpt_eq (ty : UScalarTy) (x : Nat) :
   match tryMkOpt ty x with

--- a/backends/lean/Aeneas/Std/Scalar/Ops/Div.lean
+++ b/backends/lean/Aeneas/Std/Scalar/Ops/Div.lean
@@ -13,14 +13,14 @@ open Result Error Arith ScalarElab WP
 -/
 
 def UScalar.div {ty : UScalarTy} (x y : UScalar ty) : Result (UScalar ty) :=
-  if y.bv != 0 then ok ⟨ BitVec.udiv x.bv y.bv ⟩ else fail divisionByZero
+  if y.bv != 0 then ok ⟨ BitVec.udiv x.bv y.bv ⟩ else fail panic
 
 def IScalar.div {ty : IScalarTy} (x y : IScalar ty): Result (IScalar ty) :=
   if y.val != 0 then
     -- There can be an overflow if `x` is equal to the lower bound and `y` to `-1`
     if ¬ (x.val = IScalar.min ty && y.val = -1) then ok ⟨ BitVec.sdiv x.bv y.bv ⟩
-    else fail integerOverflow
-  else fail divisionByZero
+    else fail panic
+  else fail panic
 
 def UScalar.try_div {ty : UScalarTy} (x y : UScalar ty) : Option (UScalar ty) :=
   Option.ofResult (div x y)

--- a/backends/lean/Aeneas/Std/Scalar/Ops/Rem.lean
+++ b/backends/lean/Aeneas/Std/Scalar/Ops/Rem.lean
@@ -12,11 +12,11 @@ open Result Error Arith ScalarElab WP
 # Remainder: Definitions
 -/
 def UScalar.rem {ty : UScalarTy} (x y : UScalar ty) : Result (UScalar ty) :=
-  if y.val != 0 then ok ⟨ BitVec.umod x.bv y.bv ⟩ else fail divisionByZero
+  if y.val != 0 then ok ⟨ BitVec.umod x.bv y.bv ⟩ else fail panic
 
 def IScalar.rem {ty : IScalarTy} (x y : IScalar ty) : Result (IScalar ty) :=
   if y.val != 0 then ok ⟨ BitVec.srem x.bv y.bv ⟩
-  else fail divisionByZero
+  else fail panic
 
 def UScalar.try_rem {ty : UScalarTy} (x y : UScalar ty) : Option (UScalar ty) :=
   Option.ofResult (rem x y)

--- a/backends/lean/Aeneas/Std/Scalar/Ops/Sub.lean
+++ b/backends/lean/Aeneas/Std/Scalar/Ops/Sub.lean
@@ -13,7 +13,7 @@ open Result Error Arith ScalarElab WP
 -/
 
 def UScalar.sub {ty : UScalarTy} (x y : UScalar ty) : Result (UScalar ty) :=
-  if x.val < y.val then fail .undef
+  if x.val < y.val then fail .ub
   else ok ⟨ BitVec.ofNat _ (x.val - y.val) ⟩
 
 def IScalar.sub {ty : IScalarTy} (x y : IScalar ty) : Result (IScalar ty) :=

--- a/backends/lean/Aeneas/Std/Scalar/Ops/Sub.lean
+++ b/backends/lean/Aeneas/Std/Scalar/Ops/Sub.lean
@@ -13,7 +13,7 @@ open Result Error Arith ScalarElab WP
 -/
 
 def UScalar.sub {ty : UScalarTy} (x y : UScalar ty) : Result (UScalar ty) :=
-  if x.val < y.val then fail .integerOverflow
+  if x.val < y.val then fail .undef
   else ok ⟨ BitVec.ofNat _ (x.val - y.val) ⟩
 
 def IScalar.sub {ty : IScalarTy} (x y : IScalar ty) : Result (IScalar ty) :=

--- a/backends/lean/Aeneas/Std/Scalar/OverflowingOps/Div.lean
+++ b/backends/lean/Aeneas/Std/Scalar/OverflowingOps/Div.lean
@@ -11,11 +11,11 @@ open Result Error ScalarElab
 -/
 
 def UScalar.overflowing_div {ty} (x y : UScalar ty) : Result (UScalar ty × Bool) :=
-  if y.bv != 0 then ok (⟨ BitVec.udiv x.bv y.bv ⟩, false) else fail divisionByZero
+  if y.bv != 0 then ok (⟨ BitVec.udiv x.bv y.bv ⟩, false) else fail panic
 
 def IScalar.overflowing_div {ty} (x y : IScalar ty) : Result (IScalar ty × Bool) :=
   if y.val != 0 then ok (⟨ BitVec.sdiv x.bv y.bv ⟩, BitVec.sdivOverflow x.bv y.bv)
-  else fail divisionByZero
+  else fail panic
 
 uscalar @[step_pure_def]
 def «%S».overflowing_div (x y : «%S») : Result («%S» × Bool) := @UScalar.overflowing_div .«%S» x y

--- a/backends/lean/Aeneas/Std/Slice.lean
+++ b/backends/lean/Aeneas/Std/Slice.lean
@@ -394,13 +394,13 @@ def core.slice.index.SliceIndexRangeUsizeSlice.get_mut
 def core.slice.index.SliceIndexRangeUsizeSlice.get_unchecked {T : Type} :
   Range Usize → ConstRawPtr (Slice T) → Result (ConstRawPtr (Slice T)) :=
   -- Don't know what the model should be - for now we always fail
-  fun _ _ => fail .undef
+  fun _ _ => fail .ub
 
 @[rust_fun "core::slice::index::{core::slice::index::SliceIndex<core::ops::range::Range<usize>, [@T], [@T]>}::get_unchecked_mut"]
 def core.slice.index.SliceIndexRangeUsizeSlice.get_unchecked_mut {T : Type} :
   Range Usize → MutRawPtr (Slice T) → Result (MutRawPtr (Slice T)) :=
   -- Don't know what the model should be - for now we always fail
-  fun _ _ => fail .undef
+  fun _ _ => fail .ub
 
 @[rust_fun "core::slice::index::{core::slice::index::SliceIndex<core::ops::range::Range<usize>, [@T], [@T]>}::index"]
 def core.slice.index.SliceIndexRangeUsizeSlice.index {T : Type} (r : Range Usize) (s : Slice T) : Result (Slice T) :=
@@ -464,14 +464,14 @@ def core.slice.index.SliceIndexRangeToUsizeSlice.get_mut
 def core.slice.index.SliceIndexRangeToUsizeSlice.get_unchecked
   {T : Type} (_ : core.ops.range.RangeTo Usize) (_ : ConstRawPtr (Slice T)) : Result (ConstRawPtr (Slice T)) :=
   -- TODO: update once we make the model of computation more stateful (for now we just fail)
-  fail .undef
+  fail .ub
 
 @[rust_fun "core::slice::index::{core::slice::index::SliceIndex<core::ops::range::RangeTo<usize>, [@T], [@T]>}::get_unchecked_mut"]
 def core.slice.index.SliceIndexRangeToUsizeSlice.get_unchecked_mut
   {T : Type} (_ : core.ops.range.RangeTo Usize) (_ : MutRawPtr (Slice T)) :
   Result (MutRawPtr (Slice T)) :=
   -- TODO: update once we make the model of computation more stateful (for now we just fail)
-  fail .undef
+  fail .ub
 
 @[rust_fun "core::slice::index::{core::slice::index::SliceIndex<core::ops::range::RangeTo<usize>, [@T], [@T]>}::index"]
 def core.slice.index.SliceIndexRangeToUsizeSlice.index
@@ -524,13 +524,13 @@ def core.slice.index.SliceIndexRangeFullSlice.get_mut
 opaque core.slice.index.SliceIndexRangeFullSlice.get_unchecked
   {T : Type} (_ : core.ops.range.RangeFull) (s : ConstRawPtr (Slice T)) :
   Result (ConstRawPtr (Slice T)) :=
-  fail .undef -- TODO: not sure what it should be
+  fail .ub -- TODO: not sure what it should be
 
 @[rust_fun "core::slice::index::{core::slice::index::SliceIndex<core::ops::range::RangeFull, [@T], [@T]>}::get_unchecked_mut"]
 opaque core.slice.index.SliceIndexRangeFullSlice.get_unchecked_mut
   {T : Type} (_ : core.ops.range.RangeFull) (s : MutRawPtr (Slice T)) :
   Result (MutRawPtr (Slice T)) :=
-  fail .undef -- TODO: not sure what it should be
+  fail .ub -- TODO: not sure what it should be
 
 @[simp, step_simps, rust_fun "core::slice::index::{core::slice::index::SliceIndex<core::ops::range::RangeFull, [@T], [@T]>}::index"]
 def core.slice.index.SliceIndexRangeFullSlice.index
@@ -583,13 +583,13 @@ abbrev core.slice.index.Usize.get_mut
 def core.slice.index.Usize.get_unchecked
   {T : Type} : Usize → ConstRawPtr (Slice T) → Result (ConstRawPtr T) :=
   -- We don't have a model for now
-  fun _ _ => fail .undef
+  fun _ _ => fail .ub
 
 @[rust_fun "core::slice::index::{core::slice::index::SliceIndex<usize, [@T], @T>}::get_unchecked_mut"]
 def core.slice.index.Usize.get_unchecked_mut
   {T : Type} : Usize → MutRawPtr (Slice T) → Result (MutRawPtr T) :=
   -- We don't have a model for now
-  fun _ _ => fail .undef
+  fun _ _ => fail .ub
 
 @[simp, step_simps, rust_fun "core::slice::index::{core::slice::index::SliceIndex<usize, [@T], @T>}::index"]
 abbrev core.slice.index.Usize.index {T : Type} (i : Usize) (s : Slice T) : Result T :=
@@ -648,20 +648,20 @@ def core.slice.index.SliceIndexRangeFromUsizeSlice.get_mut
 def core.slice.index.SliceIndexRangeFromUsizeSlice.get_unchecked {T : Type} :
   core.ops.range.RangeFrom Usize → ConstRawPtr (Slice T) → Result (ConstRawPtr (Slice T)) :=
   -- We don't have a model for now
-  fun _ _ => fail .undef
+  fun _ _ => fail .ub
 
 @[rust_fun "core::slice::index::{core::slice::index::SliceIndex<core::ops::range::RangeFrom<usize>, [@T], [@T]>}::get_unchecked_mut"]
 def core.slice.index.SliceIndexRangeFromUsizeSlice.get_unchecked_mut {T : Type} :
   core.ops.range.RangeFrom Usize → MutRawPtr (Slice T) → Result (MutRawPtr (Slice T)) :=
   -- We don't have a model for now
-  fun _ _ => fail .undef
+  fun _ _ => fail .ub
 
 @[rust_fun "core::slice::index::{core::slice::index::SliceIndex<core::ops::range::RangeFrom<usize>, [@T], [@T]>}::index"]
 def core.slice.index.SliceIndexRangeFromUsizeSlice.index {T : Type}
   (r : core.ops.range.RangeFrom Usize) (s : Slice T) : Result (Slice T) :=
   if r.start.val ≤ s.length then
     ok (s.drop r.start)
-  else fail .undef
+  else fail .ub
 
 @[rust_fun "core::slice::index::{core::slice::index::SliceIndex<core::ops::range::RangeFrom<usize>, [@T], [@T]>}::index_mut"]
 def core.slice.index.SliceIndexRangeFromUsizeSlice.index_mut {T : Type}

--- a/backends/lean/Aeneas/Std/Slice.lean
+++ b/backends/lean/Aeneas/Std/Slice.lean
@@ -114,7 +114,7 @@ abbrev Slice.slice {α : Type u} [Inhabited α] (s : Slice α) (i j : Nat) : Lis
 
 def Slice.index_usize {α : Type u} (v: Slice α) (i: Usize) : Result α :=
   match v[i]? with
-  | none => fail .arrayOutOfBounds
+  | none => fail .panic
   | some x => ok x
 
 theorem Slice.eq_iff {α} (s0 s1 : Slice α) : s0 = s1 ↔ s0.val = s1.val := by
@@ -260,7 +260,7 @@ theorem Slice.getElem_Nat_setAtNat_ne
 
 def Slice.update {α : Type u} (v: Slice α) (i: Usize) (x: α) : Result (Slice α) :=
   match v.val[i.val]? with
-  | none => fail .arrayOutOfBounds
+  | none => fail .panic
   | some _ =>
     ok ⟨ v.val.set i.val x, by have := v.property; simp [*] ⟩
 

--- a/backends/lean/Aeneas/Std/Vec.lean
+++ b/backends/lean/Aeneas/Std/Vec.lean
@@ -124,7 +124,7 @@ def Vec.push {α : Type u} (v : Vec α) (x : α) : Result (Vec α)
   if h : nlen ≤ U32.max || nlen ≤ Usize.max then
     ok ⟨ List.concat v.val x, by simp; scalar_tac ⟩
   else
-    fail maximumSizeExceeded
+    fail panic
 
 @[step]
 theorem Vec.push_spec {α : Type u} (v : Vec α) (x : α) (h : v.val.length < Usize.max) :
@@ -137,7 +137,7 @@ def Vec.insert {α : Type u} (v: Vec α) (i: Usize) (x: α) : Result (Vec α) :=
   if i.val < v.length then
     ok ⟨ v.val.set i x, by have := v.property; simp [*] ⟩
   else
-    fail arrayOutOfBounds
+    fail panic
 
 @[step]
 theorem Vec.insert_spec {α : Type u} (v: Vec α) (i: Usize) (x: α)
@@ -147,7 +147,7 @@ theorem Vec.insert_spec {α : Type u} (v: Vec α) (i: Usize) (x: α)
 
 def Vec.index_usize {α : Type u} (v: Vec α) (i: Usize) : Result α :=
   match v[i.val]? with
-  | none => fail .arrayOutOfBounds
+  | none => fail .panic
   | some x => ok x
 
 @[step]
@@ -160,7 +160,7 @@ theorem Vec.index_usize_spec {α : Type u} (v: Vec α) (i: Usize)
 
 def Vec.update {α : Type u} (v: Vec α) (i: Usize) (x: α) : Result (Vec α) :=
   match v.val[i.val]? with
-  | none => fail .arrayOutOfBounds
+  | none => fail .panic
   | some _ =>
     ok ⟨ v.val.set i x, by have := v.property; simp [*] ⟩
 


### PR DESCRIPTION
This PR reduces the Error type to just two cases: undef and panic.

I used Claude to do this, but a simple search and replace would have had the same effect. I reviewed the changes and checked that the entire codebase no longer contains the strings
`assertionFailure`, `integerOverflow`, `divisionByZero`, `arrayOutOfBounds`, `maximumSizeExceeded`.

Moreover, I replaced integer overflows with `undef` instead of `panic` whenever the functions behavior depends on whether it is compiled in debug or release mode.