### PR TITLE
Add ci check for  `tests/lean/lakefile.lean`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -193,7 +193,7 @@
             make format
             rm -rf ./src/_build
             rm -rf ./tests/test_runner/_build
-            if ! diff --no-dereference -ru . ${src}; then
+            if ! diff --no-dereference -ru ${src} .; then
               echo 'ERROR: Code is not formatted. Run `make format` to format the project files.'
               exit 1
             fi

--- a/flake.nix
+++ b/flake.nix
@@ -189,11 +189,18 @@
             inputs.charon.packages.${system}.rustToolchain
           ];
           buildPhase = ''
+            # Check that the OCaml code is formatted
             make format
             rm -rf ./src/_build
             rm -rf ./tests/test_runner/_build
             if ! diff --no-dereference -ru . ${src}; then
               echo 'ERROR: Code is not formatted. Run `make format` to format the project files.'
+              exit 1
+            fi
+            # Check that `tests/lean/lakefile.lean` is up to date.
+            make -C tests/lean lakefile.lean
+            if ! diff --no-dereference -u ${src}/tests/lean/lakefile.lean tests/lean/lakefile.lean; then
+              echo 'ERROR: tests/lean/lakefile.lean is out of date. Run `make -C tests/lean lakefile.lean`.'
               exit 1
             fi
           '';

--- a/tests/lean/lakefile.lean
+++ b/tests/lean/lakefile.lean
@@ -47,6 +47,7 @@ package «tests» {}
 @[default_target] lean_lib Issue1044OpaqueTuple
 @[default_target] lean_lib Issue1140GlobalLoop
 @[default_target] lean_lib Issue1141ImplFnRef
+@[default_target] lean_lib Issue1250AnonymousConst
 @[default_target] lean_lib Issue134LoopSharedBorrows
 @[default_target] lean_lib Issue194RecursiveStructProjector
 @[default_target] lean_lib Issue270LoopList


### PR DESCRIPTION
The file `tests/lean/lakefile.lean` needs to be updated each time a new lean test is added. This PR adds a check in CI to confirm that the lakefile is properly updated. (Also updates the lakefile because one entry was missing.) 

The part of the CI which checks that the lean files build correctly always regenerates the lakefile before building and so nothing was getting missed, this was only an issue for building the lean test files locally. 

A more general solution which fits with standard lean practice would be to have a single lakefile in root with several lean_lib, one of which is for the test output lean files (#706). Then in CI we would confirm that `lake exe mk_all` is up to date. 

AI: used to get info on the args used for diff, comments, etc written manually. 