### PR TITLE
Update charon

### DIFF
--- a/charon-pin
+++ b/charon-pin
@@ -1,2 +1,2 @@
 # This is the commit from https://github.com/AeneasVerif/charon that should be used with this version of aeneas.
-4ad295c1bf982b5533ce7d85f4ddc889ff3127f8
+2a70b4be6272af20c9408211c010f5a247e8bf65

--- a/flake.lock
+++ b/flake.lock
@@ -10,11 +10,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1787767180,
-        "narHash": "sha256-u6wq2DapjAi+SvHAgVD4SKXUSe+PxYHDIzWPTbwCFd0=",
+        "lastModified": 1787819800,
+        "narHash": "sha256-aN3nHABMtr+hUueUvbXYOkSyJaEJzaMeVq1qboBp08w=",
         "owner": "aeneasverif",
         "repo": "charon",
-        "rev": "4ad295c1bf982b5533ce7d85f4ddc889ff3127f8",
+        "rev": "2a70b4be6272af20c9408211c010f5a247e8bf65",
         "type": "github"
       },
       "original": {

--- a/src/PrePasses.ml
+++ b/src/PrePasses.ml
@@ -1317,7 +1317,7 @@ let decompose_str_borrows (_ : crate) (f : fun_decl) : fun_decl =
                 match (cv.kind, cv.ty) with
                 | ( CLiteral (VStr str),
                     TRef
-                      (_, (TAdt { id = TBuiltin TStr; _ } as str_ty), ref_kind)
+                      (_, (TAdt { builtin = Some TStr; _ } as str_ty), ref_kind)
                   ) ->
                     (* We need to introduce intermediate assignments *)
                     (* First the string initialization *)
@@ -2265,10 +2265,11 @@ let fix_closure_lifetimes (crate : crate) (f : fun_decl) : fun_decl =
      We do the update only if the state is inside a reference. *)
   let find_input_region (ty : ty) =
     match ty with
-    | TAdt { id = TAdtId id; generics = { regions = [ RVar rid ]; _ } }
+    | TAdt { id; generics = { regions = [ RVar rid ]; _ }; builtin = None }
     | TRef
