### PR TITLE
Fix lift_pure_function_calls to only lift monadic expressions

### DIFF
--- a/src/pure/PureMicroPassesGeneral.ml
+++ b/src/pure/PureMicroPassesGeneral.ml
@@ -2870,11 +2870,13 @@ let lift_pure_function_calls_visitor (ctx : ctx) (def : fun_decl) =
           if lifted then app else [%add_loc] mk_app span to_result_expr app
       | { e = Let (monadic, pat, bound, next); ty }, [] ->
           let next = self#visit_texpr env next in
-          (* Attempt to lift only if the let-expression is not already monadic. *)
+          (* Attempt to lift only if the let-expression is not already monadic,
+             and if the let-expression itself lives in a monad *)
           let lifted, bound =
             if monadic then (true, self#visit_texpr env bound)
-            else
+            else if is_monadic_ty ty then
               try_lift_expr (super#visit_texpr env) (self#visit_texpr env) bound
+            else (false, self#visit_texpr env bound)
           in
           { e = Let (lifted, pat, bound, next); ty }
       | f, args ->

--- a/src/pure/PureUtils.ml
+++ b/src/pure/PureUtils.ml
@@ -227,6 +227,14 @@ let dest_result_ty span (ty : ty) : ty =
 
 let is_result_ty (ty : ty) : bool = Option.is_some (opt_dest_result_ty ty)
 
+(** [true] if the type is the type of a monadic expression, i.e., an expression
+    which may appear as the body of a monadic let-binding: the error monad
+    ([Result]) or the loop monad ([LoopResult]). *)
+let is_monadic_ty (ty : ty) : bool =
+  match ty with
+  | TAdt (TBuiltin (TResult | TLoopResult), _) -> true
+  | _ -> false
+
 let dest_arrow_ty (span : Meta.span) (ty : ty) : ty * ty =
   match opt_dest_arrow_ty ty with
   | Some (arg_ty, ret_ty) -> (arg_ty, ret_ty)

--- a/tests/lean/ConstantsLean.lean
+++ b/tests/lean/ConstantsLean.lean
@@ -131,4 +131,28 @@ def Params1.CT1_LEN.default {Self : Type} (Params1Inst : Params1 Self)
   : Result Std.Usize :=
   Params1Inst.PACKED_LEN
 
+/-- [constants_lean::FEATURE_A]
+    Source: 'tests/src/constants-lean.rs', lines 52:0-52:28 -/
+@[global_simps, irreducible] def FEATURE_A : Std.U32 := 2#u32
+
+/-- [constants_lean::FEATURE_B]
+    Source: 'tests/src/constants-lean.rs', lines 53:0-53:28 -/
+@[global_simps, irreducible] def FEATURE_B : Std.U32 := 8#u32
+
+/-- [constants_lean::FEATURE_C]
+    Source: 'tests/src/constants-lean.rs', lines 54:0-54:28 -/
+@[global_simps, irreducible] def FEATURE_C : Std.U32 := 32#u32
+
+/-- [constants_lean::TWO_FEATURES]
+    Source: 'tests/src/constants-lean.rs', lines 56:0-56:48 -/
+@[global_simps, irreducible]
+def TWO_FEATURES : Std.U32 := FEATURE_A ||| FEATURE_B
+
+/-- [constants_lean::THREE_FEATURES]
+    Source: 'tests/src/constants-lean.rs', lines 57:0-57:62 -/
+@[global_simps, irreducible]
+def THREE_FEATURES : Std.U32 :=
+  let i := FEATURE_A ||| FEATURE_B
+  i ||| FEATURE_C
+
 end constants_lean

--- a/tests/src/constants-lean.rs
+++ b/tests/src/constants-lean.rs
@@ -45,3 +45,13 @@ trait Params1 {
     const PACKED_LEN: usize = (Self::N * Self::LOGQ) / 8;
     const CT1_LEN: usize = Self::PACKED_LEN;
 }
+
+// Non-failing globals must not be lifted to the error monad: chaining more than
+// two pure binary operations introduces an intermediate let-binding, which used
+// to be turned into a monadic let-binding even though the global is pure.
+const FEATURE_A: u32 = 0x02;
+const FEATURE_B: u32 = 0x08;
+const FEATURE_C: u32 = 0x20;
+
+const TWO_FEATURES: u32 = FEATURE_A | FEATURE_B;
+const THREE_FEATURES: u32 = FEATURE_A | FEATURE_B | FEATURE_C;


### PR DESCRIPTION
The extraction currently translates the following:

```rust
pub const FEATURE_A: u32 = 0x02;
pub const FEATURE_B: u32 = 0x08;
pub const FEATURE_C: u32 = 0x20;

pub const THREE_FEATURES: u32 = FEATURE_A | FEATURE_B | FEATURE_C;
```

to this:
```lean
def THREE_FEATURES : Std.U32 := do -- uses do while not in the Result monad!
  let i <- lift (FEATURE_A ||| FEATURE_B)
  i ||| FEATURE_C
```

This PR fixes it by checking that we are inside monadic code before lifting pure expressions.