### PR TITLE
Add generic coinductive specifications and refactor WP around them

### DIFF
--- a/backends/lean/Aeneas/Data/Coinductive/ITree.lean
+++ b/backends/lean/Aeneas/Data/Coinductive/ITree.lean
@@ -212,6 +212,9 @@ instance : Monad (ITree.{u} E) where
   pure := ITree.ret
   bind := ITree.bind
 
+@[simp]
+theorem ITree.pure_eq_ret (r : R) : (pure r : ITree E R) = ITree.ret r := rfl
+
 @[elab_as_elim, cases_eliminator]
 def ITree.cases {E : Effect.{u}} {R}
     {motive : ITree E R → Sort v}
@@ -327,6 +330,15 @@ theorem ret_inj {E} {α} {x y} : (@ITree.ret α E x = ITree.ret y) ↔ (x = y) :
 theorem vis_inj_effect {E} {α} {e1 e2 k1 k2} : @ITree.vis α E e1 k1 = ITree.vis e2 k2
   → e1 = e2 := by grind
 
+/-- The event *and* the continuations of two equal `vis` nodes agree. -/
+theorem vis_inj {R : Type w} {E : Effect.{v}} {i i' : E.I} {k : E.O i → ITree E R}
+    {k' : E.O i' → ITree E R} (hEq : ITree.vis i k = ITree.vis i' k') :
+    i = i' ∧ HEq k k' := by
+  have hUnfold := congrArg ITree.unfold hEq
+  simp only [unfold_vis] at hUnfold
+  injection hUnfold with hEvent hCont
+  exact ⟨hEvent, hCont⟩
+
 -- Theorems to make ITree.cases compute:
 @[simp]
 theorem ITree.cases.ret {E R motive r d v x}
@@ -377,5 +389,128 @@ theorem ITree.div_is_bot :
   have dir1 := csup_le (x := .div) (chain_empty (ITree E R)) (by grind [empty_chain])
   apply ITree.le_div_is_div
   assumption
+
+/-! ## Chains of trees and their suprema
+
+These lemmas characterize the shape and children of chain suprema.
+-/
+
+/-- A tree below a return is that return, or the bottom element. -/
+theorem ITree.le_ret_cases {t : ITree E R} {value : R} (hLe : t ⊑ ITree.ret value) :
+    t = ITree.div ∨ t = ITree.ret value := by
+  rw [ITree.le_unfold] at hLe
+  obtain rfl | ⟨_, rfl, hRet⟩ | ⟨_, _, _, _, hVis, _⟩ := hLe
+  · exact Or.inl rfl
+  · exact Or.inr (by rw [ret_inj.mp hRet])
+  · exact absurd hVis not_vis_ret
+
+/-- A tree below a `vis` node performs the same event, or is the bottom
+element. -/
+theorem ITree.le_vis_cases {t : ITree E R} {i : E.I} {k : E.O i → ITree E R}
+    (hLe : t ⊑ ITree.vis i k) :
+    t = ITree.div ∨ ∃ k', t = ITree.vis i k' ∧ ∀ o, k' o ⊑ k o := by
+  rw [ITree.le_unfold] at hLe
+  obtain rfl | ⟨_, _, hRet⟩ | ⟨_, k₁, k₂, rfl, hVis, hCont⟩ := hLe
+  · exact Or.inl rfl
+  · exact absurd hRet.symm not_vis_ret
+  · obtain ⟨rfl, hHEq⟩ := vis_inj hVis
+    obtain rfl := eq_of_heq hHEq
+    exact Or.inr ⟨k₁, rfl, hCont⟩
+
+/-- And a tree above a `vis` node performs that event too: an approximation is
+only ever refined, never contradicted. -/
+theorem ITree.vis_le_cases {t : ITree E R} {i : E.I} {k : E.O i → ITree E R}
+    (hLe : ITree.vis i k ⊑ t) :
+    ∃ k', t = ITree.vis i k' ∧ ∀ o, k o ⊑ k' o := by
+  rw [ITree.le_unfold] at hLe
+  obtain hDiv | ⟨_, hRet, _⟩ | ⟨_, k₁, k₂, hVis, rfl, hCont⟩ := hLe
+  · exact absurd hDiv.symm not_div_vis
+  · exact absurd hRet.symm not_vis_ret
+  · obtain ⟨rfl, hHEq⟩ := vis_inj hVis
+    obtain rfl := eq_of_heq hHEq
+    exact ⟨k₂, rfl, hCont⟩
+
+/-- Every element of a chain that contains a `vis` node is `div` or a `vis` node
+on the same event. -/
+theorem ITree.chain_vis_cases {c : ITree E R → Prop} (hc : chain c) {i : E.I}
+    {k' : E.O i → ITree E R} (hMem : c (ITree.vis i k')) {u : ITree E R}
+    (hu : c u) : u = ITree.div ∨ ∃ k'', u = ITree.vis i k'' := by
+  obtain hLe | hLe := hc _ _ hu hMem
+  · exact (ITree.le_vis_cases hLe).imp id fun ⟨k'', hEq, _⟩ => ⟨k'', hEq⟩
+  · exact Or.inr ((ITree.vis_le_cases hLe).imp fun k'' h => h.1)
+
+/-- The chain of the `o`-children of the `vis` nodes of a chain of trees.  The
+supremum of a chain of trees is a `vis` node whose children are the suprema of
+exactly these. -/
+def ITree.visChain (c : ITree E R → Prop) (i : E.I) (o : E.O i) :
+    ITree E R → Prop :=
+  fun t => ∃ k, c (ITree.vis i k) ∧ t = k o
+
+theorem ITree.visChain_chain {c : ITree E R → Prop} (hc : chain c) (i : E.I)
+    (o : E.O i) : chain (ITree.visChain c i o) := by
+  rintro _ _ ⟨k₁, hMem₁, rfl⟩ ⟨k₂, hMem₂, rfl⟩
+  obtain hLe | hLe := hc _ _ hMem₁ hMem₂
+  · obtain hDiv | ⟨k, hEq, hCont⟩ := ITree.le_vis_cases hLe
+    · exact absurd hDiv.symm not_div_vis
+    · obtain ⟨-, hHEq⟩ := vis_inj hEq
+      obtain rfl := eq_of_heq hHEq
+      exact Or.inl (hCont o)
+  · obtain hDiv | ⟨k, hEq, hCont⟩ := ITree.le_vis_cases hLe
+    · exact absurd hDiv.symm not_div_vis
+    · obtain ⟨-, hHEq⟩ := vis_inj hEq
+      obtain rfl := eq_of_heq hHEq
+      exact Or.inr (hCont o)
+
+/-- A chain whose supremum returns a value contains that very return: a limit
+returns nothing its approximations do not. -/
+theorem ITree.csup_ret_mem {c : ITree E R → Prop} (hc : chain c) {value : R}
+    (hEq : CCPO.csup hc = ITree.ret value) : c (ITree.ret value) := by
+  refine Classical.byContradiction fun hNot => ?_
+  have hDiv : ∀ y, c y → y ⊑ (ITree.div : ITree E R) := by
+    intro y hy
+    have hLe : y ⊑ ITree.ret value := hEq ▸ le_csup hc hy
+    obtain rfl | rfl := ITree.le_ret_cases hLe
+    · exact PartialOrder.rel_refl
+    · exact absurd hy hNot
+  exact not_ret_div (ITree.le_div_is_div _ (hEq ▸ csup_le hc hDiv))
+
+/-- And a chain whose supremum performs an event contains a tree that performs
+it. -/
+theorem ITree.csup_vis_mem {c : ITree E R → Prop} (hc : chain c) {i : E.I}
+    {k : E.O i → ITree E R} (hEq : CCPO.csup hc = ITree.vis i k) :
+    ∃ k', c (ITree.vis i k') := by
+  refine Classical.byContradiction fun hNot => ?_
+  simp only [not_exists] at hNot
+  have hDiv : ∀ y, c y → y ⊑ (ITree.div : ITree E R) := by
+    intro y hy
+    have hLe : y ⊑ ITree.vis i k := hEq ▸ le_csup hc hy
+    obtain rfl | ⟨k', rfl, -⟩ := ITree.le_vis_cases hLe
+    · exact PartialOrder.rel_refl
+    · exact absurd hy (hNot k')
+  exact not_div_vis (ITree.le_div_is_div _ (hEq ▸ csup_le hc hDiv)).symm
+
+/-- The children of the supremum are the suprema of the children: what a limit
+does after an event is what its approximations do after it. -/
+theorem ITree.csup_vis {c : ITree E R → Prop} (hc : chain c) {i : E.I}
+    {k' : E.O i → ITree E R} (hMem : c (ITree.vis i k')) :
+    CCPO.csup hc =
+      ITree.vis i (fun o => CCPO.csup (ITree.visChain_chain hc i o)) := by
+  refine is_sup_unique (CCPO.csup_spec hc) (fun x => ⟨fun hLe y hy => ?_, ?_⟩)
+  · refine PartialOrder.rel_trans ?_ hLe
+    obtain rfl | ⟨k'', rfl⟩ := ITree.chain_vis_cases hc hMem hy
+    · exact ITree.div_is_bot ▸ bot_le _
+    · rw [ITree.le_unfold]
+      exact Or.inr (Or.inr ⟨i, k'', _, rfl, rfl,
+        fun o => le_csup (ITree.visChain_chain hc i o) ⟨k'', hy, rfl⟩⟩)
+  · intro hUpper
+    obtain ⟨kx, rfl, -⟩ := ITree.vis_le_cases (hUpper _ hMem)
+    rw [ITree.le_unfold]
+    refine Or.inr (Or.inr ⟨i, _, kx, rfl, rfl, fun o => ?_⟩)
+    refine csup_le (ITree.visChain_chain hc i o) ?_
+    rintro _ ⟨k'', hMem'', rfl⟩
+    obtain ⟨kx', hEqx, hCont⟩ := ITree.vis_le_cases (hUpper _ hMem'')
+    obtain ⟨-, hHEq⟩ := vis_inj hEqx
+    obtain rfl := eq_of_heq hHEq
+    exact hCont o
 
 namespace Aeneas.Data.Coinductive