-        (_, TAdt { id = TAdtId id; generics = { regions = [ RVar rid ]; _ } }, _)
-      -> (
+        ( _,
+          TAdt { id; generics = { regions = [ RVar rid ]; _ }; builtin = None },
+          _ ) -> (
         match TypeDeclId.Map.find_opt id crate.type_decls with
         | Some decl -> (
             match decl.src with

--- a/src/extract/ExtractBase.ml
+++ b/src/extract/ExtractBase.ml
@@ -1813,7 +1813,7 @@ let ctx_compute_trait_impl_name_raw (ctx : extraction_ctx)
             let nm_ctx = Charon.NameMatcher.ctx_from_crate ctx.crate in
             let self_name =
               match self with
-              | TAdt { id = TAdtId id; generics } -> (
+              | TAdt { id; generics; builtin = None } -> (
                   (* Lookup the ADT *)
                   match TypeDeclId.Map.find_opt id ctx.crate.type_decls with
                   | None ->

--- a/src/interp/Interp.ml
+++ b/src/interp/Interp.ml
@@ -143,7 +143,14 @@ let compute_contexts (crate : crate) : decls_ctx =
   let type_decls = crate.type_decls in
   let to_extract =
     TypeDeclId.Map.filter
-      (fun id _ -> TypeDeclId.Set.mem id !type_decl_ids)
+      (fun id (d : type_decl) ->
+        (* Charon introduces declarations for the builtin types (tuples, [Box],
+           [str]): we handle those separately, and don't extract them *)
+        TypeDeclId.Set.mem id !type_decl_ids
+        &&
+        match d.src with
+        | BuiltinType _ -> false
+        | _ -> true)
       type_decls
   in
   let type_infos = analyze_type_declarations crate type_decls_list in

--- a/src/interp/InterpAbs.ml
+++ b/src/interp/InterpAbs.ml
@@ -252,11 +252,11 @@ let convert_value_to_output_avalues (span : Meta.span) (ctx : eval_ctx)
   let rec check_inputs (v : tvalue) (proj_ty : ty) : unit =
     match (v.value, proj_ty) with
     | VLiteral _, _ -> ()
-    | VAdt { variant_id; fields }, TAdt { id; generics } ->
+    | VAdt { variant_id; fields }, TAdt tref ->
         [%cassert] span (ty_no_regions v.ty)
           "Nested borrows are not supported yet";
         let field_types =
-          ctx_adt_get_instantiated_field_types span ctx id variant_id generics
+          ctx_adt_get_instantiated_field_types span ctx tref variant_id
         in
         List.iter2 check_inputs fields field_types
     | VBottom, _ -> [%internal_error] span
@@ -272,9 +272,9 @@ let convert_value_to_output_avalues (span : Meta.span) (ctx : eval_ctx)
     match (v.value, proj_ty) with
     | VLiteral _, _ -> ([], mk_eignored (Some (ctx.env, v)) proj_ty)
     | VBottom, _ -> [%internal_error] span
-    | VAdt { variant_id; fields }, TAdt { id; generics } ->
+    | VAdt { variant_id; fields }, TAdt tref ->
         let field_types =
-          ctx_adt_get_instantiated_field_types span ctx id variant_id generics
+          ctx_adt_get_instantiated_field_types span ctx tref variant_id
         in
         let avalues, outputs =
           List.split (List.map2 to_output fields field_types)

--- a/src/interp/InterpBorrowsCore.ml
+++ b/src/interp/InterpBorrowsCore.ml
@@ -2251,7 +2251,7 @@ let rec norm_proj_tys_union (span : Meta.span) ?(strict : bool = true)
       [%sanity_check] span (tref1.id = tref2.id);
       TAdt
         {
-          id = tref1.id;
+          tref1 with
           generics =
             norm_proj_generic_args_union span ~strict ctx tref1.generics
               tref2.generics;

--- a/src/interp/InterpExpansion.ml
+++ b/src/interp/InterpExpansion.ml
@@ -331,15 +331,16 @@ let compute_expanded_symbolic_box_value (span : Meta.span) (ctx : eval_ctx)
     controls the expansion of enumerations: if [false], it doesn't allow the
     expansion of enumerations *containing several variants*. *)
 let compute_expanded_symbolic_adt_value (span : Meta.span)
-    (expand_enumerations : bool) (adt_id : type_id) (generics : generic_args)
-    (ctx : eval_ctx) : symbolic_expansion list =
-  match (adt_id, generics.regions, generics.types) with
-  | TAdtId def_id, _, _ ->
+    (expand_enumerations : bool) (tref : type_decl_ref) (ctx : eval_ctx) :
+    symbolic_expansion list =
+  let generics = tref.generics in
+  match (tref.builtin, generics.regions, generics.types) with
+  | None, _, _ ->
       compute_expanded_symbolic_non_builtin_adt_value span expand_enumerations
-        def_id generics ctx
-  | TBuiltin TTuple, [], _ ->
+        tref.id generics ctx
+  | Some TTuple, [], _ ->
       [ compute_expanded_symbolic_tuple_value span ctx generics.types ]
-  | TBuiltin TBox, [], [ boxed_ty ] ->
+  | Some TBox, [], [ boxed_ty ] ->
       [ compute_expanded_symbolic_box_value span ctx boxed_ty ]
   | _ ->
       [%craise] span
@@ -564,12 +565,11 @@ let expand_symbolic_value_no_branching (span : Meta.span) (sv : symbolic_value)
   let ctx, cc =
     match rty with
     (* ADTs *)
-    | TAdt { id = adt_id; generics } ->
+    | TAdt tref ->
         (* Compute the expanded value *)
         let allow_branching = false in
         let seel =
-          compute_expanded_symbolic_adt_value span allow_branching adt_id
-            generics ctx
+          compute_expanded_symbolic_adt_value span allow_branching tref ctx
         in
         (* There should be exacly one branch *)
         let see = Collections.List.to_cons_nil seel in
@@ -617,12 +617,11 @@ let expand_symbolic_adt (span : Meta.span) (sv : symbolic_value)
   (* Execute *)
   match rty with
   (* ADTs *)
-  | TAdt { id = adt_id; generics } ->
+  | TAdt tref ->
       let allow_branching = true in
       (* Compute the expanded value *)
       let seel =
-        compute_expanded_symbolic_adt_value span allow_branching adt_id generics
-          ctx
+        compute_expanded_symbolic_adt_value span allow_branching tref ctx
       in
       (* Apply *)
       let ctx_branches =
@@ -700,7 +699,7 @@ let greedy_expand_symbolics_with_borrows (span : Meta.span) : cm_fun =
       [%ltrace "about to expand: " ^ symbolic_value_to_string ctx sv];
       let ctx, cc =
         match sv.sv_ty with
-        | TAdt { id = TAdtId def_id; _ } ->
+        | TAdt { id = def_id; builtin = None; _ } ->
             (* {!expand_symbolic_value_no_branching} checks if there are branchings,
              * but we prefer to also check it here - this leads to cleaner messages
              * and debugging *)
@@ -721,10 +720,10 @@ let greedy_expand_symbolics_with_borrows (span : Meta.span) : cm_fun =
             end;
             (* *)
             expand_symbolic_value_no_branching span sv None ctx
-        | TAdt { id = TBuiltin (TTuple | TBox); _ } | TRef (_, _, _) ->
+        | TAdt { builtin = Some (TTuple | TBox); _ } | TRef (_, _, _) ->
             (* Ok *)
             expand_symbolic_value_no_branching span sv None ctx
-        | TArray _ | TSlice _ | TAdt { id = TBuiltin TStr; _ } ->
+        | TArray _ | TSlice _ | TAdt { builtin = Some TStr; _ } ->
             (* We can't expand those *)
             [%craise] span
               "Attempted to greedily expand an ADT which can't be expanded "

--- a/src/interp/InterpExpressions.ml
+++ b/src/interp/InterpExpressions.ml
@@ -159,11 +159,11 @@ let rec copy_value (span : Meta.span) (allow_adt_copy : bool) (config : config)
   | VAdt av ->
       (* Sanity check *)
       (match v.ty with
-      | TAdt { id = TBuiltin TBox; _ } ->
+      | TAdt { builtin = Some TBox; _ } ->
           [%craise] span "Can't copy an builtin value other than Option"
-      | TAdt { id = TAdtId _; _ } as ty ->
+      | TAdt { builtin = None; _ } as ty ->
           [%sanity_check] span (allow_adt_copy || ty_is_copyable ty)
-      | TAdt { id = TBuiltin TTuple; _ } -> () (* Ok *)
+      | TAdt { builtin = Some TTuple; _ } -> () (* Ok *)
       | TArray (ty, _) | TSlice ty ->
           [%cassert] span (ty_is_copyable ty)
             "The type is not primitively copyable"
@@ -375,12 +375,12 @@ let eval_operand_no_reorganize (config : config) (span : Meta.span)
           [%ldebug "literal constant"];
           (* FIXME: the str type is not in [literal_type] *)
           match cv.ty with
-          | TAdt { id = TBuiltin TStr; _ } ->
+          | TAdt { builtin = Some TStr; _ } ->
               let v : tvalue = { value = VLiteral lit; ty = cv.ty } in
               (v, ctx, fun e -> e)
           | TLiteral lit_ty ->
               (literal_to_tvalue span lit_ty lit ctx, ctx, fun e -> e)
-          | TRef (RErased, (TAdt { id = TBuiltin TStr; _ } as str_ty), RShared)
+          | TRef (RErased, (TAdt { builtin = Some TStr; _ } as str_ty), RShared)
             ->
               (* Reference to a string *)
               (* Generate a fresh symbolic value for the string. In the translation,
@@ -777,7 +777,7 @@ let eval_unary_op_symbolic (config : config) (span : Meta.span) (unop : unop)
          We have to treat the shared borrow case separately from the box case.
       *)
       match (ty1, v.value) with
-      | TAdt { id = TBuiltin TBox; _ }, _ ->
+      | TAdt { builtin = Some TBox; _ }, _ ->
           [%cassert] span
             (not (tvalue_has_borrows (Some span) ctx v))
             "Unimplemented use of dynamic traits";
@@ -1270,19 +1270,18 @@ let eval_rvalue_aggregate (config : config) (span : Meta.span)
   let v, cf_compute =
     (* Match on the aggregate kind *)
     match aggregate_kind with
-    | AggregatedAdt ({ id = type_id; generics }, opt_variant_id, opt_field_id)
-      -> (
+    | AggregatedAdt (tref, opt_variant_id, opt_field_id) -> (
+        let generics = tref.generics in
         (* The opt_field_id is Some only for unions, that we don't support *)
         [%sanity_check] span (opt_field_id = None);
-        match type_id with
-        | TBuiltin TTuple ->
-            let tys = List.map (fun (v : tvalue) -> v.ty) values in
+        match tref.builtin with
+        | Some TTuple ->
             let v = VAdt { variant_id = None; fields = values } in
-            let generics = mk_generic_args [] tys [] [] in
-            let ty = TAdt { id = TBuiltin TTuple; generics } in
+            let ty = TAdt tref in
             let aggregated : tvalue = { value = v; ty } in
             (aggregated, fun e -> e)
-        | TAdtId def_id ->
+        | None ->
+            let def_id = tref.id in
             (* Sanity checks *)
             let type_decl = ctx_lookup_type_decl span ctx def_id in
             [%sanity_check] span
@@ -1298,11 +1297,11 @@ let eval_rvalue_aggregate (config : config) (span : Meta.span)
             let av : adt_value =
               { variant_id = opt_variant_id; fields = values }
             in
-            let aty = TAdt { id = TAdtId def_id; generics } in
+            let aty = TAdt tref in
             let aggregated : tvalue = { value = VAdt av; ty = aty } in
             (* Call the continuation *)
             (aggregated, fun e -> e)
-        | TBuiltin _ -> [%craise] span "Unreachable")
+        | Some _ -> [%craise] span "Unreachable")
     | AggregatedArray (ety, cg) ->
         (* Sanity check: all the values have the proper type *)
         [%classert] span
@@ -1364,14 +1363,14 @@ let eval_discriminant (config : config) (span : Meta.span) (p : place)
 
   let adt_id, _generics =
     match v.ty with
-    | TAdt { id; generics } -> (
-        match id with
-        | TAdtId id -> (id, generics)
-        | TBuiltin TTuple ->
+    | TAdt { id; generics; builtin } -> (
+        match builtin with
+        | None -> (id, generics)
+        | Some TTuple ->
             [%craise] span
               ("Attempting to read the discriminant of a tuple: ("
              ^ tvalue_to_string ctx v ^ " : " ^ ty_to_string ctx v.ty ^ ")")
-        | TBuiltin _ ->
+        | Some _ ->
             [%craise] span
               ("Attempting to read the discriminant of a builtin type: ("
              ^ tvalue_to_string ctx v ^ " : " ^ ty_to_string ctx v.ty ^ ")"))

--- a/src/interp/InterpMatchCtxs.ml
+++ b/src/interp/InterpMatchCtxs.ml
@@ -291,8 +291,9 @@ let rec match_types (span : Meta.span) ~(recover : bool) (ctx0 : eval_ctx)
     match_types span ~recover ctx0 ctx1 match_distinct_types match_regions
   in
   match (ty0, ty1) with
-  | ( TAdt { id = id0; generics = generics0 },
-      TAdt { id = id1; generics = generics1 } ) ->
+  | TAdt ({ id = id0; generics = generics0; _ } as tref0), TAdt tref1 ->
+      let id1 = tref1.id in
+      let generics1 = tref1.generics in
       [%cassert_recover] recover span (id0 = id1) "Not the same ADT ids";
       [%cassert_recover] recover span
         (phys_eq generics0.const_generics generics1.const_generics)
@@ -314,7 +315,7 @@ let rec match_types (span : Meta.span) ~(recover : bool) (ctx0 : eval_ctx)
           (List.combine generics0.types generics1.types)
       in
       let generics = { regions; types; const_generics; trait_refs } in
-      TAdt { id; generics }
+      TAdt { tref0 with id; generics }
   | TArray (ty0, len0), TArray (ty1, len1) ->
       [%cassert_recover] recover span (len0 = len1)
         "Arrays with different lengths";

--- a/src/interp/InterpPaths.ml
+++ b/src/interp/InterpPaths.ml
@@ -74,7 +74,7 @@ let rec project_value (span : Meta.span) (access : projection_access)
     (loan_id option * tvalue * (eval_ctx * tvalue -> eval_ctx * tvalue))
     path_access_result =
   match (pe, v.value, v.ty) with
-  | Field (opt_variant_id, field_id), VAdt adt, TAdt { id = TAdtId _; _ } ->
+  | Field (opt_variant_id, field_id), VAdt adt, TAdt { builtin = None; _ } ->
   begin
       (* Check consistency *)
       [%sanity_check] span (opt_variant_id = adt.variant_id);
@@ -89,7 +89,7 @@ let rec project_value (span : Meta.span) (access : projection_access)
       Ok (None, fv, backward)
     end
   (* Tuples *)
-  | Field (None, field_id), VAdt adt, TAdt { id = TBuiltin TTuple; _ } -> begin
+  | Field (None, field_id), VAdt adt, TAdt { builtin = Some TTuple; _ } -> begin
       let fv = FieldId.nth adt.fields field_id in
       let backward (ctx, updated) =
         (* Update the field value *)
@@ -117,7 +117,7 @@ let rec project_value (span : Meta.span) (access : projection_access)
   (* Box dereferencement *)
   | ( Deref,
       VAdt { variant_id = None; fields = [ fv ] },
-      TAdt { id = TBuiltin TBox; _ } ) -> begin
+      TAdt { builtin = Some TBox; _ } ) -> begin
       (* We allow moving outside of boxes. In practice, this kind of
        * manipulations should happen only inside unsafe code, so
        * it shouldn't happen due to user code, and we leverage it
@@ -388,7 +388,7 @@ let compute_expanded_bottom_adt_value (span : Meta.span) (ctx : eval_ctx)
   (* Initialize the expanded value *)
   let fields = List.map (mk_bottom span) field_types in
   let av = VAdt { variant_id = opt_variant_id; fields } in
-  let ty = TAdt { id = TAdtId def_id; generics } in
+  let ty = TAdt { id = def_id; generics; builtin = None } in
   { value = av; ty }
 
 let compute_expanded_bottom_tuple_value (span : Meta.span)
@@ -396,8 +396,7 @@ let compute_expanded_bottom_tuple_value (span : Meta.span)
   (* Generate the field values *)
   let fields = List.map (mk_bottom span) field_types in
   let v = VAdt { variant_id = None; fields } in
-  let generics = TypesUtils.mk_generic_args [] field_types [] [] in
-  let ty = TAdt { id = TBuiltin TTuple; generics } in
+  let ty = TypesUtils.mk_tuple_ty field_types in
   { value = v; ty }
 
 (** Auxiliary helper to expand {!Bottom} values.
@@ -440,16 +439,18 @@ let expand_bottom_value_from_projection (span : Meta.span)
   let nv =
     match (pe, p.ty) with
     (* "Regular" ADTs *)
-    | Field (opt_variant_id, _), TAdt { id = TAdtId def_id; generics } ->
+    | Field (opt_variant_id, _), TAdt { id = def_id; generics; builtin = None }
+      ->
         compute_expanded_bottom_adt_value span ctx def_id opt_variant_id
           generics
     (* Tuples *)
     | ( Field (None, _),
         TAdt
           {
-            id = TBuiltin TTuple;
             generics =
               { regions = []; types; const_generics = []; trait_refs = [] };
+            builtin = Some TTuple;
+            _;
           } ) ->
         (* Generate the field values *)
         compute_expanded_bottom_tuple_value span types

--- a/src/interp/InterpProjectors.ml
+++ b/src/interp/InterpProjectors.ml
@@ -27,12 +27,11 @@ let rec apply_proj_borrows_on_shared_borrow (span : Meta.span) (ctx : eval_ctx)
     | VLiteral _, TLiteral _ ->
         [%ldebug "literals"];
         []
-    | VAdt adt, TAdt { id; generics } ->
+    | VAdt adt, TAdt tref ->
         [%ldebug "adts"];
         (* Retrieve the types of the fields *)
         let field_types =
-          ctx_adt_get_instantiated_field_types span ctx id adt.variant_id
-            generics
+          ctx_adt_get_instantiated_field_types span ctx tref adt.variant_id
         in
 
         (* Project over the field values *)
@@ -115,11 +114,10 @@ let rec apply_proj_borrows (span : Meta.span) (check_symbolic_no_ended : bool)
     let value : avalue =
       match (v.value, ty) with
       | VLiteral _, TLiteral _ -> AIgnored (Some v)
-      | VAdt adt, TAdt { id; generics } ->
+      | VAdt adt, TAdt tref ->
           (* Retrieve the types of the fields *)
           let field_types =
-            ctx_adt_get_instantiated_field_types span ctx id adt.variant_id
-              generics
+            ctx_adt_get_instantiated_field_types span ctx tref adt.variant_id
           in
           (* Project over the field values *)
           let fields_types = List.combine adt.fields field_types in
@@ -269,11 +267,10 @@ let rec apply_eproj_borrows (span : Meta.span) (check_symbolic_no_ended : bool)
     let value : evalue =
       match (v.value, ty) with
       | VLiteral _, TLiteral _ -> EIgnored (Some (ctx.env, v))
-      | VAdt adt, TAdt { id; generics } ->
+      | VAdt adt, TAdt tref ->
           (* Retrieve the types of the fields *)
           let field_types =
-            ctx_adt_get_instantiated_field_types span ctx id adt.variant_id
-              generics
+            ctx_adt_get_instantiated_field_types span ctx tref adt.variant_id
           in
           (* Project over the field values *)
           let fields_types = List.combine adt.fields field_types in
@@ -432,11 +429,10 @@ let apply_proj_loans_on_symbolic_expansion (span : Meta.span)
     | SeLiteral lit, TLiteral _ ->
         ( AIgnored (Some { value = VLiteral lit; ty = original_sv_ty }),
           original_sv_ty )
-    | SeAdt (variant_id, fields), TAdt { id = adt_id; generics } ->
+    | SeAdt (variant_id, fields), TAdt tref ->
         (* Project over the field values *)
         let field_types =
-          ctx_adt_get_instantiated_field_types span ctx adt_id variant_id
-            generics
+          ctx_adt_get_instantiated_field_types span ctx tref variant_id
         in
         let fields =
           List.map2
@@ -497,11 +493,10 @@ let apply_eproj_loans_on_symbolic_expansion (span : Meta.span)
     | SeLiteral lit, TLiteral _ ->
         ( EIgnored (Some (ctx.env, { value = VLiteral lit; ty = proj_ty })),
           original_sv_ty )
-    | SeAdt (variant_id, fields), TAdt { id = adt_id; generics } ->
+    | SeAdt (variant_id, fields), TAdt tref ->
         (* Project over the field values *)
         let field_types =
-          ctx_adt_get_instantiated_field_types span ctx adt_id variant_id
-            generics
+          ctx_adt_get_instantiated_field_types span ctx tref variant_id
         in
         let fields =
           List.map2

--- a/src/interp/InterpStatements.ml
+++ b/src/interp/InterpStatements.ml
@@ -206,7 +206,7 @@ let set_discriminant (config : config) (span : Meta.span) (p : place)
   let v, ctx, cc = comp2 cc (prepare_lplace config span p ctx) in
   (* Update the value *)
   match (v.ty, v.value) with
-  | TAdt { id = TAdtId _ as type_id; generics }, VAdt av -> (
+  | TAdt { id = def_id; generics; builtin = None }, VAdt av -> (
       (* There are two situations:
          - either the discriminant is already the proper one (in which case we
            don't do anything)
@@ -221,23 +221,17 @@ let set_discriminant (config : config) (span : Meta.span) (p : place)
           else
             (* Replace the value *)
             let bottom_v =
-              match type_id with
-              | TAdtId def_id ->
-                  compute_expanded_bottom_adt_value span ctx def_id
-                    (Some variant_id) generics
-              | _ -> [%craise] span "Unreachable"
+              compute_expanded_bottom_adt_value span ctx def_id
+                (Some variant_id) generics
             in
             let ctx, cc =
               comp cc (assign_to_place config span bottom_v p ctx)
             in
             ((ctx, Unit), cc))
-  | TAdt { id = TAdtId _ as type_id; generics }, VBottom ->
+  | TAdt { id = def_id; generics; builtin = None }, VBottom ->
       let bottom_v =
-        match type_id with
-        | TAdtId def_id ->
-            compute_expanded_bottom_adt_value span ctx def_id (Some variant_id)
-              generics
-        | _ -> [%craise] span "Unreachable"
+        compute_expanded_bottom_adt_value span ctx def_id (Some variant_id)
+          generics
       in
       let ctx, cc = comp cc (assign_to_place config span bottom_v p ctx) in
       ((ctx, Unit), cc)
@@ -368,9 +362,12 @@ let eval_box_new_concrete (config : config) (span : Meta.span)
       [%cassert] span (v.ty = boxed_ty)
         "The input given to Box::new doesn't have the proper type";
 
-      (* Create the new box *)
-      let generics = TypesUtils.mk_generic_args_from_types [ boxed_ty ] in
-      let box_ty = TAdt { id = TBuiltin TBox; generics } in
+      (* Create the new box. We use the type of the destination: this saves us
+         from having to look up the id of the declaration of [Box]. *)
+      let box_ty = call.dest.ty in
+      [%cassert] span
+        (ty_as_opt_box box_ty = Some boxed_ty)
+        "The destination of Box::new doesn't have the proper type";
       let box_v = VAdt { variant_id = None; fields = [ v ] } in
       let box_v = mk_tvalue span box_ty box_v in
       comp cc (assign_to_place config span box_v call.dest ctx)

--- a/src/interp/Invariants.ml
+++ b/src/interp/Invariants.ml
@@ -434,7 +434,7 @@ let check_typing_invariant_visitor span ctx (lookups : bool) =
       (match (tv.value, tv.ty) with
       | VLiteral cv, TLiteral ty -> check_literal_type span cv ty
       (* ADT case *)
-      | VAdt av, TAdt { id = TAdtId def_id; generics } ->
+      | VAdt av, TAdt { id = def_id; generics; builtin = None } ->
           (* Retrieve the definition to check the variant id, the number of
            * parameters, etc. *)
           let def = ctx_lookup_type_decl span ctx def_id in
@@ -460,7 +460,7 @@ let check_typing_invariant_visitor span ctx (lookups : bool) =
             (fun ((v, ty) : tvalue * ty) -> [%sanity_check] span (v.ty = ty))
             fields_with_types
       (* Tuple case *)
-      | VAdt av, TAdt { id = TBuiltin TTuple; generics } ->
+      | VAdt av, TAdt { generics; builtin = Some TTuple; _ } ->
           [%sanity_check] span (generics.regions = []);
           [%sanity_check] span (generics.const_generics = []);
           [%sanity_check] span (av.variant_id = None);
@@ -482,7 +482,7 @@ let check_typing_invariant_visitor span ctx (lookups : bool) =
           in
           [%sanity_check] span (Z.of_int (List.length av.fields) = len)
       | VAdt _, TSlice _ -> [%craise] span "Unexpected slice value"
-      | VAdt av, TAdt { id = TBuiltin aty_id; generics } -> (
+      | VAdt av, TAdt { generics; builtin = Some aty_id; _ } -> (
           [%sanity_check] span (av.variant_id = None);
           match
             ( aty_id,
@@ -535,7 +535,7 @@ let check_typing_invariant_visitor span ctx (lookups : bool) =
           check_symbolic_value_type sv.sv_id sv.sv_ty;
           let ty' = Substitute.erase_regions sv.sv_ty in
           [%sanity_check] span (ty' = ty)
-      | VLiteral (VStr _), TAdt { id = TBuiltin TStr; _ } -> ()
+      | VLiteral (VStr _), TAdt { builtin = Some TStr; _ } -> ()
       | _ ->
           [%ltrace
             "Erroneous typing:\n- value: " ^ tvalue_to_string ctx tv
@@ -558,7 +558,7 @@ let check_typing_invariant_visitor span ctx (lookups : bool) =
       (* Check the current pair (value, type) *)
       (match (atv.value, atv.ty) with
       (* ADT case *)
-      | AAdt av, TAdt { id = TAdtId def_id; generics } ->
+      | AAdt av, TAdt { id = def_id; generics; builtin = None } ->
           (* Retrieve the definition to check the variant id, the number of
            * parameters, etc. *)
           let def = ctx_lookup_type_decl span ctx def_id in
@@ -587,7 +587,7 @@ let check_typing_invariant_visitor span ctx (lookups : bool) =
             (fun ((v, ty) : tavalue * ty) -> [%sanity_check] span (v.ty = ty))
             fields_with_types
       (* Tuple case *)
-      | AAdt av, TAdt { id = TBuiltin TTuple; generics } ->
+      | AAdt av, TAdt { generics; builtin = Some TTuple; _ } ->
           [%sanity_check] span (generics.regions = []);
           [%sanity_check] span (generics.const_generics = []);
           [%sanity_check] span (av.variant_id = None);
@@ -598,7 +598,7 @@ let check_typing_invariant_visitor span ctx (lookups : bool) =
             (fun ((v, ty) : tavalue * ty) -> [%sanity_check] span (v.ty = ty))
             fields_with_types
       (* Builtin type case *)
-      | AAdt av, TAdt { id = TBuiltin aty_id; generics } -> (
+      | AAdt av, TAdt { generics; builtin = Some aty_id; _ } -> (
           [%sanity_check] span (av.variant_id = None);
           match
             ( aty_id,

--- a/src/llbc/Builtin.ml
+++ b/src/llbc/Builtin.ml
@@ -102,19 +102,6 @@ module Sig = struct
         };
     }
 
-  (** [fn<T>(Box<T>) -> ()] *)
-  let box_free_sig : bound_fun_sig =
-    let generics =
-      mk_generic_params [] [ type_param_0 ] []
-      (* <T> *)
-    in
-    let inputs = [ mk_box_ty tvar_0 (* Box<T> *) ] in
-    let output =
-      mk_unit_ty
-      (* () *)
-    in
-    mk_sig generics inputs output
-
   (** Array/slice functions *)
 
   (** Small helper.

--- a/src/llbc/Contexts.ml
+++ b/src/llbc/Contexts.ml
@@ -648,13 +648,12 @@ let ctx_type_get_instantiated_field_etypes (span : Meta.span) (ctx : eval_ctx)
 (** Return the types of the properly instantiated ADT value (note that here, ADT
     is understood in its broad meaning: ADT, builtin value or tuple). *)
 let ctx_adt_get_instantiated_field_types (span : Meta.span) (ctx : eval_ctx)
-    (id : type_id) (variant_id : variant_id option) (generics : generic_args) :
-    ty list =
-  match id with
-  | TAdtId id ->
-      (* Retrieve the types of the fields *)
-      ctx_type_get_instantiated_field_types span ctx id variant_id generics
-  | TBuiltin aty -> (
+    (tref : type_decl_ref) (variant_id : variant_id option) : ty list =
+  let generics = tref.generics in
+  match tref.builtin with
+  | None ->
+      ctx_type_get_instantiated_field_types span ctx tref.id variant_id generics
+  | Some aty -> (
       match aty with
       | TTuple ->
           [%cassert] span (variant_id = None) "Tuples don't have variants";

--- a/src/llbc/PrintBase.ml
+++ b/src/llbc/PrintBase.ml
@@ -143,10 +143,10 @@ module Values = struct
     | TArray _ ->
         (* Happens when we aggregate values *)
         "@Array[" ^ String.concat ", " fields ^ "]"
-    | TAdt { id = TBuiltin TTuple; _ } ->
+    | TAdt { builtin = Some TTuple; _ } ->
         (* Tuple *)
         "(" ^ String.concat ", " fields ^ ")"
-    | TAdt { id = TAdtId def_id; _ } ->
+    | TAdt { id = def_id; builtin = None; _ } ->
         (* "Regular" ADT *)
         let adt_ident =
           match variant_id with
@@ -168,7 +168,7 @@ module Values = struct
               let fields = String.concat " " fields in
               adt_ident ^ " { " ^ fields ^ " }"
         else adt_ident
-    | TAdt { id = TBuiltin aty; _ } -> (
+    | TAdt { builtin = Some aty; _ } -> (
         (* Builtin type *)
         match (aty, fields) with
         | TBox, [ bv ] -> "@Box(" ^ bv ^ ")"

--- a/src/llbc/RegionsHierarchy.ml
+++ b/src/llbc/RegionsHierarchy.ml
@@ -105,10 +105,10 @@ let compute_regions_hierarchy_for_sig (span : Meta.span option) (crate : crate)
   (* Explore the types in the signature to add the edges *)
   let rec explore_ty (outer : region list) (ty : ty) =
     match ty with
-    | TAdt { id; generics } ->
+    | TAdt { id; generics; builtin } ->
         (* Add constraints coming from the type clauses *)
-        (match id with
-        | TAdtId id ->
+        (match builtin with
+        | None ->
             (* Lookup the type declaration *)
             let decl = TypeDeclId.Map.find_opt id crate.type_decls in
             let decl =
@@ -138,7 +138,7 @@ let compute_regions_hierarchy_for_sig (span : Meta.span option) (crate : crate)
             List.iter
               (add_edges_from_region_binder add_edges_from_types_outlive)
               predicates.types_outlive
-        | TBuiltin (TTuple | TBox | TStr) -> (* No clauses for those *) ());
+        | Some (TTuple | TBox | TStr) -> (* No clauses for those *) ());
         (* Explore the generics *)
         explore_generics outer generics
     | TArray _ | TSlice _ -> (* No clauses for those *) ()

--- a/src/llbc/TypesAnalysis.ml
+++ b/src/llbc/TypesAnalysis.ml
@@ -361,12 +361,12 @@ let analyze_full_ty (span : Meta.span option) (updated : bool ref)
     | TArray (ty, _) | TSlice ty ->
         (* Nothing to update: just explore the type parameters *)
         analyze span expl_info ty_info ty
-    | TAdt { id = TBuiltin (TTuple | TBox | TStr); generics } ->
+    | TAdt { generics; builtin = Some (TTuple | TBox | TStr); _ } ->
         (* Nothing to update: just explore the type parameters *)
         List.fold_left
           (fun ty_info ty -> analyze span expl_info ty_info ty)
           ty_info generics.types
-    | TAdt { id = TAdtId adt_id; generics } ->
+    | TAdt { id = adt_id; generics; builtin = None } ->
         (* Lookup the information for this type definition *)
         let adt_info =
           [%silent_unwrap_opt_span] span (TypeDeclId.Map.find_opt adt_id infos)
@@ -722,8 +722,9 @@ let compute_outlive_proj_ty (span : Meta.span option)
         | TAdt adt -> begin
             (* TODO: we need to handle those *)
             [%sanity_check_opt_span] span (adt.generics.trait_refs = []);
-            match adt.id with
-            | TAdtId id ->
+            match adt.builtin with
+            | None ->
+                let id = adt.id in
                 (* Lookup the declaration and use the region constraints
                    to check which regions outlive the projected regions. *)
                 let decl =
@@ -799,7 +800,7 @@ let compute_outlive_proj_ty (span : Meta.span option)
                     let ty, r = pred.binder_value in
                     outlive_visitor#visit_ty r ty)
                   types_outlive
-            | TBuiltin (TTuple | TBox | TStr) -> super#visit_ty outer ty
+            | Some (TTuple | TBox | TStr) -> super#visit_ty outer ty
           end
         | TArray _ | TSlice _ -> super#visit_ty outer ty
         | TVar _ | TLiteral _ | TNever -> ()
@@ -998,11 +999,11 @@ let check_no_bound_free_implied_bounds (span : Meta.span option)
                is shorter than the lifetimes appearing in the referent), as well
                as the outer borrow regions: we record [r] and dive in. *)
             self#visit_ty (r :: outer) ref_ty
-        | TAdt { id; generics = adt_generics } ->
+        | TAdt { id; generics = adt_generics; builtin } ->
             (* The implied bounds coming from the ADT's own declaration
                (constraints between its lifetime/type parameters). *)
-            (match id with
-            | TAdtId id -> (
+            (match builtin with
+            | None -> (
                 match TypeDeclId.Map.find_opt id type_decls with
                 | None -> ()
                 | Some decl ->

--- a/src/llbc/TypesUtils.ml
+++ b/src/llbc/TypesUtils.ml
@@ -2,6 +2,15 @@ open Types
 open Utils
 include Charon.TypesUtils
 
+(** Create a tuple type. *)
+let mk_tuple_ty (tys : ty list) : ty =
+  TAdt
+    {
+      id = unit_type_decl_id;
+      generics = mk_generic_args_from_types tys;
+      builtin = Some TTuple;
+    }
+
 let concat_generic_args (generics1 : generic_args) (generics2 : generic_args) :
     generic_args =
   {
@@ -111,7 +120,7 @@ let ty_has_adt_with_borrows span (infos : TypesAnalysis.type_infos) (ty : ty) :
 
       method! visit_ty env ty =
         match ty with
-        | TAdt { id; _ } when id <> TBuiltin TTuple ->
+        | TAdt { builtin; _ } when builtin <> Some TTuple ->
             let info = TypesAnalysis.analyze_ty span infos ty in
             if info.TypesAnalysis.contains_borrow then raise Found
             else super#visit_ty env ty
@@ -220,7 +229,7 @@ let type_decl_has_nested_borrows (span : Meta.span option)
   let generics =
     Substitute.generic_args_of_params_erase_regions span type_decl.generics
   in
-  let ty = TAdt { id = TAdtId type_decl.def_id; generics } in
+  let ty = TAdt { id = type_decl.def_id; generics; builtin = None } in
   ty_has_nested_borrows span infos ty
 
 let type_decl_has_nested_mut_borrows (span : Meta.span option)
@@ -228,7 +237,7 @@ let type_decl_has_nested_mut_borrows (span : Meta.span option)
   let generics =
     Substitute.generic_args_of_params_erase_regions span type_decl.generics
   in
-  let ty = TAdt { id = TAdtId type_decl.def_id; generics } in
+  let ty = TAdt { id = type_decl.def_id; generics; builtin = None } in
   ty_has_nested_mut_borrows span infos ty
 
 (** Retuns true if the type contains a borrow under a mutable borrow *)
@@ -256,10 +265,10 @@ let ty_has_mut_borrow_for_region_in_pred (infos : TypesAnalysis.type_infos)
       method! visit_TAdt env tref =
         (* Lookup the information for this ADT *)
         begin
-          match tref.id with
-          | TBuiltin (TTuple | TBox | TStr) -> ()
-          | TAdtId adt_id ->
-              let info = TypeDeclId.Map.find adt_id infos in
+          match tref.builtin with
+          | Some (TTuple | TBox | TStr) -> ()
+          | None ->
+              let info = TypeDeclId.Map.find tref.id infos in
               RegionId.iteri
                 (fun adt_rid r ->
                   if RegionId.Set.mem adt_rid info.mut_regions && pred r then
@@ -305,11 +314,11 @@ let ty_get_mutable_regions (infos : TypesAnalysis.type_infos)
       method! visit_TAdt env tref =
         (* Lookup the information for this ADT *)
         begin
-          match tref.id with
-          | TBuiltin (TTuple | TBox | TStr) -> ()
-          | TAdtId adt_id ->
+          match tref.builtin with
+          | Some (TTuple | TBox | TStr) -> ()
+          | None ->
               (* Check which region parameters are mutable *)
-              let info = TypeDeclId.Map.find adt_id infos in
+              let info = TypeDeclId.Map.find tref.id infos in
               RegionId.iteri
                 (fun adt_rid r ->
                   if RegionId.Set.mem adt_rid info.mut_regions then add_region r)
@@ -473,17 +482,6 @@ let type_decl_from_decl_id_is_tuple_struct (ctx : TypesAnalysis.type_infos)
     (id : TypeDeclId.id) : bool =
   let info = TypeDeclId.Map.find id ctx in
   info.is_tuple_struct
-
-(** Return true if a type declaration should be extracted as a tuple, because it
-    is a non-recursive structure with unnamed fields. *)
-let type_decl_from_type_id_is_tuple_struct (ctx : TypesAnalysis.type_infos)
-    (id : type_id) : bool =
-  match id with
-  | TBuiltin TTuple -> true
-  | TAdtId id ->
-      let info = TypeDeclId.Map.find id ctx in
-      info.is_tuple_struct
-  | TBuiltin _ -> false
 
 (** A trait instance id refers to a local clause if it only uses the variants:
     [Self], [Clause], [ParentClause] *)

--- a/src/llbc/ValuesUtils.ml
+++ b/src/llbc/ValuesUtils.ml
@@ -52,16 +52,14 @@ let tvalue_as_symbolic (span : Meta.span) (v : tvalue) : symbolic_value =
 
 let mk_etuple ~(borrow_proj : bool) (vl : tevalue list) : tevalue =
   let tys = List.map (fun (v : tevalue) -> v.ty) vl in
-  let generics = mk_generic_args_from_types tys in
   {
     value = EAdt { borrow_proj; variant_id = None; fields = vl };
-    ty = TAdt { id = TBuiltin TTuple; generics };
+    ty = mk_tuple_ty tys;
   }
 
 let mk_epat_tuple (vl : tepat list) : tepat =
   let tys = List.map (fun (v : tepat) -> v.ty) vl in
-  let generics = mk_generic_args_from_types tys in
-  { pat = PAdt (None, vl); ty = TAdt { id = TBuiltin TTuple; generics } }
+  { pat = PAdt (None, vl); ty = mk_tuple_ty tys }
 
 let mk_simpl_etuple ~(borrow_proj : bool) (vl : tevalue list) : tevalue =
   match vl with
@@ -71,7 +69,7 @@ let mk_simpl_etuple ~(borrow_proj : bool) (vl : tevalue list) : tevalue =
 (** Peel boxes as long as the value is of the form [Box<T>] *)
 let rec unbox_tvalue (span : Meta.span) (v : tvalue) : tvalue =
   match (v.value, v.ty) with
-  | VAdt av, TAdt { id = TBuiltin TBox; _ } -> (
+  | VAdt av, TAdt { builtin = Some TBox; _ } -> (
       match av.fields with
       | [ bv ] -> unbox_tvalue span bv
       | _ -> [%internal_error] span)
@@ -84,12 +82,6 @@ let mk_tvalue_from_symbolic_value (svalue : symbolic_value) : tvalue =
     { value = av; ty = Substitute.erase_regions svalue.sv_ty }
   in
   av
-
-(** Box a value *)
-let mk_box_value (span : Meta.span) (v : tvalue) : tvalue =
-  let box_ty = mk_box_ty v.ty in
-  let box_v = VAdt { variant_id = None; fields = [ v ] } in
-  mk_tvalue span box_ty box_v
 
 let is_bottom (v : value) : bool =
   match v with
@@ -261,7 +253,7 @@ let symbolic_value_is_greedily_expandable (span : Meta.span option)
     match sv.sv_ty with
     | TArray _ | TSlice _ -> false
     | TRef _ -> true
-    | TAdt { id = TAdtId id; _ } ->
+    | TAdt { id; builtin = None; _ } ->
         (* Lookup the type of the ADT to check if we can expand it *)
         let def = TypeDeclId.Map.find id type_decls in
         begin

--- a/src/pure/PureMicroPassesGeneral.ml
+++ b/src/pure/PureMicroPassesGeneral.ml
@@ -170,8 +170,8 @@ let simplify_decompose_struct_visitor (ctx : ctx) (def : fun_decl) =
                  like Lean have projectors for tuples (like so: `x.3`), but others
                  like Coq don't, in which case we have to deconstruct the whole ADT
                  at once (`let (a, b, c) = x in`) *)
-            || TypesUtils.type_decl_from_type_id_is_tuple_struct
-                 ctx.trans_ctx.type_ctx.type_infos (T.TAdtId adt_id)
+            || TypesUtils.type_decl_from_decl_id_is_tuple_struct
+                 ctx.trans_ctx.type_ctx.type_infos adt_id
                && not !Config.use_tuple_projectors
           in
           if use_let_with_cons then

--- a/src/symbolic/SymbolicAst.ml
+++ b/src/symbolic/SymbolicAst.ml
@@ -19,7 +19,7 @@ type symbolic_expr_id = Contexts.symbolic_expr_id [@@deriving show, eq, ord]
     information, etc.). We later use this place information to generate
     meaningful name, to prettify the generated code. *)
 type mprojection_elem = {
-  type_id : type_id;
+  type_ref : type_decl_ref;
   variant_id : variant_id option;
   field_id : field_id;
 }

--- a/src/symbolic/SymbolicToPureExpressions.ml
+++ b/src/symbolic/SymbolicToPureExpressions.ml
@@ -1501,24 +1501,24 @@ and translate_ExpandAdt_one_branch (sv : V.symbolic_value) (scrutinee : texpr)
     (svl : V.symbolic_value list) (branch : S.expr) (ctx : bs_ctx) : texpr =
   (* TODO: always introduce a match, and use micro-passes to turn the
      the match into a let? *)
-  let type_id, _ = TypesUtils.ty_as_adt sv.V.sv_ty in
+  let adt = TypesUtils.ty_as_adt sv.V.sv_ty in
   let ctx, vars = fresh_vars_for_symbolic_values svl ctx in
   let branch = translate_expr branch ctx in
-  match type_id with
-  | TAdtId _ ->
+  match adt.builtin with
+  | None ->
       let lvars = List.map (fun v -> mk_tpat_from_fvar None v) vars in
       let lv = mk_adt_pat scrutinee.ty variant_id lvars in
       let monadic = false in
       [%add_loc] mk_closed_checked_let ctx monadic lv
         (mk_opt_mplace_texpr scrutinee_mplace scrutinee)
         branch
-  | TBuiltin TTuple ->
+  | Some TTuple ->
       let vars = List.map (fun x -> mk_tpat_from_fvar None x) vars in
       let monadic = false in
       [%add_loc] mk_closed_checked_let ctx monadic (mk_simpl_tuple_pat vars)
         (mk_opt_mplace_texpr scrutinee_mplace scrutinee)
         branch
-  | TBuiltin TBox ->
+  | Some TBox ->
       (* There should be exactly one variable *)
       let var =
         match vars with
@@ -1532,7 +1532,7 @@ and translate_ExpandAdt_one_branch (sv : V.symbolic_value) (scrutinee : texpr)
         (mk_tpat_from_fvar None var)
         (mk_opt_mplace_texpr scrutinee_mplace scrutinee)
         branch
-  | TBuiltin TStr ->
+  | Some TStr ->
       (* We can't expand those values: we can access the fields only
        * through the functions provided by the API (note that we don't
        * know how to expand values like vectors or arrays, because they have a variable number

--- a/src/symbolic/SymbolicToPureTypes.ml
+++ b/src/symbolic/SymbolicToPureTypes.ml
@@ -132,11 +132,11 @@ and translate_trait_ref_kind (span : Meta.span option)
 let rec translate_sty (span : Meta.span option) (ty : T.ty) : ty =
   let translate = translate_sty in
   match ty with
-  | T.TAdt { id; generics } -> (
+  | T.TAdt { id; generics; builtin } -> (
       let generics = translate_sgeneric_args span generics in
-      match id with
-      | T.TAdtId adt_id -> TAdt (TAdtId adt_id, generics)
-      | T.TBuiltin aty -> (
+      match builtin with
+      | None -> TAdt (TAdtId id, generics)
+      | Some aty -> (
           match aty with
           | T.TTuple ->
               [%sanity_check_opt_span] span (generics.const_generics = []);
@@ -323,12 +323,13 @@ let translate_type_decl (ctx : Contexts.decls_ctx) (def : T.type_decl) :
     preds;
   }
 
-let translate_type_id (span : Meta.span option) (id : T.type_id) : type_id =
-  match id with
-  | TAdtId adt_id -> TAdtId adt_id
-  | TBuiltin T.TTuple -> TTuple
-  | TBuiltin T.TStr -> TBuiltin TStr
-  | TBuiltin T.TBox ->
+let translate_type_id (span : Meta.span option) (tref : T.type_decl_ref) :
+    type_id =
+  match tref.builtin with
+  | None -> TAdtId tref.id
+  | Some T.TTuple -> TTuple
+  | Some T.TStr -> TBuiltin TStr
+  | Some T.TBox ->
       (* Boxes have to be eliminated: this type id shouldn't be translated *)
       [%craise_opt_span] span "Unexpected box type"
 
@@ -343,18 +344,18 @@ let rec translate_fwd_ty (span : Meta.span option) (decls_ctx : C.decls_ctx)
     (ty : T.ty) : ty =
   let translate = translate_fwd_ty span decls_ctx in
   match ty with
-  | T.TAdt { id; generics } -> (
+  | T.TAdt ({ generics; _ } as tref) -> (
       let t_generics = translate_fwd_generic_args span decls_ctx generics in
       (* Eliminate boxes and simplify tuples *)
-      match id with
-      | TAdtId _ | TBuiltin TStr ->
-          let id = translate_type_id span id in
+      match tref.builtin with
+      | None | Some TStr ->
+          let id = translate_type_id span tref in
           TAdt (id, t_generics)
-      | TBuiltin TTuple ->
+      | Some TTuple ->
           (* Note that if there is exactly one type, [mk_simpl_tuple_ty] is the
              identity *)
           mk_simpl_tuple_ty t_generics.types
-      | TBuiltin TBox -> (
+      | Some TBox -> (
           (* We eliminate boxes *)
           match t_generics.types with
           | [ bty ] -> bty
@@ -458,9 +459,9 @@ and compute_back_ty_num_levels (span : Meta.span option)
       ^ "): " ^ Print.ty_to_string ctx ty ^ "\n- outer_regions: "
       ^ T.RegionGroupId.Set.to_string None outer_regions];
     match ty with
-    | T.TAdt { id; generics } -> (
-        match id with
-        | TAdtId _ ->
+    | T.TAdt { generics; builtin; _ } -> (
+        match builtin with
+        | None ->
             (* Analyze the type *)
             let info = TypesAnalysis.analyze_ty span type_infos ty in
             (* TODO: we need to extend the type analysis to count the level
@@ -478,15 +479,15 @@ and compute_back_ty_num_levels (span : Meta.span option)
               else outer_regions
             in
             save_count outer_regions
-        | TBuiltin TStr -> save_count outer_regions
-        | TBuiltin TBox -> (
+        | Some TStr -> save_count outer_regions
+        | Some TBox -> (
             (* Eliminate the box *)
             match generics.types with
             | [ bty ] -> explore outer_regions bty
             | _ ->
                 [%craise_opt_span] span
                   "Unreachable: boxes receive exactly one type parameter")
-        | TBuiltin TTuple -> List.iter (explore outer_regions) generics.types)
+        | Some TTuple -> List.iter (explore outer_regions) generics.types)
     | T.TArray (ty, _) | T.TSlice ty -> explore outer_regions ty
     | TVar _ | TNever | TLiteral _ -> save_count outer_regions
     | TRef (r, rty, rkind) -> (
@@ -591,7 +592,7 @@ and translate_back_ty_aux (span : Meta.span option) (decls_ctx : C.decls_ctx)
       "Exploring: " ^ Print.ty_to_string ctx ty ^ "\n- outer_regions: "
       ^ T.RegionGroupId.Set.to_string None outer_regions];
     match ty with
-    | T.TAdt { id = TBuiltin TTuple; generics } -> (
+    | T.TAdt { generics; builtin = Some TTuple; _ } -> (
         (* Tuples can contain borrows (which we eliminate).
 
          Note that no borrow gets eliminated if we are already inside a
@@ -603,23 +604,23 @@ and translate_back_ty_aux (span : Meta.span option) (decls_ctx : C.decls_ctx)
             (* Note that if there is exactly one type, [mk_simpl_tuple_ty]
              * is the identity *)
             Some (mk_simpl_tuple_ty tys_t))
-    | T.TAdt { id; generics } when keep_adt outer_regions ty -> (
-        match id with
-        | TAdtId _ ->
+    | T.TAdt ({ generics; _ } as tref) when keep_adt outer_regions ty -> (
+        match tref.builtin with
+        | None ->
             (* The type should contain a mutable reference for the proper
              level: translate it as a forward type *)
-            let type_id = translate_type_id span id in
+            let type_id = translate_type_id span tref in
             let generics = translate_fwd_generic_args span decls_ctx generics in
             Some (TAdt (type_id, generics))
-        | TBuiltin TStr -> stop outer_regions ty
-        | TBuiltin TBox -> (
+        | Some TStr -> stop outer_regions ty
+        | Some TBox -> (
             (* Eliminate the box *)
             match generics.types with
             | [ bty ] -> explore outer_regions bty
             | _ ->
                 [%craise_opt_span] span
                   "Unreachable: boxes receive exactly one type parameter")
-        | TBuiltin TTuple -> [%internal_error_opt_span] span)
+        | Some TTuple -> [%internal_error_opt_span] span)
     | T.TAdt _ -> None
     | T.TArray _ | T.TSlice _ ->
         if keep_adt outer_regions ty then

--- a/src/symbolic/SymbolicToPureValues.ml
+++ b/src/symbolic/SymbolicToPureValues.ml
@@ -98,7 +98,7 @@ let rec tvalue_to_texpr (ctx : bs_ctx) (ectx : C.eval_ctx) (v : V.tvalue) :
         let fields = List.map translate av.fields in
         (* Eliminate the tuple wrapper if it is a tuple with exactly one field *)
         match v.ty with
-        | TAdt { id = TBuiltin TTuple; _ } ->
+        | TAdt { builtin = Some TTuple; _ } ->
             [%sanity_check] ctx.span (variant_id = None);
             mk_simpl_tuple_texpr ctx.span fields
         | _ ->
@@ -309,7 +309,7 @@ let gtranslate_adt_fields ~(project_borrows : bool)
   let span = ctx.span in
   (* We do not do the same thing depending on whether we visit a tuple
      or a "regular" ADT *)
-  let adt_id, _ = TypesUtils.ty_as_adt av_ty in
+  let adt = TypesUtils.ty_as_adt av_ty in
   (* Check if the ADT contains borrows *)
   let proj_kind = compute_proj_kind av in
   [%ldebug
@@ -335,9 +335,9 @@ let gtranslate_adt_fields ~(project_borrows : bool)
       let filter_fields =
         filter
         &&
-        match adt_id with
-        | TBuiltin (TTuple | TBox) -> true
-        | TBuiltin _ | TAdtId _ -> (
+        match adt.builtin with
+        | Some (TTuple | TBox) -> true
+        | Some _ | None -> (
             match proj_kind with
             | UnknownProj | BorrowProj BShared | LoanProj BShared -> true
             | _ -> false)
@@ -355,8 +355,8 @@ let gtranslate_adt_fields ~(project_borrows : bool)
             (List.map
                (Print.option_to_string (fun (_, x) -> output_to_string x))
                info_fields)];
-      match adt_id with
-      | TAdtId _ ->
+      match adt.builtin with
+      | None ->
           if filter_fields then (
             [%sanity_check] span (List.for_all Option.is_none info_fields);
             (ctx, None))
@@ -367,19 +367,19 @@ let gtranslate_adt_fields ~(project_borrows : bool)
             in
             let pat = mk_adt fields in
             (ctx, Some (infos, pat))
-      | TBuiltin TBox -> begin
+      | Some TBox -> begin
           (* The box type becomes the identity in the translation *)
           match info_fields with
           | [ None ] -> (ctx, None)
           | [ Some (info, v) ] -> (ctx, Some ([ info ], v))
           | _ -> [%craise] span "Unreachable"
         end
-      | TBuiltin TStr ->
+      | Some TStr ->
           (* This case is unreachable:
              - for strings: the [str] is not polymorphic.
           *)
           [%craise] span "Unreachable"
-      | TBuiltin TTuple ->
+      | Some TTuple ->
           (* If the filtering is activated, we ignore the fields which do not
              consume values (i.e., which do not contain ended mutable borrows). *)
           if filter then
@@ -661,7 +661,7 @@ let abs_to_consumed (ctx : bs_ctx) (ectx : C.eval_ctx) (abs : V.abs)
 
 let translate_mprojection_elem span (pe : S.mprojection_elem) : mprojection_elem
     =
-  let type_id = translate_type_id span pe.type_id in
+  let type_id = translate_type_id span pe.type_ref in
   { type_id; variant_id = pe.variant_id; field_id = pe.field_id }
 
 (** Translate a "meta"-place *)

--- a/src/symbolic/SynthesizeSymbolic.ml
+++ b/src/symbolic/SynthesizeSymbolic.ml
@@ -12,8 +12,8 @@ let mk_mplace (span : Meta.span) (p : place) (ctx : Contexts.eval_ctx) : mplace
     | PlaceLocal var_id ->
         PlaceLocal (Contexts.ctx_lookup_real_var_binder span ctx var_id)
     | PlaceProjection (subplace, Field (variant_id, field_id)) ->
-        let type_id, _ = TypesUtils.ty_as_adt subplace.ty in
-        let pe = { type_id; variant_id; field_id } in
+        let type_ref = TypesUtils.ty_as_adt subplace.ty in
+        let pe = { type_ref; variant_id; field_id } in
         PlaceProjection (place_to_mplace subplace, pe)
     | PlaceProjection (subplace, (Deref | ProjIndex _ | Subslice _)) ->
         place_to_mplace subplace

--- a/tests/src/borrow-check-negative.borrow-check.out
+++ b/tests/src/borrow-check-negative.borrow-check.out
@@ -5,7 +5,7 @@ Compiler source: interp/InterpPaths.ml, line 227
 Name pattern: 'borrow_check_negative::choose_test'
 Definition span: 'tests/src/borrow-check-negative.rs', lines 16:0-26:1
 Source: 'tests/src/borrow-check-negative.rs', lines 25:12-25:14
-Compiler source: interp/Interp.ml, line 609
+Compiler source: interp/Interp.ml, line 616
 
 [[91mError[39m] Can't end abstraction 8 as it is set as non-endable
 Source: 'tests/src/borrow-check-negative.rs', lines 28:0-34:1
@@ -14,7 +14,7 @@ Compiler source: interp/InterpBorrows.ml, line 1203
 Name pattern: 'borrow_check_negative::choose_wrong'
 Definition span: 'tests/src/borrow-check-negative.rs', lines 28:0-34:1
 Source: 'tests/src/borrow-check-negative.rs', lines 28:0-34:1
-Compiler source: interp/Interp.ml, line 609
+Compiler source: interp/Interp.ml, line 616
 
 [[91mError[39m] Can not apply a projection to the ⊥ value
 Source: 'tests/src/borrow-check-negative.rs', lines 42:4-42:11
@@ -23,7 +23,7 @@ Compiler source: interp/InterpPaths.ml, line 227
 Name pattern: 'borrow_check_negative::test_mut1'
 Definition span: 'tests/src/borrow-check-negative.rs', lines 36:0-43:1
 Source: 'tests/src/borrow-check-negative.rs', lines 42:4-42:11
-Compiler source: interp/Interp.ml, line 609
+Compiler source: interp/Interp.ml, line 616
 
 [[91mError[39m] Can not apply a projection to the ⊥ value
 Source: 'tests/src/borrow-check-negative.rs', lines 51:12-51:14
@@ -32,7 +32,7 @@ Compiler source: interp/InterpPaths.ml, line 227
 Name pattern: 'borrow_check_negative::test_mut2'
 Definition span: 'tests/src/borrow-check-negative.rs', lines 46:0-52:1
 Source: 'tests/src/borrow-check-negative.rs', lines 51:12-51:14
-Compiler source: interp/Interp.ml, line 609
+Compiler source: interp/Interp.ml, line 616
 
 [[91mError[39m] Can not apply a projection to the ⊥ value
 Source: 'tests/src/borrow-check-negative.rs', lines 65:12-65:17
@@ -41,7 +41,7 @@ Compiler source: interp/InterpPaths.ml, line 227
 Name pattern: 'borrow_check_negative::refs_test1'
 Definition span: 'tests/src/borrow-check-negative.rs', lines 59:0-66:1
 Source: 'tests/src/borrow-check-negative.rs', lines 65:12-65:17
-Compiler source: interp/Interp.ml, line 609
+Compiler source: interp/Interp.ml, line 616
 
 [[91mError[39m] Can not apply a projection to the ⊥ value
 Source: 'tests/src/borrow-check-negative.rs', lines 80:12-80:17
@@ -50,7 +50,7 @@ Compiler source: interp/InterpPaths.ml, line 227
 Name pattern: 'borrow_check_negative::refs_test2'
 Definition span: 'tests/src/borrow-check-negative.rs', lines 68:0-81:1
 Source: 'tests/src/borrow-check-negative.rs', lines 80:12-80:17
-Compiler source: interp/Interp.ml, line 609
+Compiler source: interp/Interp.ml, line 616
 
 [[91mError[39m] Can not apply a projection to the ⊥ value
 Source: 'tests/src/borrow-check-negative.rs', lines 91:12-91:15
@@ -59,5 +59,5 @@ Compiler source: interp/InterpPaths.ml, line 227
 Name pattern: 'borrow_check_negative::test_box1'
 Definition span: 'tests/src/borrow-check-negative.rs', lines 83:0-92:1
 Source: 'tests/src/borrow-check-negative.rs', lines 91:12-91:15
-Compiler source: interp/Interp.ml, line 609
+Compiler source: interp/Interp.ml, line 616
 

--- a/tests/src/higher_ranked_implied_bounds_borrow.lean.out
+++ b/tests/src/higher_ranked_implied_bounds_borrow.lean.out
@@ -2,5 +2,5 @@
 [[91mError[39m] Unimplemented: found an occurrence of a lifetime constraint relating
          a higher-ranked lifetime to a free lifetime.
 Source: 'tests/src/higher_ranked_implied_bounds_borrow.rs', lines 16:0-20:1
-Compiler source: llbc/TypesAnalysis.ml, line 967
+Compiler source: llbc/TypesAnalysis.ml, line 968
 

--- a/tests/src/higher_ranked_implied_bounds_regions.lean.out
+++ b/tests/src/higher_ranked_implied_bounds_regions.lean.out
@@ -2,5 +2,5 @@
 [[91mError[39m] Unimplemented: found an occurrence of a lifetime constraint relating
          a higher-ranked lifetime to a free lifetime.
 Source: 'tests/src/higher_ranked_implied_bounds_regions.rs', lines 19:0-23:1
-Compiler source: llbc/TypesAnalysis.ml, line 967
+Compiler source: llbc/TypesAnalysis.ml, line 968
 

--- a/tests/src/higher_ranked_implied_bounds_types.lean.out
+++ b/tests/src/higher_ranked_implied_bounds_types.lean.out
@@ -2,5 +2,5 @@
 [[91mError[39m] Unimplemented: found an occurrence of a lifetime constraint relating
          a higher-ranked lifetime to a free lifetime.
 Source: 'tests/src/higher_ranked_implied_bounds_types.rs', lines 19:0-23:1
-Compiler source: llbc/TypesAnalysis.ml, line 967
+Compiler source: llbc/TypesAnalysis.ml, line 968
 

--- a/tests/src/loops-borrow-check-negative.borrow-check.out
+++ b/tests/src/loops-borrow-check-negative.borrow-check.out
@@ -5,5 +5,5 @@ Compiler source: interp/InterpBorrows.ml, line 1203
 Name pattern: 'loops_borrow_check_negative::loop_a_b'
 Definition span: 'tests/src/loops-borrow-check-negative.rs', lines 20:0-30:1
 Source: 'tests/src/loops-borrow-check-negative.rs', lines 20:0-30:1
-Compiler source: interp/Interp.ml, line 609
+Compiler source: interp/Interp.ml, line 616
 


### PR DESCRIPTION
Companion PR to https://github.com/AeneasVerif/charon/pull/1347

The main change is the addition of `src/llbc/BuiltinTypeIds.ml`, to be able to retrieve and create new tuple definitions on the side, since tuples of different arities now need different IDs, and Charon doesn't come with all the tuple arities we might need.
