### PR TITLE
Let spec register a discharge tactic

### DIFF
--- a/backends/lean/Aeneas/Std/Spec.lean
+++ b/backends/lean/Aeneas/Std/Spec.lean
@@ -25,6 +25,11 @@ structure SpecInfo where
   mk_spec_bind : Name
   mk_spec_bind_skip_args : Nat
 
+  /-- Tactic applied on mono's and bind's preconditions in `step`
+      and mono's final goal in `step*`.
+      If not solved, then the precondition/goal stay unchanged. -/
+  discharge_tactic : Option Name := none
+
   uncurry_elim_tactics : Array Lean.Name
   qimp_elim_tactics : Array Lean.Name
 

--- a/backends/lean/Aeneas/Tactic/Step/Step.lean
+++ b/backends/lean/Aeneas/Tactic/Step/Step.lean
@@ -245,6 +245,21 @@ def getSpecPost (ty : Expr) : MetaM Expr := do
   let (info, args) ← getSpecInfoArgs ty
   return args[info.post_index]!
 
+/-- The discharge tactic registered for a specification statement. -/
+def getDischargeTactic (ty : Expr) : MetaM (Option (TSyntax `tactic)) := do
+  let (info, _) ← getSpecInfoArgs ty
+  let some tacticName := info.discharge_tactic
+    | return none
+  match Parser.runParserCategory (← getEnv) `tactic tacticName.toString with
+  | .ok tactic => pure (some ⟨tactic⟩)
+  | .error error => throwError
+      "Could not parse registered discharge tactic `{tacticName}`: {error}"
+
+/-- The discharge tactic registered for the specification statement in the current goal. -/
+def getDischargeTacticFromGoal : TacticM (Option (TSyntax `tactic)) := do
+  withMainContext do
+  getDischargeTactic (← getMainTarget)
+
 /- Analyze a goal comp
 
    If comp = bind m k then return true and m
@@ -1287,6 +1302,30 @@ def evalAGrindWithPreprocess (withGroundSimprocs : Bool) (config : Grind.Config)
       Aeneas.Grind.agrindEval config params mvarId
     catch e => trace[Step] "Grind failed:\n{e.toMessageData}"
 
+/-- Prepare the tactics used to discharge preconditions and infer ghost variables. -/
+def prepareAssumTac (config : Config) : TacticM (Option (TacticM Unit)) := do
+  /- **The specification's discharge tactic**: -/
+  let dischargeTac : List (TacticM Unit) ← do
+    match ← getDischargeTacticFromGoal with
+    | none => pure []
+    | some tac => pure [
+        withTraceNode `Step
+          (fun _ => pure m!"Attempting to solve with the discharge tactic: `{tac}`") do
+        evalTactic tac
+      ]
+
+  let customAssumTacs : List (TacticM Unit) ← do
+    if config.assumTac then
+      /- Preprocessing step for `singleAssumptionTac` -/
+      let singleAssumptionTacDtree ← singleAssumptionTacPreprocess
+      pure [do
+        withTraceNode `Step (fun _ => pure m!"Attempting to solve with `singleAssumptionTac`") do
+        singleAssumptionTacCore singleAssumptionTacDtree (instMVars := config.inferGhostVars)]
+    else pure []
+
+  let assumTacs := dischargeTac ++ customAssumTacs
+  return if assumTacs.isEmpty then none else some (firstTacSolve assumTacs)
+
 def evalStepCore (config : Config) (keepPretty : Option Name) (withArg : Option Expr)
   (ids : Array (Option Name)) (idsUserProvided : Bool) (postsBasename : Option Name := none)
   (byTacStx : Option Syntax.Tactic)
@@ -1300,20 +1339,13 @@ def evalStepCore (config : Config) (keepPretty : Option Name) (withArg : Option 
   withMainContext do
 
   /- **Assumption tactic**:
-
     We use it to:
     - discharge preconditions by using local assumptions (this is activated by `Config.assumTac`)
+      and the registered discharge tactic
     - more importantly, instantiate meta-variables introduced because of ghost variables, by matching
       preconditions against local assumptions (this is activated by `Config.inferGhostVars`)
   -/
-  let customAssumTac : Option (TacticM Unit) ← do
-    if config.assumTac then
-      /- Preprocessing step for `singleAssumptionTac` -/
-      let singleAssumptionTacDtree ← singleAssumptionTacPreprocess
-      pure (some do
-        withTraceNode `Step (fun _ => pure m!"Attempting to solve with `singleAssumptionTac`") do
-        singleAssumptionTacCore singleAssumptionTacDtree (instMVars := config.inferGhostVars))
-    else pure none
+  let assumTac ← prepareAssumTac config
 
   /- **Grind tactic**: Excluded from allTacs when `threadGrindState = true` -/
   let grindTac : List (TacticM Unit) :=
@@ -1408,7 +1440,7 @@ def evalStepCore (config : Config) (keepPretty : Option Name) (withArg : Option 
     async := config.async,
     inferGhostVars := config.inferGhostVars,
     inferPost := config.inferPost,
-    keepPretty, ids, idsUserProvided, postsBasename, assumTac := customAssumTac,
+    keepPretty, ids, idsUserProvided, postsBasename, assumTac,
     solvePreconditionTac,
     config,
     stepState := if config.threadGrindState then stepState else {},

--- a/backends/lean/Aeneas/Tactic/Step/StepStar.lean
+++ b/backends/lean/Aeneas/Tactic/Step/StepStar.lean
@@ -372,7 +372,7 @@ partial def Script.toSyntax (script : Script) : MetaM (Array Syntax.Tactic) := d
 inductive TargetKind where
 | bind (names : Array (Option Name))
 | switch (info : Bifurcation.Info)
-| result
+| result (dischargeTac : Option (TSyntax `tactic))
 | unknown
 
 /- Smaller helper which we use to check in which situation we are -/
@@ -383,7 +383,7 @@ def analyzeTarget : TacticM TargetKind := do
     -- Dive into a registered specification
     let some program ← observing? (Step.getSpecProgram goalTy)
       | trace[Step] "not an application of a registered specification statement: {goalTy}"
-        return .result
+        return .result none
     trace[Step] "application of a registered specification statement about: {program}"
     let e ← Utils.normalizeLetBindings program
     -- Check whether this is a bind
@@ -396,7 +396,7 @@ def analyzeTarget : TacticM TargetKind := do
       pure (.switch bfInfo)
     else
       trace[Step] "not a registered spec"
-      pure .result
+      pure (.result (← Step.getDischargeTactic goalTy))
   catch _ =>
     trace[Step] "exception caught"
     pure .unknown
@@ -543,21 +543,22 @@ where
       /- Put everything together — after branches, state is discarded (we can't merge
          divergent e-graphs). Use the pre-branch state going forward. -/
       mkStx branchInfos
-    | .result => do
-      let (info, mainGoal) ← onResult cfg ss
+    | .result dischargeTac => do
+      let (info, mainGoal) ← onResult cfg ss dischargeTac
       let mainGoal ← match mainGoal with
         | none => pure #[]
         | some mainGoal => pure #[(mainGoal, none)]
       pure { info with subgoals := info.subgoals ++ mainGoal }
     | .unknown => do
       trace[Step] "don't know what to do: it may be a terminal goal, attempting to solve it with grind"
-      let (info, mainGoal) ← onResult cfg ss
+      let (info, mainGoal) ← onResult cfg ss none
       let mainGoal ← match mainGoal with
         | none => pure #[]
         | some mainGoal => pure #[(mainGoal, none)]
       pure { info with subgoals := info.subgoals ++ mainGoal }
 
-  onResult (cfg : Config) (ss : Step.StepState) : TacticM (Info × Option MVarId) := do
+  onResult (cfg : Config) (ss : Step.StepState)
+      (dischargeTac : Option (TSyntax `tactic)) : TacticM (Info × Option MVarId) := do
     withTraceNode `Step (fun _ => pure m!"onResult") do
     /- If we encounter `(do f a)` we process it as if it were `(do let res ← f a; return res)`
        since (id = (· >>= pure)) and when we desugar the do block we have that
@@ -575,10 +576,16 @@ where
       trace[Step] "done"
       pure (info, none)
     | some (mvarId, _) =>
-      let (info', mvarId) ← onFinish cfg mvarId
+      let dischargeTactics :=
+        match dischargeTac with
+        | none => []
+        | some tac => [("specification discharge tactic", tac, evalTactic tac)]
+      let (info', mvarId) ← onFinish cfg mvarId dischargeTactics
       pure (info ++ info', mvarId)
 
-  onFinish (cfg : Config) (mvarId : MVarId) : TacticM (Info × Option MVarId) := do
+  onFinish (cfg : Config) (mvarId : MVarId)
+      (extraTacl : List (String × Syntax.Tactic × TacticM Unit) := []) :
+      TacticM (Info × Option MVarId) := do
     withTraceNode `Step (fun _ => pure m!"onFinish") do
     setGoals [mvarId]
     traceGoalWithNode "goal"
@@ -615,7 +622,7 @@ where
             tacStx.resolve stx
           | none => tryFinish tacl
       let finishTactics :=
-        [("grind", ← `(tactic| agrind), grindTac)] ++
+        [("grind", ← `(tactic| agrind), grindTac)] ++ extraTacl ++
         match cfg.preconditionTac with
         | none => []
         | some tac => [("user tactic", tac, evalTactic tac)]

--- a/backends/lean/Aeneas/Tactic/Step/Tests.lean
+++ b/backends/lean/Aeneas/Tactic/Step/Tests.lean
@@ -1,5 +1,6 @@
 import Aeneas.Tactic.Step.Tests.Triple
 import Aeneas.Tactic.Step.Tests.Coin
+import Aeneas.Tactic.Step.Tests.DischargeTactic
 import Aeneas.Tactic.Step.Tests.HigherOrder
 import Aeneas.Tactic.Step.Tests.IntroOutputs
 import Aeneas.Tactic.Step.Tests.MaxRecDepthMetavar

--- a/backends/lean/Aeneas/Tactic/Step/Tests/DischargeTactic.lean
+++ b/backends/lean/Aeneas/Tactic/Step/Tests/DischargeTactic.lean
@@ -1,0 +1,95 @@
+import Aeneas.Tactic.Step
+
+open Aeneas
+
+/-!
+# Tests for `SpecInfo.discharge_tactic`
+-/
+
+namespace Aeneas.Tactic.Step.Tests.DischargeTactic
+
+abbrev Post (α : Type) := α → Prop
+
+def Post.entails (P Q : Post α) : Prop := ∀ value, P value → Q value
+
+theorem Post.entails_iff (P Q : Post α) :
+    Post.entails P Q ↔ ∀ value, P value → Q value :=
+  Iff.rfl
+
+def triple (P : Prop) (m : Id α) (Q : Post α) : Prop :=
+  P → Q m
+
+theorem triple_step_mono {P Pm : Prop} {Q : Post α}
+    (m : Id α) (Qm : Post α) (hStep : triple Pm m Qm)
+    (hPre : P → Pm)
+    (hPost : Post.entails Qm Q) :
+    triple P m Q :=
+  fun hP => hPost m (hStep (hPre hP))
+
+inductive DischargeMarker : Prop where
+  | intro
+
+theorem triple_step_bind {P Pm : Prop} {next : α → Id β} {Q : Post β}
+    (m : Id α) (Qm : Post α) (hStep : triple Pm m Qm)
+    (hPre : P → Pm)
+    (_ : DischargeMarker) -- `step` must apply the registered discharge tactic.
+    (hNext : ∀ value, triple (Qm value) (next value) Q) :
+    triple P (m >>= next) Q :=
+  fun hP => hNext m (hStep (hPre hP))
+
+
+theorem dischargeMarker : DischargeMarker :=
+  .intro
+
+elab "discharge_markers" : tactic => do
+  Lean.Elab.Tactic.evalTactic (← `(tactic| first
+    | exact dischargeMarker
+    | assumption))
+
+#register_spec_info {
+    spec_name := ``triple
+    arity := 4
+    program_index := 2
+    post_index := 3
+    mk_spec_mono := ``triple_step_mono
+    mk_spec_mono_skip_args := 4
+    mk_spec_bind := ``triple_step_bind
+    mk_spec_bind_skip_args := 6
+    discharge_tactic := some `discharge_markers
+    qimp_elim_tactics := #[``Post.entails_iff, ``true_imp_iff]
+    uncurry_elim_tactics := #[]
+    to_mvcgen := none
+    liftings := #[]
+  }
+
+def pureValue (value : Nat) : Id Nat :=
+  value
+
+@[step]
+theorem pureValue_spec (value : Nat) (h : DischargeMarker) :
+    triple True (pureValue value) (fun _ => DischargeMarker) :=
+  fun _ => h
+
+/- Should infer the ghost argument from the precondition. -/
+example (value : Nat) :
+    triple True (pureValue value) (fun  _ => DischargeMarker) := by
+  step
+  assumption -- Plain `step` leaves the mono goal for the caller.
+
+/- `step*` runs the specification's discharge tactic on the final mono goal. -/
+example (value : Nat) :
+    triple True (pureValue value) (fun _ => DischargeMarker) := by
+  step*
+
+/--
+info: Try this:
+
+  [apply]     let* ⟨ _, _ ⟩ ← pureValue_spec
+    agrind
+-/
+#guard_msgs in
+example (value : Nat) :
+    triple True (pureValue value) (fun _ => DischargeMarker) := by
+  step*?
+
+end Aeneas.Tactic.Step.Tests.DischargeTactic


### PR DESCRIPTION
Adds support for registering a custom discharge tactic for `step`. The tactic is ran on `step`'s preconditions and on `step*`'s final goal.