--- a/backends/lean/Aeneas/Data/Coinductive/Spec.lean
+++ b/backends/lean/Aeneas/Data/Coinductive/Spec.lean
@@ -1,0 +1,599 @@
+import Aeneas.Data.Coinductive.StateMachine
+
+/-!
+Generic total- and partial-correctness judgments for interaction trees.
+`TotalSpec` is a least fixed point; `PartialSpec` is a greatest fixed point
+that permits divergence but not stuck events.
+-/
+
+namespace Aeneas.Data.Coinductive
+
+open Lean.Order
+
+universe u u' v w
+
+variable {E : Effect.{v}} {α : Type u} {β : Type u'} {M : StateMachine.{w, v} E}
+
+/-! ## One layer of a correctness judgment -/
+
+/-- One correctness layer: returns use `Q`, divergence uses `Div`, and events
+delegate to `M.handle`. -/
+def SpecF (M : StateMachine E) (Q : α → M.State → Prop) (Div : Prop)
+    (X : ITree E α → M.State → Prop) (m : ITree E α) (s : M.State) : Prop :=
+  ITree.cases
+    (motive := fun _ => Prop)
+    (fun value => Q value s)
+    Div
+    (fun event k => M.handle event s fun answer s' => X (k answer) s')
+    m
+
+/-! Computation rules for `SpecF`. -/
+
+theorem SpecF.ret {Q : α → M.State → Prop} {Div : Prop}
+    {X : ITree E α → M.State → Prop} {value : α} {s : M.State} :
+    SpecF M Q Div X (.ret value) s = Q value s := by
+  simp only [SpecF, ITree.cases.ret]
+
+theorem SpecF.div {Q : α → M.State → Prop} {Div : Prop}
+    {X : ITree E α → M.State → Prop} {s : M.State} :
+    SpecF M Q Div X (ITree.div : ITree E α) s = Div := by
+  simp only [SpecF, ITree.cases.div]
+
+/-- The event case, which hands the obligation straight to the machine. -/
+theorem SpecF.vis {Q : α → M.State → Prop} {Div : Prop}
+    {X : ITree E α → M.State → Prop} {event : E.I} {k : E.O event → ITree E α}
+    {s : M.State} :
+    SpecF M Q Div X (.vis event k) s =
+      M.handle event s fun answer s' => X (k answer) s' := by
+  simp only [SpecF, ITree.cases.vis]
+
+/-- `SpecF` is monotone in its postcondition, divergence case, and tail. -/
+theorem SpecF.mono {Q Q' : α → M.State → Prop} {Div Div' : Prop}
+    {X X' : ITree E α → M.State → Prop}
+    (hQ : ∀ value s, Q value s → Q' value s) (hDiv : Div → Div')
+    (hX : ∀ m s, X m s → X' m s) {m : ITree E α} {s : M.State}
+    (hLayer : SpecF M Q Div X m s) : SpecF M Q' Div' X' m s := by
+  revert hLayer
+  cases m using ITree.cases with
+  | ret value =>
+      simp only [ITree.pure_eq_ret, SpecF.ret]
+      exact hQ value s
+  | div =>
+      simp only [SpecF.div]
+      exact hDiv
+  | vis event k =>
+      simp only [SpecF.vis]
+      exact M.handle_mono fun answer s' => hX (k answer) s'
+
+/-- The common case of `SpecF.mono`: only the rest of the run is weakened. -/
+theorem SpecF.mono_tail {Q : α → M.State → Prop} {Div : Prop}
+    {X X' : ITree E α → M.State → Prop} (hX : ∀ m s, X m s → X' m s)
+    {m : ITree E α} {s : M.State} (hLayer : SpecF M Q Div X m s) :
+    SpecF M Q Div X' m s :=
+  hLayer.mono (fun _ _ => id) id hX
+
+/-! ## The two judgments -/
+
+/-- Total correctness as the least fixed point of `SpecF Q False`. -/
+def TotalSpec (M : StateMachine E) (Q : α → M.State → Prop) (m : ITree E α)
+    (s : M.State) : Prop :=
+  ∀ X : ITree E α → M.State → Prop,
+    (∀ m' s', SpecF M Q False X m' s' → X m' s') → X m s
+
+/-- Partial correctness as the greatest fixed point of `SpecF Q True`. -/
+def PartialSpec (M : StateMachine E) (Q : α → M.State → Prop) (m : ITree E α)
+    (s : M.State) : Prop :=
+  ∃ X : ITree E α → M.State → Prop,
+    (∀ m' s', X m' s' → SpecF M Q True X m' s') ∧ X m s
+
+/-! ### The constructors and destructors of `TotalSpec` -/
+
+/-- Induction on a total-correctness derivation. -/
+theorem TotalSpec.induction {Q : α → M.State → Prop}
+    {P : ITree E α → M.State → Prop}
+    (hRet : ∀ value s, Q value s → P (.ret value) s)
+    (hVis : ∀ (event : E.I) (k : E.O event → ITree E α) (s : M.State),
+      M.handle event s (fun answer s' => P (k answer) s') → P (.vis event k) s)
+    {m : ITree E α} {s : M.State} (hSpec : TotalSpec M Q m s) : P m s := by
+  refine hSpec P fun m' s' hLayer => ?_
+  revert hLayer
+  cases m' using ITree.cases with
+  | ret value =>
+      simp only [ITree.pure_eq_ret, SpecF.ret]
+      exact hRet value s'
+  | div =>
+      simp only [SpecF.div]
+      exact False.elim
+  | vis event k =>
+      simp only [SpecF.vis]
+      exact hVis event k s'
+
+/-- Total correctness is a pre-fixed point: one layer of it is it.  This is the
+two constructors at once, and the exact counterpart of `PartialSpec.intro`. -/
+theorem TotalSpec.intro {Q : α → M.State → Prop} {m : ITree E α} {s : M.State}
+    (hLayer : SpecF M Q False (TotalSpec M Q) m s) : TotalSpec M Q m s :=
+  fun X hClosed => hClosed m s (hLayer.mono_tail fun _ _ hSpec => hSpec X hClosed)
+
+/-- And it is a fixed point: it survives one event.  Every destructor below is
+this rule read in one of the three cases of `SpecF`, and it is the counterpart of
+`PartialSpec.step`. -/
+theorem TotalSpec.step {Q : α → M.State → Prop} {m : ITree E α} {s : M.State}
+    (hSpec : TotalSpec M Q m s) : SpecF M Q False (TotalSpec M Q) m s :=
+  hSpec.induction
+    (P := SpecF M Q False (TotalSpec M Q))
+    (fun _ _ hPost => by simpa only [SpecF.ret] using hPost)
+    fun _ _ _ hHandle => by
+      simpa only [SpecF.vis] using
+        M.handle_mono (fun _ _ hLayer => TotalSpec.intro hLayer) hHandle
+
+theorem TotalSpec.ret {Q : α → M.State → Prop} {value : α} {s : M.State}
+    (hPost : Q value s) : TotalSpec M Q (.ret value) s :=
+  intro (by simpa only [SpecF.ret] using hPost)
+
+theorem TotalSpec.vis {Q : α → M.State → Prop} {event : E.I}
+    {k : E.O event → ITree E α} {s : M.State}
+    (hHandle : M.handle event s fun answer s' => TotalSpec M Q (k answer) s') :
+    TotalSpec M Q (.vis event k) s :=
+  intro (by simpa only [SpecF.vis] using hHandle)
+
+theorem TotalSpec.ret_post {Q : α → M.State → Prop} {value : α} {s : M.State}
+    (hSpec : TotalSpec M Q (.ret value) s) : Q value s := by
+  simpa only [SpecF.ret] using hSpec.step
+
+/-- `TotalSpec.ret`/`TotalSpec.ret_post` as one rewrite. -/
+@[simp]
+theorem TotalSpec.ret_iff {Q : α → M.State → Prop} {value : α} {s : M.State} :
+    TotalSpec M Q (.ret value) s ↔ Q value s :=
+  ⟨TotalSpec.ret_post, TotalSpec.ret⟩
+
+/-- Divergence is never totally correct.  This is the case `PartialSpec`
+deliberately keeps. -/
+theorem TotalSpec.div_false {Q : α → M.State → Prop} {s : M.State}
+    (hSpec : TotalSpec M Q (ITree.div : ITree E α) s) : False := by
+  simpa only [SpecF.div] using hSpec.step
+
+/-- The event destructor: the machine answers the event here, and total
+correctness continues in the state it answers with.  An event the machine cannot
+answer is not totally correct, since there is nothing to destructure. -/
+theorem TotalSpec.vis_view {Q : α → M.State → Prop} {event : E.I}
+    {k : E.O event → ITree E α} {s : M.State}
+    (hSpec : TotalSpec M Q (.vis event k) s) :
+    M.handle event s fun answer s' => TotalSpec M Q (k answer) s' := by
+  simpa only [SpecF.vis] using hSpec.step
+
+/-! ### The constructors and destructors of `PartialSpec`
+
+The same for the greatest fixed point, where `PartialSpec.coinduction` takes the
+place `TotalSpec.induction` has above. -/
+
+/-- The introduction rule: a relation closed under one event proves partial
+correctness of every configuration it holds of.  This is what a loop invariant
+is applied to. -/
+theorem PartialSpec.coinduction {Q : α → M.State → Prop}
+    (X : ITree E α → M.State → Prop)
+    (hClosed : ∀ m' s', X m' s' → SpecF M Q True X m' s') {m : ITree E α}
+    {s : M.State} (hX : X m s) : PartialSpec M Q m s :=
+  ⟨X, hClosed, hX⟩
+
+/-- Partial correctness is a post-fixed point: it survives one event. -/
+theorem PartialSpec.step {Q : α → M.State → Prop} {m : ITree E α} {s : M.State}
+    (hSpec : PartialSpec M Q m s) : SpecF M Q True (PartialSpec M Q) m s := by
+  obtain ⟨X, hClosed, hX⟩ := hSpec
+  exact (hClosed m s hX).mono_tail fun m' s' hX' => ⟨X, hClosed, hX'⟩
+
+/-- And it is a fixed point: one layer of it is it. -/
+theorem PartialSpec.intro {Q : α → M.State → Prop} {m : ITree E α} {s : M.State}
+    (hLayer : SpecF M Q True (PartialSpec M Q) m s) : PartialSpec M Q m s := by
+  refine coinduction
+    (fun m' s' => PartialSpec M Q m' s' ∨ (m' = m ∧ s' = s)) ?_ (Or.inr ⟨rfl, rfl⟩)
+  rintro m' s' (hSpec | ⟨rfl, rfl⟩)
+  · exact hSpec.step.mono_tail fun _ _ => Or.inl
+  · exact hLayer.mono_tail fun _ _ => Or.inl
+
+theorem PartialSpec.ret {Q : α → M.State → Prop} {value : α} {s : M.State}
+    (hPost : Q value s) : PartialSpec M Q (.ret value) s :=
+  intro (by simpa only [SpecF.ret] using hPost)
+
+/-- Divergence owes nothing.  This is the constructor `TotalSpec` deliberately
+does not have. -/
+@[simp]
+theorem PartialSpec.div {Q : α → M.State → Prop} {s : M.State} :
+    PartialSpec M Q (ITree.div : ITree E α) s :=
+  intro (by simp only [SpecF.div])
+
+theorem PartialSpec.vis {Q : α → M.State → Prop} {event : E.I}
+    {k : E.O event → ITree E α} {s : M.State}
+    (hHandle : M.handle event s fun answer s' => PartialSpec M Q (k answer) s') :
+    PartialSpec M Q (.vis event k) s :=
+  intro (by simpa only [SpecF.vis] using hHandle)
+
+theorem PartialSpec.ret_post {Q : α → M.State → Prop} {value : α} {s : M.State}
+    (hSpec : PartialSpec M Q (.ret value) s) : Q value s := by
+  simpa only [SpecF.ret] using hSpec.step
+
+/-- `PartialSpec.ret`/`PartialSpec.ret_post` as one rewrite. -/
+@[simp]
+theorem PartialSpec.ret_iff {Q : α → M.State → Prop} {value : α} {s : M.State} :
+    PartialSpec M Q (.ret value) s ↔ Q value s :=
+  ⟨PartialSpec.ret_post, PartialSpec.ret⟩
+
+/-- The event destructor; the counterpart of `TotalSpec.vis_view`. -/
+theorem PartialSpec.vis_view {Q : α → M.State → Prop} {event : E.I}
+    {k : E.O event → ITree E α} {s : M.State}
+    (hSpec : PartialSpec M Q (.vis event k) s) :
+    M.handle event s fun answer s' => PartialSpec M Q (k answer) s' := by
+  simpa only [SpecF.vis] using hSpec.step
+
+/-! ## What the two judgments say of each other -/
+
+/-- Total correctness is partial correctness. -/
+theorem TotalSpec.toPartial {Q : α → M.State → Prop} {m : ITree E α}
+    {s : M.State} (hSpec : TotalSpec M Q m s) : PartialSpec M Q m s :=
+  hSpec.induction (P := PartialSpec M Q) (fun _ _ hPost => .ret hPost)
+    fun _ _ _ hHandle => .vis hHandle
+
+/-! ## Structural rules -/
+
+theorem TotalSpec.mono {Q Q' : α → M.State → Prop} {m : ITree E α} {s : M.State}
+    (hSpec : TotalSpec M Q m s) (hQ : ∀ value s, Q value s → Q' value s) :
+    TotalSpec M Q' m s :=
+  hSpec.induction (P := TotalSpec M Q')
+    (fun value s' hPost => .ret (hQ value s' hPost)) fun _ _ _ hHandle => .vis hHandle
+
+theorem PartialSpec.mono {Q Q' : α → M.State → Prop} {m : ITree E α} {s : M.State}
+    (hSpec : PartialSpec M Q m s) (hQ : ∀ value s, Q value s → Q' value s) :
+    PartialSpec M Q' m s :=
+  coinduction (PartialSpec M Q)
+    (fun _ _ hSpec' => hSpec'.step.mono hQ id fun _ _ => id) hSpec
+
+theorem TotalSpec.bind {Q₁ : α → M.State → Prop} {Q₂ : β → M.State → Prop}
+    {m : ITree E α} {next : α → ITree E β} {s : M.State}
+    (hFirst : TotalSpec M Q₁ m s)
+    (hNext : ∀ value s', Q₁ value s' → TotalSpec M Q₂ (next value) s') :
+    TotalSpec M Q₂ (ITree.bind m next) s :=
+  hFirst.induction (P := fun t u => TotalSpec M Q₂ (ITree.bind t next) u)
+    (fun value s' hPost => by
+      simpa only [itree_ret_bind] using hNext value s' hPost)
+    fun _ _ _ hHandle => by
+      rw [itree_vis_bind]
+      exact .vis hHandle
+
+theorem PartialSpec.bind {Q₁ : α → M.State → Prop} {Q₂ : β → M.State → Prop}
+    {m : ITree E α} {next : α → ITree E β} {s : M.State}
+    (hFirst : PartialSpec M Q₁ m s)
+    (hNext : ∀ value s', Q₁ value s' → PartialSpec M Q₂ (next value) s') :
+    PartialSpec M Q₂ (ITree.bind m next) s := by
+  refine coinduction
+    (fun t s' => (∃ m', t = ITree.bind m' next ∧ PartialSpec M Q₁ m' s') ∨
+      PartialSpec M Q₂ t s')
+    ?_ (Or.inl ⟨m, rfl, hFirst⟩)
+  rintro t s' (⟨m', rfl, hSpec⟩ | hSpec)
+  · revert hSpec
+    cases m' using ITree.cases with
+    | ret value =>
+        simp only [ITree.pure_eq_ret, itree_ret_bind]
+        intro hSpec
+        exact ((hNext value s' hSpec.ret_post).step).mono_tail fun _ _ => Or.inr
+    | div => simp only [itree_div_bind, SpecF.div, implies_true]
+    | vis event k =>
+        simp only [itree_vis_bind, SpecF.vis]
+        intro hSpec
+        exact M.handle_mono (fun _ _ hNext' => Or.inl ⟨_, rfl, hNext'⟩) hSpec.vis_view
+  · exact hSpec.step.mono_tail fun _ _ => Or.inr
+
+/-- Total correctness is monotone in the interaction-tree approximation order:
+what a program does, a program that does more does too. -/
+theorem TotalSpec.mono_le {Q : α → M.State → Prop} {m m' : ITree E α}
+    (hLe : m ⊑ m') {s : M.State} (hSpec : TotalSpec M Q m s) :
+    TotalSpec M Q m' s := by
+  refine hSpec.induction
+    (P := fun t u => ∀ t', t ⊑ t' → TotalSpec M Q t' u) ?_ ?_ m' hLe
+  · intro value s' hPost t' hLe'
+    rw [ITree.le_unfold] at hLe'
+    obtain hDiv | ⟨value', hRet, rfl⟩ | ⟨_, _, _, hVis, _, _⟩ := hLe'
+    · exact absurd hDiv not_ret_div
+    · obtain rfl := ret_inj.mp hRet
+      exact .ret hPost
+    · exact absurd hVis not_vis_ret
+  · intro event k s' hHandle t' hLe'
+    rw [ITree.le_unfold] at hLe'
+    obtain hDiv | ⟨_, hRet, _⟩ | ⟨_, k₁, k₂, hVis, rfl, hLe''⟩ := hLe'
+    · exact absurd hDiv.symm not_div_vis
+    · exact absurd hRet.symm not_vis_ret
+    · obtain ⟨rfl, hCont⟩ := vis_inj hVis
+      obtain rfl := eq_of_heq hCont
+      exact .vis (M.handle_mono (fun answer _ hNext => hNext _ (hLe'' answer)) hHandle)
+
+/-- Partial correctness is anti-monotone in the tree approximation order. -/
+theorem PartialSpec.mono_le {Q : α → M.State → Prop} {m m' : ITree E α}
+    (hLe : m ⊑ m') {s : M.State} (hSpec : PartialSpec M Q m' s) :
+    PartialSpec M Q m s := by
+  refine coinduction (fun t s' => ∃ t', t ⊑ t' ∧ PartialSpec M Q t' s') ?_
+    ⟨m', hLe, hSpec⟩
+  rintro t s' ⟨t', hLe', hSpec'⟩
+  rw [ITree.le_unfold] at hLe'
+  obtain rfl | ⟨value, rfl, rfl⟩ | ⟨event, k, k', rfl, rfl, hCont⟩ := hLe'
+  · simp only [SpecF.div]
+  · simpa only [SpecF.ret] using hSpec'.ret_post
+  · simp only [SpecF.vis]
+    exact M.handle_mono (fun answer _ hNext => ⟨_, hCont answer, hNext⟩)
+      hSpec'.vis_view
+
+/-! ## Partial correctness at a limit -/
+
+/-- Partial correctness on a conjunctive machine is admissible. -/
+theorem PartialSpec.admissible (hConj : M.Conjunctive) (Q : α → M.State → Prop)
+    (s : M.State) :
+    Lean.Order.admissible (fun m : ITree E α => PartialSpec M Q m s) := by
+  intro c hc hAll
+  refine coinduction
+    (fun t u => ∃ c' : ITree E α → Prop, ∃ hc' : chain c',
+      (∀ x, c' x → PartialSpec M Q x u) ∧ t = CCPO.csup hc')
+    ?_ ⟨c, hc, hAll, rfl⟩
+  rintro t u ⟨c', hc', hAll', rfl⟩
+  generalize hEq : CCPO.csup hc' = t
+  cases t using ITree.cases with
+  | ret value =>
+      simp only [ITree.pure_eq_ret, SpecF.ret]
+      exact (hAll' _ (ITree.csup_ret_mem hc' hEq)).ret_post
+  | div => simp only [SpecF.div]
+  | vis event k =>
+      simp only [SpecF.vis]
+      -- One transition answers every approximation's demand.
+      obtain ⟨k₀, hMem₀⟩ := ITree.csup_vis_mem hc' hEq
+      have hChildren :
+          M.handle event u fun answer u' =>
+            ∀ k' : { k' : E.O event → ITree E α // c' (ITree.vis event k') },
+              PartialSpec M Q (k'.val answer) u' :=
+        hConj.handle_forall ⟨k₀, hMem₀⟩ fun k' => (hAll' _ k'.property).vis_view
+      -- Limit children are suprema of approximation children.
+      obtain rfl : k = fun o => CCPO.csup (ITree.visChain_chain hc' event o) := by
+        rw [ITree.csup_vis hc' hMem₀] at hEq
+        obtain ⟨-, hCont⟩ := vis_inj hEq.symm
+        exact eq_of_heq hCont
+      refine M.handle_mono (fun answer u' hChild => ?_) hChildren
+      exact ⟨ITree.visChain c' event answer, ITree.visChain_chain hc' event answer,
+        by rintro _ ⟨k', hMem', rfl⟩; exact hChild ⟨k', hMem'⟩, rfl⟩
+
+/-! ## Adequacy -/
+
+/-- Total correctness is execution to a return satisfying the postcondition. -/
+theorem TotalSpec.exec_iff {Q : α → M.State → Prop} {m : ITree E α} {s : M.State} :
+    TotalSpec M Q m s ↔
+      Exec M m s fun t u => ∃ value, t = ITree.ret value ∧ Q value u := by
+  constructor
+  · intro hSpec
+    exact hSpec.induction
+      (P := fun t u => Exec M t u fun t' u' => ∃ value, t' = ITree.ret value ∧ Q value u')
+      (fun value s' hPost => Exec.stop ⟨value, rfl, hPost⟩)
+      fun _ _ _ hHandle => Exec.event hHandle
+  · intro hExec
+    refine hExec.induction (P := fun t u => TotalSpec M Q t u) ?_
+      fun _ _ _ hHandle => TotalSpec.vis hHandle
+    rintro m' s' ⟨value, rfl, hPost⟩
+    exact TotalSpec.ret hPost
+
+/-- A total specification on a resolving machine yields a terminating run. -/
+theorem TotalSpec.evaluates (hResolves : M.Resolves) {Q : α → M.State → Prop}
+    {m : ITree E α} {s : M.State} (hSpec : TotalSpec M Q m s) :
+    ∃ value s', M.Evaluates m s value s' ∧ Q value s' := by
+  obtain ⟨m', s', hRuns, value, rfl, hPost⟩ :=
+    Exec.exists_stop hResolves (TotalSpec.exec_iff.mp hSpec)
+  exact ⟨value, s', hRuns, hPost⟩
+
+/-- Partial correctness is preserved by every run of the machine: it is a
+property of a configuration, not of the program it started from. -/
+theorem PartialSpec.runs (hConj : M.Conjunctive) (hFeasible : M.Feasible)
+    {Q : α → M.State → Prop}
+    {m m' : ITree E α} {s s' : M.State} (hSpec : PartialSpec M Q m s)
+    (hRuns : M.Runs m s m' s') : PartialSpec M Q m' s' := by
+  refine hRuns.induction
+    (P := fun t u => PartialSpec M Q t u → PartialSpec M Q m' s')
+    (fun t u hStop hSpec' => by
+      obtain ⟨rfl, rfl⟩ := hStop
+      exact hSpec')
+    (fun event k u hHandle hSpec' => ?_) hSpec
+  -- One feasible transition meets both demands.
+  obtain ⟨answer, u', hPreserves, hChild⟩ :=
+    hFeasible _ _ _ (hConj.handle_and hHandle hSpec'.vis_view)
+  exact hPreserves hChild
+
+/-- A run of a partially correct program that stops establishes the
+postcondition. -/
+theorem PartialSpec.evaluates (hConj : M.Conjunctive) (hFeasible : M.Feasible)
+    {Q : α → M.State → Prop}
+    {m : ITree E α} {s : M.State} {value : α} {s' : M.State}
+    (hSpec : PartialSpec M Q m s) (hEval : M.Evaluates m s value s') :
+    Q value s' :=
+  (hSpec.runs hConj hFeasible hEval).ret_post
+
+end Aeneas.Data.Coinductive
+
+namespace Aeneas.Data.Coinductive.StateTest
+
+inductive StateEvent : Type 1 where
+  | get
+  | put (value : Nat)
+  | fail
+  | choose (α : Type)
+
+@[reducible]
+def StateEvent.output : StateEvent → Type 1
+  | .get => ULift Nat
+  | .put _ => ULift Unit
+  | .fail => ULift Unit
+  | .choose α => ULift α
+
+@[reducible]
+def StateEffect : Effect where
+  I := StateEvent
+  O := StateEvent.output
+
+@[reducible]
+def machine : StateMachine StateEffect where
+  State := Nat
+  handle event state C :=
+    match event with
+    | .get => C ⟨state⟩ state
+    | .put value => C ⟨()⟩ value
+    | .fail => False
+    | .choose α => Nonempty α ∧ ∀ answer, C ⟨answer⟩ state
+  handle_mono := by
+    rintro event state C C' hC hHandle
+    cases event
+    · exact hC _ _ hHandle
+    · exact hC _ _ hHandle
+    · exact hHandle.elim
+    · exact ⟨hHandle.1, fun answer => hC _ _ (hHandle.2 answer)⟩
+
+theorem machine_conjunctive : machine.Conjunctive := by
+  rintro event state Demands ⟨C₀, hC₀⟩ hAll
+  cases event
+  · exact fun C hC => hAll C hC
+  · exact fun C hC => hAll C hC
+  · exact (hAll C₀ hC₀).elim
+  · exact ⟨(hAll C₀ hC₀).1, fun answer C hC => (hAll C hC).2 answer⟩
+
+theorem machine_feasible : machine.Feasible := by
+  rintro event state C hHandle
+  cases event
+  · exact ⟨⟨state⟩, state, hHandle⟩
+  · rename_i value
+    exact ⟨⟨()⟩, value, hHandle⟩
+  · exact hHandle.elim
+  · obtain ⟨⟨answer⟩, hAll⟩ := hHandle
+    exact ⟨⟨answer⟩, state, hAll answer⟩
+
+theorem not_machine_resolves : ¬ machine.Resolves := by
+  intro hResolves
+  obtain ⟨answer, state', -, hHandle⟩ :=
+    hResolves (.choose Bool) 0 (fun _ _ => True) ⟨⟨true⟩, fun _ => trivial⟩
+  have hTrue := (hHandle.2 true).1
+  have hFalse := (hHandle.2 false).1
+  have hEq := hTrue.trans hFalse.symm
+  simp only [ULift.up.injEq] at hEq
+  exact Bool.noConfusion hEq
+
+def spec (m : ITree StateEffect α) (p : α → Nat → Prop) (state : Nat) : Prop :=
+  TotalSpec machine p m state
+
+def dspec (m : ITree StateEffect α) (p : α → Nat → Prop) (state : Nat) : Prop :=
+  PartialSpec machine p m state
+
+example (Q : Nat → Nat → Prop) :
+    Lean.Order.admissible fun computation : ITree StateEffect Nat =>
+      dspec computation Q 0 :=
+  PartialSpec.admissible machine_conjunctive Q 0
+
+def get : ITree StateEffect Nat :=
+  .vis .get fun value => .ret value.down
+
+def put (value : Nat) : ITree StateEffect Unit :=
+  .vis (.put value) fun result => .ret result.down
+
+def fail : ITree StateEffect Unit :=
+  .vis .fail fun result => .ret result.down
+
+def choose (α : Type) : ITree StateEffect α :=
+  .vis (.choose α) fun result => .ret result.down
+
+def increment : ITree StateEffect Nat :=
+  do
+    let value ← get
+    let _ ← put (value + 1)
+    return value
+
+def failure : ITree StateEffect Unit :=
+  do
+    let _ ← fail
+    return ()
+
+def flip : ITree StateEffect Nat :=
+  do
+    let answer ← choose Bool
+    return if answer then 0 else 1
+
+theorem increment_spec (state : Nat) :
+    spec increment (fun value state' => value = state ∧ state' = state + 1)
+      state := by
+  simp [spec, increment, get, put, Bind.bind]
+  apply TotalSpec.vis
+  apply TotalSpec.vis
+  exact TotalSpec.ret ⟨rfl, rfl⟩
+
+example (state : Nat) :
+    ∃ value state',
+      machine.Evaluates increment state value state' ∧
+      value = state ∧ state' = state + 1 := by
+  refine ⟨state, state + 1, ?_, rfl, rfl⟩
+  simp [increment, get, put, Bind.bind]
+  apply StateMachine.Evaluates.event
+  apply StateMachine.Evaluates.event
+  exact StateMachine.Evaluates.ret state (state + 1)
+
+example (state : Nat) :
+    spec increment (fun value state' => value = state ∧ state' = state + 1)
+      state :=
+  increment_spec state
+
+example (state : Nat) :
+    dspec increment (fun value state' => value = state ∧ state' = state + 1)
+      state :=
+  TotalSpec.toPartial (increment_spec state)
+
+example (state : Nat) :
+    spec flip (fun value state' => (value = 0 ∨ value = 1) ∧ state' = state)
+      state := by
+  simp [spec, flip, choose, Bind.bind]
+  apply TotalSpec.vis
+  change Nonempty Bool ∧ ∀ answer : Bool,
+    TotalSpec machine
+      (fun value state' => (value = 0 ∨ value = 1) ∧ state' = state)
+      (.ret (if answer then 0 else 1)) state
+  constructor
+  · exact ⟨true⟩
+  · intro answer
+    apply TotalSpec.ret
+    cases answer
+    · simp
+    · simp
+
+example (state : Nat) :
+    dspec flip (fun value state' => (value = 0 ∨ value = 1) ∧ state' = state)
+      state :=
+  TotalSpec.toPartial (show
+    spec flip (fun value state' => (value = 0 ∨ value = 1) ∧ state' = state)
+      state by
+    simp [spec, flip, choose, Bind.bind]
+    apply TotalSpec.vis
+    change Nonempty Bool ∧ ∀ answer : Bool,
+      TotalSpec machine
+        (fun value state' => (value = 0 ∨ value = 1) ∧ state' = state)
+        (.ret (if answer then 0 else 1)) state
+    constructor
+    · exact ⟨true⟩
+    · intro answer
+      apply TotalSpec.ret
+      cases answer
+      · simp
+      · simp)
+
+example {Q : Nat → Nat → Prop} {m m' : ITree StateEffect Nat}
+    {state state' : Nat} (hSpec : dspec m Q state)
+    (hRuns : machine.Runs m state m' state') :
+    dspec m' Q state' :=
+  hSpec.runs machine_conjunctive machine_feasible hRuns
+
+example (state : Nat) (Q : Unit → Nat → Prop) :
+    ¬ spec failure Q state := by
+  intro hSpec
+  simp [spec, failure, fail, Bind.bind] at hSpec
+  exact hSpec.vis_view
+
+example (state : Nat) (Q : Unit → Nat → Prop) :
+    ¬ dspec failure Q state := by
+  intro hSpec
+  simp [dspec, failure, fail, Bind.bind] at hSpec
+  exact hSpec.vis_view
+
+end Aeneas.Data.Coinductive.StateTest

--- a/backends/lean/Aeneas/Data/Coinductive/StateMachine.lean
+++ b/backends/lean/Aeneas/Data/Coinductive/StateMachine.lean
@@ -1,0 +1,269 @@
+import Aeneas.Data.Coinductive.ITree
+
+/-!
+# Interaction trees and the state machines that run them
+
+State machines assign transitions to interaction-tree events.
+`Exec` is their finite multi-step execution relation.
+Based on the POPL 2025 paper *Program Logics à la Carte*.
+-/
+
+namespace Aeneas.Data.Coinductive
+
+universe u v w x
+
+variable {E : Effect.{v}} {α β γ : Type x}
+
+/-! ## State machines -/
+
+/-- A state machine with continuation-passing event transitions. -/
+structure StateMachine (E : Effect.{v}) where
+  /-- The states the machine runs on. -/
+  State : Type u
+  /-- `handle e s C` holds when the machine can answer the event `e` in the
+  state `s` by a transition whose result and successor state satisfy `C`. -/
+  handle : (event : E.I) → State → (E.O event → State → Prop) → Prop
+  /-- Answering an event with a stronger outcome answers it with a weaker one
+  (`sehandler_mono` in the paper). -/
+  handle_mono :
+    ∀ {event : E.I} {s : State} {C C' : E.O event → State → Prop},
+      (∀ answer s', C answer s' → C' answer s') →
+      handle event s C → handle event s C'
+
+namespace StateMachine
+
+/-- Build a state machine from a transition relation. -/
+def ofStep (σ : Type u) (Step : (event : E.I) → σ → E.O event → σ → Prop) :
+    StateMachine E where
+  State := σ
+  handle event s C := ∃ answer s', Step event s answer s' ∧ C answer s'
+  handle_mono := by
+    rintro event s C C' hC ⟨answer, s', hStep, hOutcome⟩
+    exact ⟨answer, s', hStep, hC answer s' hOutcome⟩
+
+/-- Every handled demand is witnessed by one concrete transition. -/
+def Resolves (M : StateMachine E) : Prop :=
+  ∀ (event : E.I) (s : M.State) (C : E.O event → M.State → Prop),
+    M.handle event s C →
+    ∃ answer s', C answer s' ∧ M.handle event s fun a u => a = answer ∧ u = s'
+
+theorem ofStep_resolves (σ : Type u)
+    (Step : (event : E.I) → σ → E.O event → σ → Prop) :
+    (ofStep σ Step).Resolves := by
+  rintro event s C ⟨answer, s', hStep, hOutcome⟩
+  exact ⟨answer, s', hOutcome, answer, s', hStep, rfl, rfl⟩
+
+/-- Every handled demand has an answer and successor state. -/
+def Feasible (M : StateMachine E) : Prop :=
+  ∀ (event : E.I) (s : M.State) (C : E.O event → M.State → Prop),
+    M.handle event s C → ∃ answer s', C answer s'
+
+/-- One transition can satisfy every demand in a nonempty family.
+This excludes genuine angelic choice. -/
+def Conjunctive (M : StateMachine E) : Prop :=
+  ∀ {event : E.I} {s : M.State}
+    (Demands : (E.O event → M.State → Prop) → Prop), (∃ C, Demands C) →
+    (∀ C, Demands C → M.handle event s C) →
+    M.handle event s fun answer s' => ∀ C, Demands C → C answer s'
+
+theorem ofStep_conjunctive (σ : Type u)
+    (Step : (event : E.I) → σ → E.O event → σ → Prop)
+    (hFunctional : ∀ (event : E.I) (s : σ) (answer₁ : E.O event) (s₁ : σ)
+      (answer₂ : E.O event) (s₂ : σ),
+      Step event s answer₁ s₁ → Step event s answer₂ s₂ → answer₁ = answer₂ ∧ s₁ = s₂) :
+    (ofStep σ Step).Conjunctive := by
+  rintro event s Demands ⟨C₀, hC₀⟩ hAll
+  obtain ⟨answer, s', hStep, -⟩ := hAll C₀ hC₀
+  refine ⟨answer, s', hStep, fun C hC => ?_⟩
+  obtain ⟨answer', s'', hStep', hOutcome⟩ := hAll C hC
+  obtain ⟨rfl, rfl⟩ := hFunctional event s answer' s'' answer s' hStep' hStep
+  exact hOutcome
+
+variable {M : StateMachine E}
+
+theorem Resolves.feasible (hResolves : M.Resolves) : M.Feasible := by
+  intro event s C hHandle
+  obtain ⟨answer, s', hOutcome, -⟩ := hResolves event s C hHandle
+  exact ⟨answer, s', hOutcome⟩
+
+/-- `Conjunctive` at a family rather than a set: one transition answers a whole
+inhabited family of demands at once. -/
+theorem Conjunctive.handle_forall (hConj : M.Conjunctive) {ι : Sort w} (i₀ : ι)
+    {event : E.I} {s : M.State} {C : ι → E.O event → M.State → Prop}
+    (hHandle : ∀ i, M.handle event s (C i)) :
+    M.handle event s fun answer s' => ∀ i, C i answer s' := by
+  refine M.handle_mono (fun _ _ hAll i => hAll (C i) ⟨i, rfl⟩)
+    (hConj (fun X => ∃ i, X = C i) ⟨C i₀, i₀, rfl⟩ ?_)
+  rintro X ⟨i, rfl⟩
+  exact hHandle i
+
+/-- `Conjunctive` at two demands. -/
+theorem Conjunctive.handle_and (hConj : M.Conjunctive) {event : E.I} {s : M.State}
+    {C C' : E.O event → M.State → Prop} (hHandle : M.handle event s C)
+    (hHandle' : M.handle event s C') :
+    M.handle event s fun answer s' => C answer s' ∧ C' answer s' := by
+  refine M.handle_mono (fun _ _ hBoth => ⟨hBoth true, hBoth false⟩)
+    (hConj.handle_forall (ι := Bool) (C := fun b => bif b then C else C') true ?_)
+  rintro (_ | _) <;> assumption
+
+end StateMachine
+
+/-! ## The multi-step relation -/
+
+/-- One execution layer: stop, or handle one visible event. -/
+def ExecF (M : StateMachine.{u,v} E)
+    (C X : ITree E α → M.State → Prop) (m : ITree E α) (s : M.State) : Prop :=
+  C m s ∨
+    match m.unfold with
+    | .vis event k => M.handle event s fun answer s' => X (k answer) s'
+    | _ => False
+
+/-- Finite execution from `(m, s)` to a configuration satisfying `C`. -/
+def Exec (M : StateMachine E) (m : ITree E α) (s : M.State)
+    (C : ITree E α → M.State → Prop) : Prop :=
+  ∀ X : ITree E α → M.State → Prop,
+    (∀ m' s', ExecF M C X m' s' → X m' s') → X m s
+
+namespace Exec
+
+variable {M : StateMachine E} {C C' P : ITree E α → M.State → Prop}
+
+/-- An execution may stop where it stands (`ExecStop`). -/
+theorem stop {m : ITree E α} {s : M.State} (hC : C m s) : Exec M m s C :=
+  fun _ hClosed => hClosed m s (Or.inl hC)
+
+/-- An execution may take one transition of the machine (`ExecVis`). -/
+theorem event {event : E.I} {k : E.O event → ITree E α} {s : M.State}
+    (hHandle : M.handle event s fun answer s' => Exec M (k answer) s' C) :
+    Exec M (.vis event k) s C := by
+  intro X hClosed
+  refine hClosed _ s (Or.inr ?_)
+  simp only [unfold_vis]
+  exact M.handle_mono (fun answer s' hExec => hExec X hClosed) hHandle
+
+/-- The induction principle of `Exec`: a property that holds wherever an
+execution may stop and is preserved by one transition of the machine holds of
+every configuration an execution starts from. -/
+theorem induction {m : ITree E α} {s : M.State} (hExec : Exec M m s C)
+    (hStop : ∀ m' s', C m' s' → P m' s')
+    (hEvent : ∀ (event : E.I) (k : E.O event → ITree E α) (s' : M.State),
+      M.handle event s' (fun answer u => P (k answer) u) → P (.vis event k) s') :
+    P m s := by
+  refine hExec P fun m' s' hStep => ?_
+  rcases hStep with hC | hStep
+  · exact hStop m' s' hC
+  · revert hStep
+    cases m' with
+    | ret value => simp only [ITree.pure_eq_ret, unfold_ret, false_implies]
+    | div => simp only [unfold_tau, false_implies]
+    | vis event k =>
+        simp only [unfold_vis]
+        exact hEvent event k s'
+
+theorem mono {m : ITree E α} {s : M.State} (hExec : Exec M m s C)
+    (hC : ∀ m' s', C m' s' → C' m' s') : Exec M m s C' :=
+  hExec.induction (fun m' s' hStop => stop (hC m' s' hStop)) fun _ _ _ => event
+
+/-- Executions compose: `exec_dup` of the paper. -/
+theorem dup {m : ITree E α} {s : M.State}
+    (hExec : Exec M m s fun m' s' => Exec M m' s' C) : Exec M m s C :=
+  hExec.induction (fun _ _ hStop => hStop) fun _ _ _ => event
+
+/-- Running `m >>= next` amounts to running `m` and continuing with `next`;
+`exec_bind_post` of the paper. -/
+theorem bind_post {m : ITree E α} {s : M.State} {next : α → ITree E γ}
+    {C : ITree E γ → M.State → Prop}
+    (hExec : Exec M m s fun m' s' => C (m' >>= next) s') :
+    Exec M (m >>= next) s C :=
+  hExec.induction (P := fun m' s' => Exec M (m' >>= next) s' C)
+    (fun _ _ hStop => stop hStop)
+    fun ev k s' hHandle => by
+      simpa only [vis_bind] using
+        event (M := M) (event := ev) (k := fun answer => k answer >>= next) hHandle
+
+/-- `exec_bind` of the paper. -/
+theorem bind {m : ITree E α} {s : M.State} {next : α → ITree E γ}
+    {C : ITree E γ → M.State → Prop}
+    (hExec : Exec M m s fun m' s' => Exec M (m' >>= next) s' C) :
+    Exec M (m >>= next) s C :=
+  dup (bind_post hExec)
+
+end Exec
+
+/-! ## Reachability and evaluation -/
+
+namespace StateMachine
+
+/-- `M.Runs m s m' s'`: the machine `M` takes the configuration `(m, s)` to the
+configuration `(m', s')`. -/
+def Runs (M : StateMachine E) (m : ITree E α) (s : M.State) (m' : ITree E α)
+    (s' : M.State) : Prop :=
+  Exec M m s fun t u => t = m' ∧ u = s'
+
+/-- `M.Evaluates m s value s'`: the program `m`, run by the machine `M` from the
+state `s`, returns `value` and leaves the state `s'`. -/
+def Evaluates (M : StateMachine E) (m : ITree E α) (s : M.State) (value : α)
+    (s' : M.State) : Prop :=
+  M.Runs m s (.ret value) s'
+
+variable {M : StateMachine E}
+
+theorem Runs.refl (m : ITree E α) (s : M.State) : M.Runs m s m s :=
+  Exec.stop ⟨rfl, rfl⟩
+
+theorem Evaluates.ret (value : α) (s : M.State) :
+    M.Evaluates (.ret value) s value s :=
+  Runs.refl _ _
+
+/-- An evaluation that begins with one transition of the machine. -/
+theorem Evaluates.event {event : E.I} {k : E.O event → ITree E α}
+    {s s' : M.State} {value : α}
+    (hHandle :
+      M.handle event s fun answer u => M.Evaluates (k answer) u value s') :
+    M.Evaluates (.vis event k) s value s' :=
+  Exec.event hHandle
+
+/-- An evaluation that begins with one transition of a machine given by a
+transition relation. -/
+theorem Evaluates.step {σ : Type u}
+    {Step : (event : E.I) → σ → E.O event → σ → Prop}
+    {event : E.I} {k : E.O event → ITree E α} {s s₁ s₂ : σ}
+    {answer : E.O event} {value : α}
+    (hStep : Step event s answer s₁)
+    (hNext : (ofStep σ Step).Evaluates (k answer) s₁ value s₂) :
+    (ofStep σ Step).Evaluates (.vis event k) s value s₂ :=
+  Exec.event (M := ofStep σ Step) ⟨answer, s₁, hStep, hNext⟩
+
+theorem Evaluates.bind {m : ITree E α} {next : α → ITree E γ}
+    {s s₁ s₂ : M.State} {value : α} {result : γ}
+    (hFirst : M.Evaluates m s value s₁)
+    (hNext : M.Evaluates (next value) s₁ result s₂) :
+    M.Evaluates (m >>= next) s result s₂ :=
+  Exec.bind (Exec.mono hFirst fun m' s' hStop => by
+    obtain ⟨rfl, rfl⟩ := hStop
+    rw [show (ITree.ret value : ITree E α) >>= next = next value from
+      itree_ret_bind value next]
+    exact hNext)
+
+end StateMachine
+
+namespace Exec
+
+/-- A resolving machine realizes an `Exec` witness as an actual run. -/
+theorem exists_stop {M : StateMachine E} (hResolves : M.Resolves)
+    {m : ITree E α} {s : M.State} {C : ITree E α → M.State → Prop}
+    (hExec : Exec M m s C) :
+    ∃ m' s', M.Runs m s m' s' ∧ C m' s' := by
+  refine hExec.induction (P := fun m s => ∃ m' s', M.Runs m s m' s' ∧ C m' s')
+    (fun m' s' hStop => ⟨m', s', StateMachine.Runs.refl _ _, hStop⟩)
+    fun ev k s' hHandle => ?_
+  obtain ⟨answer, s₁, hNext, hSingle⟩ := hResolves ev s' _ hHandle
+  obtain ⟨m', s₂, hRuns, hC⟩ := hNext
+  refine ⟨m', s₂, event ?_, hC⟩
+  refine M.handle_mono (fun a u hOutcome => ?_) hSingle
+  obtain ⟨rfl, rfl⟩ := hOutcome
+  exact hRuns
+
+end Exec
+
+end Aeneas.Data.Coinductive

--- a/backends/lean/Aeneas/Std/WP.lean
+++ b/backends/lean/Aeneas/Std/WP.lean
@@ -5,6 +5,7 @@ import Aeneas.Tactic.Solver.Grind.Init
 import Aeneas.Std.Spec
 import Aeneas.Data.Coinductive.ITree
 import Aeneas.Data.Coinductive.Effect
+import Aeneas.Data.Coinductive.Spec
 
 namespace Aeneas.Std.WP
 
@@ -19,77 +20,42 @@ def Wp α := Post α → Pre
 
 def wp_return (x:α) : Wp α := fun p => p x
 
-@[grind]
-inductive spec {α} : (x : Result α) → (p : Post α) →  Prop where
-| ret : ∀ {p x}, p x → spec (.ok x) p
-
-
-inductive dspec {α} : (x : Result α) → (p : Post α) →  Prop where
-| ret : ∀ {p x}, p x → dspec (.ok x) p
-| div : ∀ p, dspec div p
-
-theorem spec_dspec (α) (x : Result α) (p: Post α) : spec x p → dspec x p := by
-  intros s
-  cases s
-  apply dspec.ret
-  assumption
+section ResultImplementation
 
 unseal Result
+
+@[reducible]
+def machine : StateMachine RustEffect where
+  State := Unit
+  handle event _ _ :=
+    match event with
+    | .fail _ => False
+  handle_mono _ := False.elim
+
+theorem machine_conjunctive : machine.Conjunctive := by
+  intro _ _ _ hNonempty hAll
+  obtain ⟨C₀, hC₀⟩ := hNonempty
+  exact (hAll C₀ hC₀).elim
+
+theorem machine_resolves : machine.Resolves := by
+  intro _ _ _ hHandle
+  exact hHandle.elim
+
+theorem machine_feasible : machine.Feasible :=
+  machine_resolves.feasible
+
+def spec (m : Result α) (p : Post α) : Prop :=
+  TotalSpec machine (fun value _ => p value) m ()
+
+def dspec (m : Result α) (p : Post α) : Prop :=
+  PartialSpec machine (fun value _ => p value) m ()
+
+theorem spec_dspec (α) (x : Result α) (p: Post α) : spec x p → dspec x p :=
+  TotalSpec.toPartial
+
 theorem dspec_admissible {α} (p : Post α )
-  : admissible (fun x => dspec x p) := by
-  intro c hchain h
-  simp at h
-  by_cases (∃ a, c a) <;> rename_i h1
-  · have : c (CCPO.csup hchain) := by
-      by_cases (∃ a, c (.ok a))
-      · rename_i h2
-        rcases h2 with ⟨a, ca⟩
-        have dir1 := csup_le (x:=.ok a) hchain (by
-          intros y cy
-          have h := h y cy
-          cases h
-          · have order := hchain _ _ ca cy
-            cases order <;> try assumption
-            rename_i h
-            simp [ok] at *
-            rw [ITree.le_ret_inj _ _ h]
-            rfl
-          · simp [div, ok]
-            rw [← ITree.div_is_bot]
-            apply bot_le
-          )
-        have dir2 := le_csup hchain ca
-        rw [PartialOrder.rel_antisymm dir1 dir2]
-        assumption
-      · have := CCPO.csup_spec hchain
-        simp [is_sup] at this
-        have this := (this .div).mpr
-        have only_div : ∀ a, c a → a = div := by
-          intros a ca
-          have h := h a ca
-          cases h <;> grind
-        have this := this (by
-          intros y cy
-          simp [only_div y cy]
-          apply PartialOrder.rel_refl
-          )
-        simp [Result, instCCPOResult]
-        rw [ITree.le_div_is_div (CCPO.csup (c:=c) hchain) this]
-        rcases h1 with ⟨a, ca⟩
-        have h := h a ca
-        simp [div] at only_div
-        rw [← only_div a ca]
-        assumption
-    grind
-  · have : CCPO.csup hchain = bot := by
-      unfold bot empty_chain
-      congr
-      grind
-    rw [this]
-    unfold Result
-    rw [ITree.div_is_bot]
-    constructor
-seal Result
+  : admissible (fun x => dspec x p) :=
+  PartialSpec.admissible machine_conjunctive _ ()
 
 /-- Variant of `uncurry` used to decompose tuples in post-conditions.
 
@@ -108,26 +74,20 @@ def uncurry' {α β} (p : α → β → Prop) : α × β → Prop :=
 @[defeq] theorem uncurry'_eq x (p : α → β → Prop) : uncurry' p x = p x.fst x.snd := by simp [uncurry']
 
 @[simp, grind =, agrind =]
-theorem spec_ok (x : α) : spec (ok x) p ↔ p x := by
-  constructor
-  · intros s
-    generalize H : ok x = v at s
-    cases s
-    simp at H
-    grind
-  · intros px
-    constructor
-    assumption
+theorem spec_ok (x : α) : spec (ok x) p ↔ p x :=
+  TotalSpec.ret_iff
 
 @[simp, grind =, agrind =]
-theorem spec_vis (e k) : spec (.vis e k) p ↔ False := by grind [ok_not_vis, vis_not_ok]
+theorem spec_vis (e k) : spec (.vis e k) p ↔ False :=
+  ⟨fun h => TotalSpec.vis_view h, False.elim⟩
 
 @[simp, grind =, agrind =]
 theorem spec_fail (e : Error) : spec (fail e) p ↔ False := by
   simp [Result.fail_eq_vis]
 
 @[simp, grind =, agrind =]
-theorem spec_div : spec div p ↔ False := by grind [ok_not_div, div_not_ok]
+theorem spec_div : spec div p ↔ False :=
+  ⟨TotalSpec.div_false, False.elim⟩
 
 /-! ### `spec_*` for tuple posts
 
@@ -140,28 +100,21 @@ theorem spec_ok_pair {α β} (a : α) (b : β) (f : α → β → Prop) :
 
 @[simp, grind =, agrind =]
 theorem spec_fail_pair (e : Error) (f : α → β → Prop) :
-    spec (fail e) (uncurry f) ↔ False := by grind
+    spec (fail e) (uncurry f) ↔ False := by simp
 
 @[simp, grind =, agrind =]
 theorem spec_div_pair (f : α → β → Prop) :
     spec div (uncurry f) ↔ False := by simp
 
 theorem spec_mono {α} {P₁ : Post α} {m : Result α} {P₀ : Post α} (h : spec m P₀):
-  (∀ x, P₀ x → P₁ x) → spec m P₁ := by
-  intros HMonPost
-  revert h
-  intros s
-  cases s
-  grind
+  (∀ x, P₀ x → P₁ x) → spec m P₁ :=
+  fun HMonPost => TotalSpec.mono h fun value _ => HMonPost value
 
 theorem spec_bind {α β} {k : α -> Result β} {Pₖ : Post β} {m : Result α} {Pₘ : Post α} :
   spec m Pₘ →
   (forall x, Pₘ x → spec (k x) Pₖ) →
-  spec (m >>= k) Pₖ := by
-  intro Hm Hk
-  cases Hm
-  simp [Bind.bind]
-  grind only
+  spec (m >>= k) Pₖ :=
+  fun Hm Hk => TotalSpec.bind Hm fun value _ => Hk value
 
 /-- Small helper to currify functions -/
 def curry {α β γ} (f : α × β → γ) (x : α) : β → γ := fun y => f (x, y)
@@ -186,13 +139,8 @@ theorem qimp_iff {α} (P₀ P₁ : Post α) : qimp P₀ P₁ ↔ ∀ x, imp (P�
 
 /-- Alternative to `spec_mono`: we control the introduction of universal quantifiers by introducing `imp`. -/
 theorem spec_mono' {α} {P₁ : Post α} {m : Result α} {P₀ : Post α} (h : spec m P₀):
-  qimp P₀ P₁ → spec m P₁ := by
-  intros HMonPost
-  revert h
-  intros s
-  cases s
-  constructor
-  grind only [qimp]
+  qimp P₀ P₁ → spec m P₁ :=
+  fun HMonPost => TotalSpec.mono h fun value _ => HMonPost value
 
 /-- Implication of a `spec` predicate with quantifier -/
 def qimp_spec {α β} (P : α → Prop) (k : α → Result β) (Q : β → Prop) : Prop :=
@@ -202,12 +150,8 @@ def qimp_spec {α β} (P : α → Prop) (k : α → Result β) (Q : β → Prop)
 theorem spec_bind' {α β} {k : α -> Result β} {Pₖ : Post β} {m : Result α} {Pₘ : Post α} :
   spec m Pₘ →
   (qimp_spec Pₘ k Pₖ) →
-  spec (Std.bind m k) Pₖ := by
-  intro Hm Hk
-  simp only [qimp_spec] at *
-  cases Hm
-  simp
-  grind only
+  spec (Std.bind m k) Pₖ :=
+  fun Hm Hk => TotalSpec.bind (next := k) Hm fun value _ => Hk value
 
 /-- We use this lemma to decompose nested `uncurry'` predicates into a sequence of universal quantifiers. -/
 @[simp]
@@ -240,11 +184,7 @@ theorem qimp_spec_exists {α β γ} (P : γ → α → Prop) (k : α → Result 
 
 theorem spec_equiv_exists (m:Result α) (P:Post α) :
   spec m P ↔ (∃ y, m = ok y ∧ P y) := by
-  constructor
-  · intros s
-    cases s
-    grind only [ok]
-  · grind
+  cases m <;> simp
 
 theorem spec_imp_exists {m:Result α} {P:Post α} :
   spec m P → (∃ y, m = ok y ∧ P y) := by
@@ -256,12 +196,8 @@ theorem exists_imp_spec {m:Result α} {P:Post α} :
 
 -- `dspec` theorems
 theorem dspec_mono' {α} {P₁ : Post α} {m : Result α} {P₀ : Post α} (h : dspec m P₀):
-  qimp P₀ P₁ → dspec m P₁ := by
-  intros HMonPost
-  revert h
-  intros s
-  cases s <;> constructor
-  grind only [qimp]
+  qimp P₀ P₁ → dspec m P₁ :=
+  fun HMonPost => PartialSpec.mono h fun value _ => HMonPost value
 
 /-- Implication of a `dspec` predicate with quantifier -/
 def qimp_dspec {α β} (P : α → Prop) (k : α → Result β) (Q : β → Prop) : Prop :=
@@ -270,14 +206,8 @@ def qimp_dspec {α β} (P : α → Prop) (k : α → Result β) (Q : β → Prop
 theorem dspec_bind' {α β} {k : α -> Result β} {Pₖ : Post β} {m : Result α} {Pₘ : Post α} :
   dspec m Pₘ →
   (qimp_dspec Pₘ k Pₖ) →
-  dspec (Std.bind m k) Pₖ := by
-  intro Hm Hk
-  simp only [qimp_dspec] at *
-  cases Hm
-  · simp
-    grind only
-  · simp
-    constructor
+  dspec (Std.bind m k) Pₖ :=
+  fun Hm Hk => PartialSpec.bind (next := k) Hm fun value _ => Hk value
 
 @[simp]
 def qimp_dspec_uncurry' {α₀ α₁ β} (P : α₀ → α₁ → Prop) (k : α₀ × α₁ → Result β) (Q : β → Prop) :
@@ -299,22 +229,16 @@ def qimp_dspec_iff {α β} (P : α → Prop) (k : α → Result β) (Q : β → 
   simp [qimp_dspec, imp]
 
 @[simp, grind =, agrind =]
-theorem dspec_ok (x : α) : dspec (ok x) p ↔ p x := by
-  constructor
-  · intros s
-    generalize h : Result.ok x = v at s
-    cases s <;> simp at *; grind
-  · intros px
-    constructor
-    assumption
+theorem dspec_ok (x : α) : dspec (ok x) p ↔ p x :=
+  PartialSpec.ret_iff
 
 @[simp, grind =, agrind =]
-theorem dspec_vis (e k) : dspec (.vis e k) p ↔ False := by
-  constructor
-  · intros s
-    generalize h : Result.vis e k = v at s
-    cases s <;> simp at *
-  · intros; contradiction
+theorem dspec_vis (e k) : dspec (.vis e k) p ↔ False :=
+  ⟨fun h => PartialSpec.vis_view h, False.elim⟩
+
+@[simp, grind =, agrind =]
+theorem dspec_div : dspec (div : Result α) p ↔ True :=
+  iff_true_intro PartialSpec.div
 
 @[simp, grind =, agrind =]
 theorem dspec_fail (e : Error) : dspec (fail e) p ↔ False := by
@@ -323,6 +247,8 @@ theorem dspec_fail (e : Error) : dspec (fail e) p ↔ False := by
 theorem dspec_imp_forall {m:Result α} {P:Post α} :
   dspec m P → (∀ y, m = ok y → P y) := by
   grind only [= dspec_ok]
+
+end ResultImplementation
 
 end Aeneas.Std.WP
 

--- a/backends/lean/Aeneas/Tactic/Step/Tests/IntroOutputs.lean
+++ b/backends/lean/Aeneas/Tactic/Step/Tests/IntroOutputs.lean
@@ -453,8 +453,7 @@ def nestedExistentialProg : Result ((Nat × Nat) × Nat) := ok ((1, 2), 3)
 @[step]
 theorem nestedExistentialProg_spec :
     nestedExistentialProg ⦃ (a, b) c => ∃ (_ : a = 1), b = 2 ∧ c = 3 ⦄ := by
-  constructor
-  simp
+  unfold nestedExistentialProg; simp
 
 /--
 info: Try this:


### PR DESCRIPTION
This commit introduces a generic, state-machine-parameterized semantics for ITrees (inspired by _Program Logics à la Carte_) with total and partial correctness judgments and correspondence results relating them to execution. It also refactors the existing `Result` specifications in `Std/WP.lean` around this.

The first thing to mention is that neither the total or partial judgements are defined using inductives. I found having a common functor (`SpecF`), and then defining total correctness as the least fixpoint and partial correctness as greatest fixpoint to be the most elegant. (One could have total correctness as an inductive, if one has a reason for it).

The only problem I am aware of with these definitions is that partial correctness requires conjunctivity to be able to prove that is admissible. From what AI tells me, this is because CCPOs are also mixed in. Angelic nondeterminism usually does not satisfy conjunctivity, but I am not 100% sure about that since Loom has angelic nondeterminism. Anyway, Son told me we need only demonic nondeterminism for now, so I did not looked further into this.

The code is written completely by AI. From what I can tell, it looks pretty standard, however, I have not previously developed semantics for conductive types, and I am also not familiar with CCPOs.