### PR TITLE
Fix a bug in `PrePasses.simplify_trait_calls`

### DIFF
--- a/src/PrePasses.ml
+++ b/src/PrePasses.ml
@@ -2169,6 +2169,11 @@ let simplify_trait_calls (crate : crate) : crate =
       if f.item_meta.is_local then visitor#visit_fun_decl_id () f.def_id;
       match f.body with
       | StructuredBody body -> visitor#visit_block () body.body
+      | TargetDispatchBody targets ->
+          List.iter
+            (fun ((_ : string), (fdr : Types.fun_decl_ref)) ->
+              visitor#visit_fun_decl_id () fdr.id)
+            targets
       | _ -> ())
     crate.fun_decls;
 


### PR DESCRIPTION
A case had been forgotten, making the pass filter function declarations that it should preserve.