### PR TITLE
Fix release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,11 +108,15 @@ jobs:
           curl https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh -sSf | sh -s -- -y --default-toolchain none
           echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
 
+      - name: Hash Lean dependencies
+        id: hash-lean-dependencies
+        run: echo "hash=$(nix-hash --flat --type sha256 dist_staging/backends/lean/lake-manifest.json)" >> "$GITHUB_OUTPUT"
+
       - name: Cache Lean dependencies
         uses: actions/cache@v6
         with:
           path: dist_staging/backends/lean/.lake
-          key: ${{ matrix.os }}-lean-${{ hashFiles('dist_staging/backends/lean/lake-manifest.json') }}
+          key: ${{ matrix.os }}-lean-${{ steps.hash-lean-dependencies.outputs.hash }}
           restore-keys: |
             ${{ matrix.os }}-lean-
 


### PR DESCRIPTION
The `hashFiles(..)` helper is not available on node 24 it seems