### PR TITLE
No longer build release artifacts for intel macos

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,10 +59,6 @@ jobs:
             artifact_name: aeneas-linux-aarch64
             nix_attr: aeneas-static-release
             nix_machine: false
-          - os: macos-15-intel
-            artifact_name: aeneas-macos-x86_64
-            nix_attr: aeneas-release
-            nix_machine: false
           - os: macos-latest
             artifact_name: aeneas-macos-aarch64
             nix_attr: aeneas-release


### PR DESCRIPTION
The target is deprecated by Apple and in latest nixpkgs